### PR TITLE
fix: export Preview type for TypeScript configuration

### DIFF
--- a/packages/@storybook-astro/framework/src/index.ts
+++ b/packages/@storybook-astro/framework/src/index.ts
@@ -3,8 +3,15 @@ export type {
   Args,
   ArgTypes,
   Parameters,
+  ProjectAnnotations,
   StrictArgs
 } from 'storybook/internal/types';
+
+import type { ProjectAnnotations } from 'storybook/internal/types';
+import type { AstroRenderer } from './portable-stories.ts';
+
+/** Preview configuration type for `.storybook/preview.ts` in Astro projects. */
+export type Preview = ProjectAnnotations<AstroRenderer>;
 
 // Export portable stories functionality
 export {


### PR DESCRIPTION
## Summary

Exports a `Preview` type from `@storybook-astro/framework` so users can type their `.storybook/preview.ts` configuration:

```ts
import type { Preview } from '@storybook-astro/framework';

const preview: Preview = {
  parameters: { layout: 'centered' },
};

export default preview;
```

The type is defined as `ProjectAnnotations<AstroRenderer>`, matching the pattern used by `@storybook/react` and other framework packages.

## Related Issue

Partially addresses #17 — adds the `Preview` type. The `definePreview` function (CSF Factories) requires further design work around SSR integration and will be handled separately.