### PR TITLE
fix: make StorybookConfig options and integrations optional

### DIFF
--- a/packages/@storybook-astro/framework/src/types.ts
+++ b/packages/@storybook-astro/framework/src/types.ts
@@ -15,7 +15,7 @@ export type RenderStoryInput = {
 };
 
 export type FrameworkOptions = {
-  integrations: Integration[];
+  integrations?: Integration[];
   sanitization?: SanitizationOptions;
   storyRules?: StoryRulesOptions;
   resolveFrom?: string;
@@ -24,7 +24,7 @@ export type FrameworkOptions = {
 type StorybookConfigFramework = {
   framework: {
     name: FrameworkName;
-    options: FrameworkOptions;
+    options?: FrameworkOptions;
   };
 };
 


### PR DESCRIPTION
## Summary

Makes `framework.options` and `FrameworkOptions.integrations` optional in the `StorybookConfig` type. Users who don't need framework integrations (e.g. pure Astro components) are no longer forced to provide them.

The runtime code in `preset.ts` and other consumers already defaults `integrations` to `[]` via `??`, so this is a types-only change with no behavioral impact.

## Related Issue

Closes #18