### PR TITLE
Add README for renderer package

### DIFF
--- a/packages/@storybook-astro/renderer/README.md
+++ b/packages/@storybook-astro/renderer/README.md
@@ -1,0 +1,21 @@
+# @storybook-astro/renderer
+
+Client-side renderer for the [Storybook Astro](https://storybook-astro.org) framework.
+
+> **You don't need to install this package directly.** Install [`@storybook-astro/framework`](https://www.npmjs.com/package/@storybook-astro/framework) instead — it includes this renderer automatically as a dependency.
+
+## Install
+
+```bash
+npm install -D storybook @storybook/builder-vite @storybook-astro/framework
+```
+
+## Links
+
+- [Getting Started](https://storybook-astro.org/getting-started)
+- [Live Demo](https://demo.storybook-astro.org)
+- [GitHub](https://github.com/storybook-astro/storybook-astro)
+
+## License
+
+MIT


### PR DESCRIPTION
Adds a README to `@storybook-astro/renderer` so that users viewing the package on npmjs.org understand they should install `@storybook-astro/framework` instead, which pulls in the renderer automatically.

Co-Authored-By: Oz <oz-agent@warp.dev>