### PR TITLE
fix: resolve Alpine SSR test failures in happy-dom environment

### DIFF
--- a/packages/@storybook-astro/framework/src/testing/renderer-daemon.ts
+++ b/packages/@storybook-astro/framework/src/testing/renderer-daemon.ts
@@ -138,6 +138,18 @@ export async function startTestingRendererDaemon(): Promise<RunningDaemon> {
   }
 
   const server = createHttpServer(async (request, response) => {
+    // Allow cross-origin requests from browser-like test environments (e.g. happy-dom).
+    response.setHeader('Access-Control-Allow-Origin', '*');
+    response.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    response.setHeader('Access-Control-Allow-Headers', 'content-type');
+
+    if (request.method === 'OPTIONS') {
+      response.statusCode = 204;
+      response.end();
+
+      return;
+    }
+
     if (request.method !== 'POST' || request.url !== RENDER_PATH) {
       response.statusCode = 404;
       response.end();

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 import { getViteConfig } from 'astro/config';
 import react from '@vitejs/plugin-react';
@@ -6,6 +7,19 @@ import vue from '@vitejs/plugin-vue';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import solid from 'vite-plugin-solid';
 import alpinejs from '@astrojs/alpinejs';
+import { alpinejs as alpineIntegration } from '@storybook-astro/framework/integrations';
+import { registerTestingIntegrationsForRoot } from '@storybook-astro/framework/testing/integration-config';
+
+const root = import.meta.dirname;
+
+// Register the Alpine integration so the testing renderer daemon can SSR
+// Alpine-based Astro components in the happy-dom test environment.
+registerTestingIntegrationsForRoot(root, [alpineIntegration()]);
+
+const globalSetupPath = resolve(
+  root,
+  '../@storybook-astro/framework/src/vitest/global-setup.ts'
+);
 
 const vitestConfig = defineConfig({
   mode: 'test',
@@ -28,7 +42,8 @@ const vitestConfig = defineConfig({
     setupFiles: ['vitest.setup.ts'],
     name: 'components',
     environment: 'happy-dom',
-    include: ['src/**/*.test.ts']
+    include: ['src/**/*.test.ts'],
+    globalSetup: [globalSetupPath]
   }
 });
 


### PR DESCRIPTION
## Problem

The two Alpine component tests (`Accordion` and `Counter`) in `packages/components` were failing with `Error: not implemented` when `AstroContainer.create()` called `process.cwd()`. This happened because:

1. The `components` vitest config uses `happy-dom`, which causes browser-like module resolution — loading the `@astrojs/compiler` browser WASM bridge that replaces `process.cwd()` with a stub.
2. The testing renderer daemon (used by other test projects) was unreachable from `happy-dom` workers because its HTTP server didn't handle CORS preflight requests.
3. The `components` project had no daemon global-setup wired, so it couldn't fall back to daemon-based SSR rendering.

## Changes

### `renderer-daemon.ts`
Added CORS headers (`Access-Control-Allow-Origin: *`) and `OPTIONS` preflight handling so browser-like test environments (e.g. `happy-dom`) can communicate with the daemon via `fetch`.

### `packages/components/vitest.config.ts`
- Registered the Alpine integration via `registerTestingIntegrationsForRoot` so the daemon knows how to SSR Alpine-based Astro components for this project root.
- Wired the framework's `global-setup.ts` into `test.globalSetup` so the daemon is started when running the components tests standalone.

## Verification

All 28 test files (55 tests) pass, including the two previously failing Alpine tests.

Co-Authored-By: Oz <oz-agent@warp.dev>