### PR TITLE
fix: resolve astro-prerendered-stories.json 404 in storybook dev with npm installs

### DIFF
--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -71,6 +71,15 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, { conf
   if (!finalConfig.optimizeDeps.exclude.includes('@astrojs/vue')) {
     finalConfig.optimizeDeps.exclude.push('@astrojs/vue');
   }
+  // Exclude the renderer from Vite's esbuild pre-bundler so that
+  // import.meta.hot is preserved in the preview iframe. When installed
+  // via npm (not workspace:*), Vite would otherwise pre-bundle the
+  // renderer with esbuild, which strips import.meta.hot and causes the
+  // renderer to fall back to fetching astro-prerendered-stories.json
+  // (a 404 in dev mode) rather than using the Vite HMR channel.
+  if (!finalConfig.optimizeDeps.exclude.includes('@storybook-astro/renderer')) {
+    finalConfig.optimizeDeps.exclude.push('@storybook-astro/renderer');
+  }
   // Mark Vue virtual modules as external so esbuild doesn't try to resolve them
   if (!finalConfig.optimizeDeps.esbuildOptions) {
     finalConfig.optimizeDeps.esbuildOptions = {};

--- a/packages/@storybook-astro/renderer/src/render.tsx
+++ b/packages/@storybook-astro/renderer/src/render.tsx
@@ -17,9 +17,12 @@ type ViteHot = {
 };
 
 function getViteHot(): ViteHot | undefined {
-  const meta = import.meta as ImportMeta & { hot?: ViteHot };
-
-  return meta.hot;
+  // Direct property access is required: Vite's importAnalysis plugin detects
+  // import.meta.hot via static analysis to inject the HMR context for this
+  // module. Accessing it through an intermediate variable
+  // (const meta = import.meta; meta.hot) bypasses Vite's detection, leaving
+  // import.meta.hot undefined even when the module is served directly by Vite.
+  return (import.meta as ImportMeta & { hot?: ViteHot }).hot;
 }
 
 // Cache for pending Astro component render requests
@@ -220,7 +223,13 @@ function isAstroComponent(element: unknown): element is AstroComponentFactory {
 /**
  * Renders an Astro component to the canvas using server-side rendering.
  *
- * In static builds, uses pre-rendered HTML from astro-prerendered-stories.json.
+ * Rendering strategy:
+ * 1. If Vite HMR is available (dev mode): renders via HMR middleware.
+ * 2. If HMR is absent and prerendered HTML exists (static build): renders from JSON.
+ * 3. If HMR is absent but prerendered HTML is missing (npm install in dev, not yet
+ *    built): logs a warning and attempts HMR anyway — the optimizeDeps.exclude fix
+ *    in preset.ts should prevent this path, but this handles any edge case where
+ *    import.meta.hot is transiently unavailable.
  */
 async function renderAstroToCanvas(
   element: AstroComponentFactory,
@@ -231,10 +240,26 @@ async function renderAstroToCanvas(
   const hot = getViteHot();
 
   if (!hot) {
-    const prerenderedHtml = await resolvePrerenderedStoryHtml(
-      storyContext?.id,
-      storyContext?.parameters?.__astroPrerendered
-    );
+    // Attempt to load prerendered HTML (the expected path for static builds).
+    // If the file is missing (404 in dev mode), catch and fall through to the
+    // HMR path rather than surfacing a confusing network error to the user.
+    let prerenderedHtml: string | undefined;
+
+    try {
+      prerenderedHtml = await resolvePrerenderedStoryHtml(
+        storyContext?.id,
+        storyContext?.parameters?.__astroPrerendered
+      );
+    } catch {
+      // Prerendered stories not available — likely running storybook dev without
+      // a prior storybook build. Fall through and let renderAstroComponent handle
+      // it (it will attempt HMR or show a clear static-build message).
+      console.warn(
+        '[storybook-astro] Could not load astro-prerendered-stories.json. ' +
+        'If you are running `storybook dev`, this may indicate a Vite dependency ' +
+        'optimization issue. Attempting HMR rendering instead.'
+      );
+    }
 
     if (prerenderedHtml) {
       canvasElement.innerHTML = prerenderedHtml;


### PR DESCRIPTION
## Problem

Users installing `@storybook-astro/framework` via npm (not from a monorepo workspace) see this error when running `storybook dev`:

```
Failed to load astro-prerendered-stories.json. Received 404 Not Found.
```

This affects anyone who followed the getting started guide and ran `npm install @storybook-astro/framework`, including the reporter of issue #36.

## Root Cause

The framework uses a dual-mode rendering architecture:
- **Dev mode**: renders Astro components on-demand via Vite HMR (`import.meta.hot`)
- **Static build**: pre-renders all stories to `astro-prerendered-stories.json` during `storybook build`

The renderer selects between these paths by checking `import.meta.hot`. When `hot` is undefined, it falls back to loading the prerendered JSON, which 404s in dev.

**Why `import.meta.hot` was undefined in npm installs:** Vite's esbuild pre-bundler optimizes packages in `node_modules` for performance. During this pre-bundling, esbuild strips `import.meta.hot` because it doesn't understand Vite's HMR runtime. The renderer chunk (`chunk-JL2EXXOE.js`) was being pre-bundled, losing `import.meta.hot` entirely.

This did **not** affect the monorepo sandboxes (which use `workspace:*` and load TypeScript source directly through Vite, bypassing pre-bundling) or the demo site (a static build at Cloudflare Pages, which correctly creates the prerendered JSON).

**Why tests passed:** The test suite uses `composeStories`/`renderStory` (portable stories via Vitest), which call `handlerFactory()` directly — no Vite HMR, no prerendered JSON involved.

## Fix

**Fix 1 — root cause** (`packages/@storybook-astro/framework/src/preset.ts`): 
Add `@storybook-astro/renderer` to Vite's `optimizeDeps.exclude`. This prevents esbuild pre-bundling of the renderer, so Vite serves it directly through its transform pipeline, correctly injecting `import.meta.hot`.

**Fix 2 — defensive fallback** (`packages/@storybook-astro/renderer/src/render.tsx`):
Wrap the `resolvePrerenderedStoryHtml` call in a `try/catch` in `renderAstroToCanvas`. If the JSON fetch fails (404), emit a clear console warning and fall through to the HMR render path rather than crashing with a confusing network error. Static builds are unaffected — they still render from the prerendered JSON when it exists.

## Testing

- All 61 tests pass (`yarn test`)
- To manually verify: install `@storybook-astro/framework` via npm into a fresh Astro project and run `storybook dev` — stories should now render via HMR instead of crashing

Closes #36