### PR TITLE
fix: stub astro:react:opts and astro:preact:opts virtual modules in Storybook context

### DIFF
--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -50,6 +50,10 @@
         "types": "./src/vitest/index.ts",
         "import": "./dist/vitest/index.js"
       },
+      "./msw-helpers": {
+        "types": "./src/msw-helpers.ts",
+        "import": "./dist/msw-helpers.js"
+      },
       "./preset": {
         "types": "./preset.ts",
         "import": "./dist/preset.js"

--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -4,6 +4,7 @@ import { viteStorybookRendererFallbackPlugin } from './viteStorybookRendererFall
 import { vitePluginAstroComponentMarker } from './vitePluginAstroComponentMarker.ts';
 import { vitePluginAstroBuildPrerender } from './vitePluginAstroBuildPrerender.ts';
 import { vitePluginAstroVueFallback } from './vitePluginAstroVueFallback.ts';
+import { vitePluginAstroIntegrationOptsFallback } from './vitePluginAstroIntegrationOptsFallback.ts';
 import { resolveSanitizationOptions } from './lib/sanitization.ts';
 import { mergeWithAstroConfig } from './vitePluginAstro.ts';
 
@@ -36,6 +37,7 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, { conf
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vitePluginAstroBuildPrerender(options) as any,
     vitePluginAstroVueFallback(),
+    vitePluginAstroIntegrationOptsFallback(),
     ...viteConfig.plugins
   );
 
@@ -59,17 +61,20 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, { conf
 
   const finalConfig = await mergeWithAstroConfig(config, integrations, resolveFrom, mode, command);
 
-  // Exclude @astrojs/vue from dependency optimization because it imports
-  // virtual modules that esbuild cannot resolve (virtual:@astrojs/vue/app).
-  // This must be done after mergeWithAstroConfig to avoid being overwritten.
+  // Exclude Astro framework integration packages from Vite's esbuild dep
+  // pre-bundler. These packages import virtual modules (e.g. virtual:@astrojs/vue/app,
+  // astro:react:opts, astro:preact:opts) that esbuild cannot resolve. This
+  // must be done after mergeWithAstroConfig to avoid being overwritten.
   if (!finalConfig.optimizeDeps) {
     finalConfig.optimizeDeps = {};
   }
   if (!finalConfig.optimizeDeps.exclude) {
     finalConfig.optimizeDeps.exclude = [];
   }
-  if (!finalConfig.optimizeDeps.exclude.includes('@astrojs/vue')) {
-    finalConfig.optimizeDeps.exclude.push('@astrojs/vue');
+  for (const pkg of ['@astrojs/vue', '@astrojs/react', '@astrojs/preact']) {
+    if (!finalConfig.optimizeDeps.exclude.includes(pkg)) {
+      finalConfig.optimizeDeps.exclude.push(pkg);
+    }
   }
   // Exclude the renderer from Vite's esbuild pre-bundler so that
   // import.meta.hot is preserved in the preview iframe. When installed
@@ -80,16 +85,24 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, { conf
   if (!finalConfig.optimizeDeps.exclude.includes('@storybook-astro/renderer')) {
     finalConfig.optimizeDeps.exclude.push('@storybook-astro/renderer');
   }
-  // Mark Vue virtual modules as external so esbuild doesn't try to resolve them
+  // Mark integration virtual modules as external so esbuild skips them
+  // when it encounters them inside any package it does pre-bundle.
   if (!finalConfig.optimizeDeps.esbuildOptions) {
     finalConfig.optimizeDeps.esbuildOptions = {};
   }
   if (!finalConfig.optimizeDeps.esbuildOptions.external) {
     finalConfig.optimizeDeps.esbuildOptions.external = [];
   }
-  const vueVirtualModules = ['virtual:@astrojs/vue/app', 'virtual:astro:vue-app'];
+  const integrationVirtualModules = [
+    // @astrojs/vue
+    'virtual:@astrojs/vue/app',
+    'virtual:astro:vue-app',
+    // @astrojs/react and @astrojs/preact
+    'astro:react:opts',
+    'astro:preact:opts'
+  ];
 
-  for (const mod of vueVirtualModules) {
+  for (const mod of integrationVirtualModules) {
     if (!finalConfig.optimizeDeps.esbuildOptions.external.includes(mod)) {
       finalConfig.optimizeDeps.esbuildOptions.external.push(mod);
     }

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildPrerender.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildPrerender.ts
@@ -14,6 +14,7 @@ import { resolveRulesConfigFilePath } from './rules-options.ts';
 import { selectStoryRules } from './rules.ts';
 import type { FrameworkOptions } from './types.ts';
 import { vitePluginAstroFontsFallback } from './vitePluginAstroFontsFallback.ts';
+import { vitePluginAstroIntegrationOptsFallback } from './vitePluginAstroIntegrationOptsFallback.ts';
 import { vitePluginAstroRoutesFallback } from './vitePluginAstroRoutesFallback.ts';
 import { vitePluginAstroVueFallback } from './vitePluginAstroVueFallback.ts';
 
@@ -305,6 +306,7 @@ async function createStorySsrServer(
       vitePluginAstroFontsFallback(),
       vitePluginAstroVueFallback(),
       vitePluginAstroRoutesFallback(),
+      vitePluginAstroIntegrationOptsFallback(),
       {
         name: 'storybook-astro:static-prerender-ssr-stubs',
         resolveId(id: string) {

--- a/packages/@storybook-astro/framework/src/vitePluginAstroIntegrationOptsFallback.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroIntegrationOptsFallback.ts
@@ -1,0 +1,48 @@
+import type { Plugin } from 'vite';
+
+/**
+ * Stub for `astro:react:opts` and `astro:preact:opts` virtual modules.
+ *
+ * These modules are exported by @astrojs/react and @astrojs/preact respectively.
+ * They carry the `include`/`exclude` glob options passed to the integration and
+ * are imported by each integration's server.js during SSR rendering.
+ *
+ * Normally the opts plugin is registered by the Astro integration inside a full
+ * Astro Vite build. In Storybook's SSR context the integration hooks do not run,
+ * so the virtual module is never registered and resolution fails.
+ *
+ * This fallback stubs both modules with `export default {}` (empty opts), which
+ * is safe: the server renderers use the opts only for framework detection hints,
+ * and Storybook's integration config (via the `include` globs in .storybook/main.js)
+ * already handles routing correctly.
+ */
+
+const OPTS_STUB = `export default {};`;
+
+const VIRTUAL_IDS = ['astro:react:opts', 'astro:preact:opts'];
+
+export function vitePluginAstroIntegrationOptsFallback(): Plugin {
+  const resolvedIds = new Map(VIRTUAL_IDS.map((id) => [id, '\0' + id]));
+  const resolvedIdSet = new Set(resolvedIds.values());
+
+  return {
+    name: 'storybook-astro-integration-opts-fallback',
+    // Must run before vite:resolve so the virtual module IDs are intercepted
+    // before Vite tries to find them as Node package imports (and fails).
+    enforce: 'pre',
+
+    resolveId(id) {
+      const resolved = resolvedIds.get(id);
+
+      if (resolved) {
+        return resolved;
+      }
+    },
+
+    load(id) {
+      if (resolvedIdSet.has(id)) {
+        return { code: OPTS_STUB };
+      }
+    }
+  };
+}

--- a/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
+++ b/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
@@ -9,6 +9,7 @@ import { viteAstroContainerRenderersPlugin } from './viteAstroContainerRenderers
 import { vitePluginAstroFontsFallback } from './vitePluginAstroFontsFallback.ts';
 import { vitePluginAstroVueFallback } from './vitePluginAstroVueFallback.ts';
 import { vitePluginAstroRoutesFallback } from './vitePluginAstroRoutesFallback.ts';
+import { vitePluginAstroIntegrationOptsFallback } from './vitePluginAstroIntegrationOptsFallback.ts';
 import { ssrLoadModuleWithFsFallback } from './lib/ssr-load-module-with-fs-fallback.ts';
 import { resolveRulesConfigFilePath } from './rules-options.ts';
 
@@ -146,6 +147,7 @@ export async function createViteServer(integrations: Integration[], resolveFrom 
       vitePluginAstroFontsFallback(),
       vitePluginAstroVueFallback(),
       vitePluginAstroRoutesFallback(),
+      vitePluginAstroIntegrationOptsFallback(),
       ...(config.plugins?.filter(Boolean) ?? []),
       viteAstroContainerRenderersPlugin(safeIntegrations)
     ]

--- a/packages/@storybook-astro/framework/tsup.config.ts
+++ b/packages/@storybook-astro/framework/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     'src/vitest/index.ts',
     'src/integrations/index.ts',
     'src/middleware.ts',
+    'src/msw-helpers.ts',
   ],
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
## Problem

Running `storybook dev` with `@astrojs/react` and/or `@astrojs/preact` integrations fails with:

```
✘ [ERROR] Could not resolve "astro:preact:opts"
    node_modules/@astrojs/preact/dist/server.js:1:17:
      1 │ import opts from "astro:preact:opts";
✘ [ERROR] Unexpected end of JSON input [plugin onEnd]
✘ [ERROR] Could not resolve "astro:react:opts"
```

Discovered while testing with a standalone npm-installed project (`sandbox-astro6-local`). The monorepo sandboxes were unaffected because they use `workspace:*` linking which loads TypeScript source directly through Vite, bypassing the issues below.

## Root Cause

`@astrojs/react` and `@astrojs/preact` server renderers import a virtual module (`astro:react:opts` / `astro:preact:opts`) containing the `include`/`exclude` glob options passed to the integration. In a full Astro build the integration's own Vite plugin registers this virtual module. Storybook never runs Astro's bootstrap, so the hooks never fire and the virtual module is never registered.

This is the same class of issue already handled for `@astrojs/vue` (`vitePluginAstroVueFallback`), Astro fonts, and Astro routes — all virtual modules that Astro's integration system would normally register.

The error manifests in **two separate ways**:

**1. esbuild during dep pre-bundling (browser-side build)**

Vite uses esbuild to pre-bundle `node_modules` packages for performance. esbuild operates independently of Vite's plugin system and has no awareness of Vite virtual modules. When it pre-bundles `@astrojs/preact` or `@astrojs/react`, it encounters the virtual module import inside `server.js` and fails. The `Unexpected end of JSON input [plugin onEnd]` error is a downstream consequence of this failure in `vitePluginAstroBuildPrerender`'s story collection step.

**2. SSR Vite servers at render time**

The framework creates three separate internal Vite servers for different purposes. Without the fallback plugin in each, any of them could fail when an integration's server renderer tries to import the opts module.

## Changes

### `vitePluginAstroIntegrationOptsFallback.ts` (new file)

A new Vite plugin following the same pattern as the existing `vitePluginAstroVueFallback`. Intercepts `astro:react:opts` and `astro:preact:opts` at the Vite resolver level and stubs them with `export default {}`.

Registered in all three places where internal Vite servers are configured:
- `preset.ts` — Storybook's browser-side Vite server
- `viteStorybookAstroMiddlewarePlugin.ts` — the dev-mode HMR SSR server used for live rendering
- `vitePluginAstroBuildPrerender.ts`'s `createStorySsrServer` — the SSR server used during `storybook build`

### `preset.ts` — extend `optimizeDeps` exclusions

Adds `@astrojs/react` and `@astrojs/preact` to `optimizeDeps.exclude` (the same treatment already applied to `@astrojs/vue`) so esbuild never pre-bundles them. Also adds `astro:react:opts` and `astro:preact:opts` to `esbuildOptions.external` so any package esbuild *does* bundle that transitively encounters these IDs treats them as external rather than failing.

### `tsup.config.ts` + `package.json` — build and export `msw-helpers`

`msw-helpers.ts` was not a tsup entry point so it was never compiled to `dist/`. The `./*` → `./src/*` export fallback in `publishConfig` resolved `@storybook-astro/framework/msw-helpers` to a bare TypeScript path (no extension) that Vite's dep scanner cannot process, producing a secondary "Are they installed?" error. Fixed by adding `msw-helpers.ts` to tsup entries and an explicit `./msw-helpers` entry to `publishConfig.exports`.

## Known Risks

**Renderer disambiguation becomes path-agnostic**

The key line in both server renderers is:
```js
const filter = opts?.include || opts?.exclude ? createFilter(opts.include, opts.exclude) : null;
```
With `export default {}`, both `opts.include` and `opts.exclude` are `undefined`, so `filter = null`. The path-based file filter is effectively disabled — both renderers fall back to component type/prototype heuristics to determine which one should render a given component.

This is semantically equivalent to calling `react()` with no `include`/`exclude` (the documented default), and works correctly for the vast majority of setups. There is a theoretical edge case where React and Preact components coexist with ambiguous type signatures and no file-path filter to disambiguate them. In practice Storybook's story routing is explicit (via `include` globs in `.storybook/main.js` and `parameters.renderer` annotations), so renderer selection is already determined before the opts filter would apply.

**Performance: larger packages excluded from optimization**

Excluding `@astrojs/react` and `@astrojs/preact` from `optimizeDeps` means they are served as individual files in dev mode rather than a single pre-bundled chunk. Initial Storybook dev load may be marginally slower. This is consistent with the existing treatment of `@astrojs/vue`.

**No automated test coverage for the new plugin**

The 61 tests all use portable stories (`composeStories`/`renderStory`) which invoke `handlerFactory()` directly and never pass through the Vite plugin chain. A regression in `vitePluginAstroIntegrationOptsFallback` would not be caught by CI.

**Hardcoded virtual module names**

The module IDs `astro:react:opts` and `astro:preact:opts` are hardcoded. If Astro renames these in a future release the stubs would silently stop working. This is a pre-existing pattern in the codebase (Vue stubs are also hardcoded).

## Tests

All 61 tests pass (`yarn test`). Manually verified with a standalone `sandbox-astro6-local` test site using `@storybook-astro/framework@1.0.1` installed from npm.