### PR TITLE
docs: add styling guide for global CSS, CSS frameworks, fonts, and static assets

### DIFF
--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -47,6 +47,7 @@ export default defineConfig({
         {
           label: 'Guides',
           items: [
+            { label: 'Styling', slug: 'guides/styling' },
             { label: 'Images', slug: 'guides/images' },
             { label: 'Testing Stories', slug: 'guides/testing' },
             { label: 'Sanitization', slug: 'guides/sanitization' },

--- a/apps/website/src/content/docs/getting-started/configuration.md
+++ b/apps/website/src/content/docs/getting-started/configuration.md
@@ -70,6 +70,8 @@ const preview = {
 export default preview;
 ```
 
+If your project uses global CSS, a CSS utility framework (UnoCSS, Tailwind CSS), or custom fonts, see the [Styling guide](/guides/styling/) for how to make them available in Storybook.
+
 ## 3. Add scripts to `package.json`
 
 ```json

--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -34,6 +34,19 @@ Provide first-class support for Astro 6's new Font Provider API, allowing develo
 - Ensure font files are emitted correctly during `storybook build`
 - Support both remote and local font providers
 
+### Auto-detect CSS Frameworks from Astro Config
+
+Automatically detect and configure CSS utility frameworks (UnoCSS, Tailwind CSS, etc.) registered as Astro integrations, so their Vite plugins are available in Storybook without manual `viteFinal` configuration.
+
+**Status**: Planned  
+**Complexity**: Medium  
+**Details**: Currently, CSS frameworks configured as Astro integrations (e.g. `unocss/astro`, `@astrojs/tailwind`) are not automatically wired into Storybook's Vite pipeline. Users must manually add the framework's Vite plugin via `viteFinal` in `.storybook/main.js` and import virtual modules in the preview. See the [Styling guide](/guides/styling/) for the current manual setup.
+
+**Improvements needed**:
+- Detect CSS-related Vite plugins from the resolved Astro config during `mergeWithAstroConfig`
+- Automatically register detected plugins in Storybook's Vite pipeline
+- Handle virtual module imports (e.g. `virtual:uno.css`) in the preview
+
 ## Medium Priority
 
 ### Enhanced Testing & Portable Stories

--- a/apps/website/src/content/docs/guides/styling.md
+++ b/apps/website/src/content/docs/guides/styling.md
@@ -1,0 +1,199 @@
+---
+title: Styling
+description: Set up global CSS, CSS frameworks, fonts, and static assets in Storybook.
+---
+
+Astro component scoped styles work automatically — Storybook Astro handles them during rendering. But global styles, CSS utility frameworks, and fonts loaded outside your components (e.g. in a layout's `<head>`) require manual setup.
+
+## Global CSS
+
+Most Astro projects have a global stylesheet imported in a layout file:
+
+```astro
+---
+// src/layouts/Default.astro
+import '../styles/global.css';
+---
+```
+
+Storybook doesn't render your layout, so you need to import global styles in the Storybook preview. Create a `.storybook/preview.css` file:
+
+```css
+/* .storybook/preview.css */
+@import '../src/styles/global.css';
+```
+
+Then import it in `.storybook/preview.js`:
+
+```javascript
+// .storybook/preview.js
+import './preview.css';
+
+const preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+export default preview;
+```
+
+## CSS utility frameworks
+
+CSS frameworks like [UnoCSS](https://unocss.dev/) and [Tailwind CSS](https://tailwindcss.com/) are typically configured as Astro integrations, but their Vite plugins may not be automatically available in Storybook's build pipeline. You can add them directly using `viteFinal` in `.storybook/main.js`.
+
+### UnoCSS
+
+```javascript
+// .storybook/main.js
+import UnoCSS from 'unocss/vite';
+
+export default {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  framework: {
+    name: '@storybook-astro/framework',
+    options: {},
+  },
+  async viteFinal(config) {
+    config.plugins = config.plugins || [];
+    config.plugins.push(UnoCSS());
+    return config;
+  },
+};
+```
+
+Then import UnoCSS's generated stylesheet in `.storybook/preview.js`:
+
+```javascript
+import 'virtual:uno.css';
+import './preview.css';
+```
+
+UnoCSS reads your project's `uno.config.ts` automatically, so your presets (e.g. `presetWind`, `presetIcons`, `presetTypography`) will apply.
+
+### Tailwind CSS
+
+For Tailwind CSS v4+ (which uses a Vite plugin):
+
+```javascript
+// .storybook/main.js
+import tailwindcss from '@tailwindcss/vite';
+
+export default {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  framework: {
+    name: '@storybook-astro/framework',
+    options: {},
+  },
+  async viteFinal(config) {
+    config.plugins = config.plugins || [];
+    config.plugins.push(tailwindcss());
+    return config;
+  },
+};
+```
+
+For Tailwind CSS v3 (which uses PostCSS), no `viteFinal` changes are needed — just ensure your global CSS with `@tailwind` directives is imported in `.storybook/preview.css` and your `postcss.config.js` is in place.
+
+## Fonts
+
+Fonts loaded via Astro components (e.g. in `<head>` through a layout) won't be available in stories because Storybook renders components in isolation, without your page layout.
+
+Add `@font-face` declarations directly in `.storybook/preview.css`:
+
+```css
+/* .storybook/preview.css */
+@import '../src/styles/global.css';
+
+@font-face {
+  font-family: 'CustomFont';
+  font-style: normal;
+  font-display: swap;
+  src: url('/fonts/custom-font.woff2') format('woff2');
+}
+
+.custom-font {
+  font-family: 'CustomFont', sans-serif;
+}
+```
+
+:::tip
+Match the `font-family` names and CSS selectors to what your Astro font setup generates, so components render with the correct fonts without changes.
+:::
+
+## Static assets
+
+If your font files or other assets live in the `public/` directory, tell Storybook to serve them with `staticDirs`:
+
+```javascript
+// .storybook/main.js
+export default {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  staticDirs: ['../public'],
+  framework: {
+    name: '@storybook-astro/framework',
+    options: {},
+  },
+};
+```
+
+This makes files in `public/` available at the root URL path — e.g. `public/fonts/outfit.ttf` is served at `/fonts/outfit.ttf`, matching how Astro serves them.
+
+## Full example
+
+Here's a complete setup for a project using UnoCSS with local fonts:
+
+```javascript
+// .storybook/main.js
+import UnoCSS from 'unocss/vite';
+
+export default {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  staticDirs: ['../public'],
+  framework: {
+    name: '@storybook-astro/framework',
+    options: {},
+  },
+  async viteFinal(config) {
+    config.plugins = config.plugins || [];
+    config.plugins.push(UnoCSS());
+    return config;
+  },
+};
+```
+
+```javascript
+// .storybook/preview.js
+import 'virtual:uno.css';
+import './preview.css';
+
+const preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+export default preview;
+```
+
+```css
+/* .storybook/preview.css */
+@import '../src/styles/global.css';
+
+@font-face {
+  font-family: 'Poppins';
+  font-style: normal;
+  font-display: swap;
+  src: url('/fonts/poppins.ttf') format('truetype');
+}
+
+.poppins { font-family: 'Poppins', sans-serif; }
+```


### PR DESCRIPTION
## Summary

Adds a new Styling guide and related documentation updates to help users configure global CSS, CSS utility frameworks, fonts, and static assets in Storybook.

## Changes

- **New `guides/styling.md`** — Covers:
  - Importing global CSS via `.storybook/preview.css`
  - Setting up CSS utility frameworks (UnoCSS, Tailwind CSS v3/v4) via `viteFinal`
  - Adding `@font-face` declarations for fonts loaded outside components
  - Serving static assets (e.g. font files) with `staticDirs`
  - Full working example combining all of the above

- **Updated `guides/roadmap.md`** — Added high-priority item "Auto-detect CSS Frameworks from Astro Config" noting that CSS integrations like `unocss/astro` are not automatically wired into Storybook's Vite pipeline, with improvements needed in `mergeWithAstroConfig`

- **Updated `astro.config.mjs`** — Added Styling guide to the sidebar under Guides

- **Updated `getting-started/configuration.md`** — Added callout linking to the Styling guide after the preview.js section

## Context

Discovered while setting up Storybook for a project using UnoCSS and local fonts (`astro-font`). CSS utility classes and fonts loaded via Astro layout components are not available in Storybook by default, requiring manual Vite plugin and `@font-face` configuration.

Co-Authored-By: Oz <oz-agent@warp.dev>