### PR TITLE
fix: make setProjectAnnotations, composeStory, composeStories generic over renderer type

### DIFF
--- a/packages/@storybook-astro/framework/src/index.ts
+++ b/packages/@storybook-astro/framework/src/index.ts
@@ -11,8 +11,18 @@ import { definePreview as definePreviewBase, type PreviewAddon, type InferTypes,
 import type { ProjectAnnotations } from 'storybook/internal/types';
 import type { AstroRenderer } from './portable-stories.ts';
 
-/** Preview configuration type for `.storybook/preview.ts` in Astro projects. */
-export type Preview = ProjectAnnotations<AstroRenderer>;
+/**
+ * Preview configuration type for `.storybook/preview.ts` in Astro projects.
+ * Reflects the full type returned by `definePreview`, including addon type extensions.
+ * Use this to annotate your preview module when needed:
+ *
+ * ```ts
+ * import type { Preview } from '@storybook-astro/framework';
+ * const preview: Preview = { ... };
+ * export default preview;
+ * ```
+ */
+export type Preview<Addons extends PreviewAddon<never>[] = []> = CsfPreview<AstroRenderer & InferTypes<Addons>>;
 
 // Export portable stories functionality
 export {

--- a/packages/@storybook-astro/framework/src/portable-stories.test.ts
+++ b/packages/@storybook-astro/framework/src/portable-stories.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Type-level tests for portable-stories utilities.
+ *
+ * These tests verify that setProjectAnnotations, composeStory, and composeStories
+ * accept the widened renderer type produced by definePreview when addons are used.
+ * Without the generic R parameter, users get "has no properties in common" errors
+ * when passing a definePreview result to setProjectAnnotations.
+ *
+ * See: https://github.com/storybook-astro/storybook-astro/issues/58
+ */
+import { expectTypeOf, test } from 'vitest';
+import type { NormalizedProjectAnnotations } from 'storybook/internal/types';
+import { definePreview, setProjectAnnotations, type AstroRenderer } from './index.ts';
+
+test('setProjectAnnotations accepts a module whose default export is a widened Preview type', () => {
+  // This is the shape of `import * as preview from '.storybook/preview'`
+  // when the preview uses definePreview with addons.
+  type PreviewModule = { default: ReturnType<typeof definePreview<[]>> };
+
+  expectTypeOf<(annotations: PreviewModule) => NormalizedProjectAnnotations<AstroRenderer>>()
+    .toBeCallableWith({ default: definePreview({}) });
+});
+
+test('setProjectAnnotations return type narrows correctly for base AstroRenderer', () => {
+  const result = setProjectAnnotations([]);
+
+  expectTypeOf(result).toMatchTypeOf<NormalizedProjectAnnotations<AstroRenderer>>();
+});

--- a/packages/@storybook-astro/framework/src/portable-stories.ts
+++ b/packages/@storybook-astro/framework/src/portable-stories.ts
@@ -89,12 +89,12 @@ const render = (args: Args, context?: any) => {
  *
  * @param projectAnnotations - E.g. (import projectAnnotations from '../.storybook/preview')
  */
-export function setProjectAnnotations(
+export function setProjectAnnotations<R extends AstroRenderer = AstroRenderer>(
   projectAnnotations:
-    | NamedOrDefaultProjectAnnotations<AstroRenderer>
-    | NamedOrDefaultProjectAnnotations<AstroRenderer>[]
-): NormalizedProjectAnnotations<AstroRenderer> {
-  return originalSetProjectAnnotations<AstroRenderer>(projectAnnotations);
+    | NamedOrDefaultProjectAnnotations<R>
+    | NamedOrDefaultProjectAnnotations<R>[]
+): NormalizedProjectAnnotations<R> {
+  return originalSetProjectAnnotations<R>(projectAnnotations);
 }
 
 /**
@@ -123,10 +123,10 @@ export function setProjectAnnotations(
  * @param projectAnnotations - E.g. (import * as projectAnnotations from '../.storybook/preview') this can be applied automatically if you use `setProjectAnnotations` in your setup files.
  * @param exportsName - In case your story does not contain a name and you want it to have a name.
  */
-export function composeStory<TArgs extends Args = Args>(
-  story: StoryAnnotationsOrFn<AstroRenderer, TArgs>,
-  componentAnnotations: ComponentAnnotations<AstroRenderer, TArgs>,
-  projectAnnotations?: ProjectAnnotations<AstroRenderer>,
+export function composeStory<TArgs extends Args = Args, R extends AstroRenderer = AstroRenderer>(
+  story: StoryAnnotationsOrFn<R, TArgs>,
+  componentAnnotations: ComponentAnnotations<R, TArgs>,
+  projectAnnotations?: ProjectAnnotations<R>,
   exportsName?: string
 ) {
   // Merge project annotations with Astro renderer
@@ -139,7 +139,7 @@ export function composeStory<TArgs extends Args = Args>(
   
   return originalComposeStory<AstroRenderer, TArgs>(
     story as any,
-    componentAnnotations,
+    componentAnnotations as any,
     mergedProjectAnnotations as any,
     exportsName as any
   );
@@ -169,9 +169,9 @@ export function composeStory<TArgs extends Args = Args>(
  * @param storiesImport - E.g. (import * as stories from './Button.stories')
  * @param projectAnnotations - E.g. (import * as globalConfig from '../.storybook/preview') this can be applied automatically if you use `setProjectAnnotations` in your setup files.
  */
-export function composeStories<TModule extends Record<string, any>>(
+export function composeStories<TModule extends Record<string, any>, R extends AstroRenderer = AstroRenderer>(
   storiesImport: TModule,
-  projectAnnotations?: ProjectAnnotations<AstroRenderer>
+  projectAnnotations?: ProjectAnnotations<R>
 ): { [K in keyof Omit<TModule, 'default'>]: any } {
   // Merge project annotations with Astro renderer
   const mergedProjectAnnotations: any = projectAnnotations ? {


### PR DESCRIPTION
Closes #58

## Problem

`definePreview` returns `Preview<AstroRenderer & InferTypes<Addons>>` — addon types get merged into the renderer type. But `setProjectAnnotations` (and `composeStory`/`composeStories`) were hardcoded to accept only the base `AstroRenderer`. Users with addon-enriched previews got:

```
Type 'Preview<AstroRenderer & A11yTypes & DocsTypes & { csf4: true; }>' has no properties in common with type 'ProjectAnnotations<AstroRenderer>'
```

## Changes

- **`portable-stories.ts`** — Added `R extends AstroRenderer = AstroRenderer` generic to `setProjectAnnotations`, `composeStory`, and `composeStories`. The default keeps existing callers unchanged; callers with widened renderer types now type-check correctly.
- **`framework/src/index.ts`** — Fixed the `Preview` type export from `ProjectAnnotations<AstroRenderer>` (simple/incorrect form) to `CsfPreview<AstroRenderer & InferTypes<Addons>>`, matching what `definePreview` actually returns.
- **`portable-stories.test.ts`** (new) — Type-level regression tests to catch if this gap re-opens on a future Storybook upgrade.