### PR TITLE
fix: demo site improvements — rename Sandbox to Demo, fix website tsconfig

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,19 @@ Thank you for your interest in contributing! This project is community-driven an
    ```bash
    yarn install
    ```
-4. Start Storybook (from an integration example):
+4. Start both Storybook instances and the website simultaneously:
    ```bash
+   yarn dev
+   ```
+   This runs the Astro 6 demo on port **6006**, the Astro 5 demo on port **6007**, and the marketing website in parallel.
+
+   Or start a single Storybook instance:
+   ```bash
+   # Astro 6 (port 6006)
    yarn workspace @storybook-astro/integration-astro6 storybook
+
+   # Astro 5 (port 6007)
+   yarn workspace @storybook-astro/integration-astro5 storybook
    ```
 5. Run tests:
    ```bash

--- a/apps/website/src/pages/contribute.astro
+++ b/apps/website/src/pages/contribute.astro
@@ -31,12 +31,11 @@ cd storybook-astro</code></pre>
         <pre><code>yarn install</code></pre>
       </li>
       <li>
-        Start Storybook (dev mode):
-        <pre><code>yarn storybook</code></pre>
-      </li>
-      <li>
-        Run the Astro site:
+        Start both Storybook testing instances and the website simultaneously:
         <pre><code>yarn dev</code></pre>
+        This runs the Astro 6 demo (port 6006), the Astro 5 demo (port 6007), and the marketing website in parallel.
+        To start a single Storybook instance instead:
+        <pre><code>yarn workspace @storybook-astro/integration-astro6 storybook</code></pre>
       </li>
     </ol>
 

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
+  },
   "exclude": ["dist"],
   "include": [".astro/types.d.ts", "./src/**/*"]
 }

--- a/integration/astro5/src/stories/Overview.mdx
+++ b/integration/astro5/src/stories/Overview.mdx
@@ -2,9 +2,9 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Overview" />
 
-# Storybook Astro — Astro 5 Sandbox
+# Storybook Astro — Astro 5 Demo
 
-This sandbox validates `@storybook-astro/framework` against **Astro 5**. Running on port **6007**.
+This demo validates `@storybook-astro/framework` against **Astro 5**. Running on port **6007**.
 
 ## Versions
 

--- a/integration/astro6/src/stories/Overview.mdx
+++ b/integration/astro6/src/stories/Overview.mdx
@@ -2,9 +2,9 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Overview" />
 
-# Storybook Astro — Astro 6 Sandbox
+# Storybook Astro — Astro 6 Demo
 
-This sandbox validates `@storybook-astro/framework` against **Astro 6**. Running on port **6006**.
+This demo validates `@storybook-astro/framework` against **Astro 6**. Running on port **6006**.
 
 ## Versions
 


### PR DESCRIPTION
## Summary

- **Rename "Sandbox" to "Demo"** in the Overview page titles for both Astro 5 and Astro 6 demo sites — the sites are public-facing demos, not internal sandboxes
- **Update contributing docs** — `CONTRIBUTING.md` and `contribute.astro` now accurately describe `yarn dev` as launching both Storybook testing instances (ports 6006/6007) and the website in parallel, not a standalone Astro site
- **Fix website `tsconfig.json`** — adds `jsxImportSource: "preact"` (with `jsx: "react-jsx"`) so TypeScript resolves `JSX.IntrinsicElements` from `preact/jsx-runtime`, eliminating _"JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists"_ warnings on HTML elements in `.astro` pages

## Test plan

- [ ] Overview page on each demo site shows "Storybook Astro — Astro 6 Demo" / "Astro 5 Demo" (no "Sandbox")
- [ ] `yarn website` — verify marketing site loads and `.astro` pages show no JSX type warnings in VS Code
- [ ] `yarn test` — all tests pass