### PR TITLE
fix: resolve renderer via import.meta.resolve for pnpm compatibility

### DIFF
--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -12,7 +12,14 @@ import { mergeWithAstroConfig } from './vitePluginAstro.ts';
 
 export const core = {
   builder: '@storybook/builder-vite',
-  renderer: '@storybook-astro/renderer'
+  // Use import.meta.resolve so Storybook receives an absolute file:// URL
+  // to the renderer preset rather than a bare package specifier.  When
+  // package managers like pnpm use strict node_modules isolation, bare
+  // specifiers are resolved from the *project root*, where the renderer
+  // (a dep of this framework, not the user's project) is not hoisted.
+  // The absolute URL is resolved from *this* file's location where the
+  // renderer is always accessible as a direct dependency.
+  renderer: import.meta.resolve('@storybook-astro/renderer')
 };
 
 export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, { configType, presets }) => {


### PR DESCRIPTION
## Summary

- Fixes `MissingRenderToCanvasError` when using pnpm
- Changes `core.renderer` in the framework preset from a bare package specifier to an absolute path via `import.meta.resolve()`

## Root Cause

With pnpm's strict node_modules isolation, transitive dependencies are not hoisted to the project root. Storybook resolves `core.renderer` by searching upward from the `.storybook` directory — so the bare specifier `'@storybook-astro/renderer'` fails to resolve when the package only exists inside the framework's own `node_modules` subtree. The renderer is silently skipped, `entry-preview` never loads, and `renderToCanvas` is never registered.

## Fix

`import.meta.resolve('@storybook-astro/renderer')` produces an absolute `file://` URL resolved from the framework preset's own location, where the renderer is always accessible as a direct dependency. Storybook's `resolveAddonName` handles `file://` URLs correctly and loads the preset directly. This is the same pattern used by `@storybook/react-vite` and other official Storybook framework presets.

Closes #64