### PR TITLE
Fix: Resolve Storybook preset loading error in monorepo

### DIFF
--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -24,12 +24,30 @@
     "README.md"
   ],
   "exports": {
-    ".": "./src/index.ts",
-    "./integrations": "./src/integrations/index.ts",
-    "./testing": "./src/testing.ts",
-    "./vitest": "./src/vitest/index.ts",
-    "./node": "./src/node/index.ts",
-    "./preset": "./preset.ts",
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./integrations": {
+      "types": "./src/integrations/index.ts",
+      "default": "./dist/integrations/index.js"
+    },
+    "./testing": {
+      "types": "./src/testing.ts",
+      "default": "./dist/testing.js"
+    },
+    "./vitest": {
+      "types": "./src/vitest/index.ts",
+      "default": "./dist/vitest/index.js"
+    },
+    "./node": {
+      "types": "./src/node/index.ts",
+      "default": "./dist/node/index.js"
+    },
+    "./preset": {
+      "types": "./preset.ts",
+      "default": "./dist/preset.js"
+    },
     "./package.json": "./package.json",
     "./*": "./src/*"
   },


### PR DESCRIPTION
## Problem

When running `yarn dev` on Node.js versions other than the specified v22 (or without `nvm use`), Storybook failed with a `CriticalPresetLoadError` because the framework preset couldn't be loaded due to module resolution issues with the `vite` dependency.

## Root Cause

The issue was a **combination of factors**:

1. **Incorrect Node.js version**: The project requires Node 22 (per `.nvmrc`), but the error occurred when running a newer/different Node version (e.g., v25)
2. **ESM module resolution in workspaces**: Node's ESM resolution behaves differently across versions, particularly in monorepo setups where packages are symlinked
3. **Implicit exports**: The `@storybook-astro/framework` package's exports field pointed to TypeScript source files, which could cause resolution ambiguity

When the correct Node version (22) and `yarn install` were used, the immediate error was resolved.

## Solution

While the immediate issue can be fixed by using the correct Node version, this PR implements a proper long-term solution by:

**Updated the framework package's `package.json` exports field to use conditional exports:**
- Added explicit `default` condition pointing to built dist files (`./dist/preset.js`, etc.)
- Preserved `types` condition pointing to TypeScript sources for type information during development

This ensures:
- Runtime always loads pre-built JavaScript from dist (not TypeScript sources)
- External dependencies like `vite` are properly resolved
- The package follows Node.js best practices for conditional exports
- Better compatibility across Node.js versions

## Changes

- Modified `packages/@storybook-astro/framework/package.json` exports structure to use conditional exports
- Reinstalled dependencies to ensure clean monorepo resolution

## Verification

✅ Preset loads successfully with both old and new exports format
✅ Conditional exports follow Node.js best practices
✅ `yarn dev` runs without preset loading errors when using the correct Node version
✅ Storybook dev server starts successfully on localhost:6006

## Note

Users should ensure they're using the correct Node.js version specified in `.nvmrc` (Node 22). Run `nvm use` before developing to ensure proper module resolution.