### PR TITLE
feat: disable Controls for Astro stories in production builds

### DIFF
--- a/apps/website/src/content/docs/how-it-works/static-builds.md
+++ b/apps/website/src/content/docs/how-it-works/static-builds.md
@@ -25,7 +25,7 @@ Since Astro components require server-side rendering via the Container API, stat
 Astro component stories are rendered with their default args at build time. Changing args via the Controls panel has no effect in static builds.
 :::
 
-- **No interactive Controls** — Since Astro components are pre-rendered at build time, the Controls panel cannot re-render them with different args. This only affects Astro components — framework component stories (React, Vue, etc.) remain fully interactive.
+- **No interactive Controls** — Since Astro components are pre-rendered at build time, the Controls panel cannot re-render them with different args. This only affects Astro components — framework component stories (React, Vue, etc.) remain fully interactive. In static builds, the package automatically disables all control inputs for Astro stories and shows an **ℹ️ Astro** info row in the Controls table so viewers understand why. No configuration is needed.
 - **No story-level component override** — Stories that override the meta-level `component` are not pre-rendered.
 - **Dev mode unaffected** — In `storybook dev`, all components render on-demand and Controls work as expected.
 

--- a/apps/website/src/content/docs/writing-stories/controls.md
+++ b/apps/website/src/content/docs/writing-stories/controls.md
@@ -54,8 +54,10 @@ export default {
 
 ## Static build limitation
 
-:::caution
-For Astro components in static builds (`storybook build`), changing args via Controls has no effect because Astro components are pre-rendered at build time. Controls work fully in dev mode (`storybook dev`) and for framework component stories (React, Vue, etc.).
-:::
+In static builds (`storybook build`), Astro components are pre-rendered at build time with their default args. The Controls panel cannot re-render them with different values.
 
-See [Static Builds](/how-it-works/static-builds/) for more details on this limitation.
+The package handles this automatically: in a static build, all control inputs for Astro component stories are disabled and an **ℹ️ Astro** info row appears in the Controls table explaining that the component is pre-rendered. No configuration is needed.
+
+Controls work fully in dev mode (`storybook dev`) and for framework component stories (React, Vue, etc.) in all modes.
+
+See [Static Builds](/how-it-works/static-builds/) for more details.

--- a/packages/@storybook-astro/renderer/src/entry-preview.ts
+++ b/packages/@storybook-astro/renderer/src/entry-preview.ts
@@ -2,4 +2,44 @@
 
 export const parameters = { renderer: 'astro' };
 
+function isAstroComponent(component: unknown): boolean {
+  return (
+    typeof component === 'function' &&
+    component !== null &&
+    'isAstroComponentFactory' in component &&
+    (component as { isAstroComponentFactory: boolean }).isAstroComponentFactory === true
+  );
+}
+
+const isProduction = import.meta.env.PROD;
+
+// In production builds, disable controls for Astro components (they are pre-rendered).
+export const argTypesEnhancers = isProduction
+  ? [
+      (context: { component: unknown; argTypes: Record<string, Record<string, unknown>> }) => {
+        const { component, argTypes } = context;
+
+        if (!isAstroComponent(component)) {
+          return argTypes;
+        }
+
+        const disabledArgTypes: Record<string, Record<string, unknown>> = {};
+
+        for (const [key, argType] of Object.entries(argTypes)) {
+          disabledArgTypes[key] = { ...argType, control: false };
+        }
+
+        disabledArgTypes['_astroPrerendered'] = {
+          name: 'Pre-rendered',
+          description:
+            'This Astro component is pre-rendered at build time. Controls are unavailable in static builds.',
+          control: false,
+          table: { category: 'ℹ️ Astro' },
+        };
+
+        return disabledArgTypes;
+      },
+    ]
+  : [];
+
 export { renderToCanvas, render } from './render.tsx';

--- a/packages/@storybook-astro/renderer/tsconfig.json
+++ b/packages/@storybook-astro/renderer/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vite/client"]
+  },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary

- Adds `argTypesEnhancers` to `entry-preview.ts` in the renderer package that automatically disables all control inputs for Astro component stories in static builds (`storybook build`)
- An **ℹ️ Astro** info row is injected into the Controls table explaining that the component is pre-rendered and controls are unavailable
- Behaviour is fully automatic — no user configuration required
- Development mode (`storybook dev`) and non-Astro stories (React, Vue, etc.) are unaffected
- Adds `vite/client` types to the renderer `tsconfig.json` to resolve `import.meta.env`

## Docs

- `writing-stories/controls.md` — updated static build limitation section to describe the automatic UI behaviour
- `how-it-works/static-builds.md` — extended the "No interactive Controls" limitation to mention the automatic handling

## Test plan

- [ ] Run `storybook dev` — Controls panel works as normal for all Astro stories
- [ ] Run `storybook build` and serve the output — Controls panel for Astro stories shows disabled inputs and the **ℹ️ Astro** info row
- [ ] Confirm React/Vue/Svelte stories are unaffected in both modes