### PR TITLE
fix: use --test flag for CI and smoke test Storybook builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,12 +43,12 @@ jobs:
 
       - name: Build Storybook (Astro 6)
         continue-on-error: true
-        run: timeout 180 yarn workspace @storybook-astro/integration-astro6 build-storybook || test $? -eq 124
+        run: timeout 180 yarn workspace @storybook-astro/integration-astro6 build-storybook -- --test || test $? -eq 124
         env:
           STORYBOOK_DISABLE_TELEMETRY: 1
 
       - name: Build Storybook (Astro 5)
         continue-on-error: true
-        run: timeout 180 yarn workspace @storybook-astro/integration-astro5 build-storybook || test $? -eq 124
+        run: timeout 180 yarn workspace @storybook-astro/integration-astro5 build-storybook -- --test || test $? -eq 124
         env:
           STORYBOOK_DISABLE_TELEMETRY: 1

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -113,7 +113,7 @@ run_fresh() {
   npm install --legacy-peer-deps --no-package-lock --silent
 
   log "Running storybook build..."
-  run_with_timeout 180 ./node_modules/.bin/storybook build --quiet \
+  run_with_timeout 180 ./node_modules/.bin/storybook build --quiet --test \
     || { fail "storybook build failed or timed out"; exit 1; }
 
   log "Running component tests..."
@@ -154,7 +154,7 @@ run_upgrade() {
   npm install --legacy-peer-deps --no-package-lock --silent
 
   log "Verifying @latest works..."
-  run_with_timeout 180 ./node_modules/.bin/storybook build --quiet \
+  run_with_timeout 180 ./node_modules/.bin/storybook build --quiet --test \
     || { fail "storybook build failed on @latest — upgrade test cannot proceed"; exit 1; }
   ./node_modules/.bin/vitest run
 
@@ -175,7 +175,7 @@ run_upgrade() {
   npm install --legacy-peer-deps --no-package-lock --silent
 
   log "Verifying upgrade works..."
-  run_with_timeout 180 ./node_modules/.bin/storybook build --quiet \
+  run_with_timeout 180 ./node_modules/.bin/storybook build --quiet --test \
     || { fail "storybook build failed after upgrade"; exit 1; }
   ./node_modules/.bin/vitest run
 


### PR DESCRIPTION
## Summary

- Adds `--test` to all `storybook build` commands used purely for crash detection in CI (`build.yml`) and smoke tests (`smoke-test.sh`)
- Disables docs generation and heavy addons for these builds, reducing build time and resource usage
- The `build-storybook` scripts in the integration `package.json` files are intentionally left unchanged — they serve dual purpose (CI + local dev builds)

## Test plan

- [ ] Verify CI "Build Storybook" steps complete faster on the next push to `develop`
- [ ] Confirm smoke tests still pass with `--test` flag