### PR TITLE
fix: force light-theme colors in Pagefind search dialog

### DIFF
--- a/apps/website/src/styles/starlight-overrides.css
+++ b/apps/website/src/styles/starlight-overrides.css
@@ -123,7 +123,7 @@ mobile-starlight-toc .caret {
 :root #starlight__search {
   --pagefind-ui-primary: #24292f;
   --pagefind-ui-text: #24292f;
-  --pagefind-ui-background: #ffffff;
   --pagefind-ui-border: #e1e4e8;
+  --pagefind-ui-background: #ffffff;
   --pagefind-ui-tag: #eef0f2;
 }

--- a/apps/website/src/styles/starlight-overrides.css
+++ b/apps/website/src/styles/starlight-overrides.css
@@ -110,3 +110,20 @@ mobile-starlight-toc .caret {
 .sidebar-pane {
   border-color: #e1e4e8;
 }
+
+/* ── Pagefind search dialog: force light-theme colors ── */
+/*
+ * The site always uses a light body. When the OS is in dark mode, Starlight
+ * applies [data-theme="dark"] which makes --sl-color-text and --sl-color-gray-*
+ * light-colored. Pagefind UI inherits those via --pagefind-ui-primary/text, so
+ * result titles (.pagefind-ui__result-link) become unreadable on the white dialog
+ * background. Override with hardcoded light-theme values to stay readable regardless
+ * of OS color scheme.
+ */
+:root #starlight__search {
+  --pagefind-ui-primary: #24292f;
+  --pagefind-ui-text: #24292f;
+  --pagefind-ui-background: #ffffff;
+  --pagefind-ui-border: #e1e4e8;
+  --pagefind-ui-tag: #eef0f2;
+}


### PR DESCRIPTION
## Summary

- Pagefind UI inherits `--pagefind-ui-primary`/`--pagefind-ui-text` from Starlight's color tokens
- When OS is in dark mode, Starlight applies `[data-theme="dark"]` which flips those tokens to light values
- The site's dialog background is always white, making result link titles (`.pagefind-ui__result-link`) unreadable
- Fix overrides the five Pagefind UI color variables on `#starlight__search` with hardcoded light-theme values using `:root #starlight__search` for higher specificity

Closes #70

## Test plan

- [ ] Build the website (`yarn build` in `apps/website`)
- [ ] Open the site with OS set to dark mode
- [ ] Open the search dialog and verify result titles are readable (dark text on white background)
- [ ] Verify appearance is unchanged with OS set to light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)