### PR TITLE
fix: use static render mode for built Storybook demos

### DIFF
--- a/integration/astro5/.storybook/main.js
+++ b/integration/astro5/.storybook/main.js
@@ -22,6 +22,7 @@ const config = {
   framework: {
     name: '@storybook-astro/framework',
     options: {
+      renderMode: 'static',
       storyRules: './.storybook/story-rules.ts',
       integrations: [
         react({

--- a/integration/astro6/.storybook/main.js
+++ b/integration/astro6/.storybook/main.js
@@ -22,6 +22,7 @@ const config = {
   framework: {
     name: '@storybook-astro/framework',
     options: {
+      renderMode: 'static',
       storyRules: './.storybook/story-rules.ts',
       integrations: [
         react({


### PR DESCRIPTION
## Problem
Deployed Storybook demos (`storybook-astro-demo`, `storybook-astro-demo-astro5`) show the error "Unable to reach Astro rendering server at http://localhost:3000" when viewing any component story.

## Root cause
`@storybook-astro/framework` supports three render modes (see `packages/@storybook-astro/framework/src/preset.ts`):
- `'development'` — uses Vite HMR (dev server only)
- `'server'` — default in production; fetches rendered HTML from an HTTP server at `STORYBOOK_ASTRO_SERVER_URL` (default `http://localhost:3000`)
- `'static'` — pre-renders all stories at build time and bundles them as `astro-prerendered-stories.json`

Neither `integration/astro5/.storybook/main.js` nor `integration/astro6/.storybook/main.js` sets `renderMode`, so the production `build-storybook` output is hard-wired to POST to `http://localhost:3000/render`. On a static host (Cloudflare Workers Assets) there is no such server, so every Astro story fails to render.

## Fix
Set `renderMode: 'static'` in `framework.options` for both integration Storybook configs. This makes `build-storybook` pre-render stories into `storybook-static/astro-prerendered-stories.json`, which `renderer-static.ts` loads at runtime — no server required.

## Testing
- Local: `yarn workspace @storybook-astro/integration-astro6 build-storybook` should produce `astro-prerendered-stories.json` alongside the HTML output.
- Preview: the Cloudflare preview URL attached to this PR should render Astro stories without the "Unable to reach Astro rendering server" error.