### PR TITLE
fix(framework): inject passthrough image service in build prerender

### DIFF
--- a/packages/@storybook-astro/framework/src/lib/passthrough-image-service.ts
+++ b/packages/@storybook-astro/framework/src/lib/passthrough-image-service.ts
@@ -1,0 +1,76 @@
+/**
+ * Install a passthrough image service on `globalThis.astroAsset.imageService`.
+ *
+ * AstroContainer has no image service configuration API, and the default
+ * `getConfiguredImageService()` tries to dynamically import "virtual:image-service"
+ * which fails in astro6/Vite 7's module runner. Even when it succeeds (astro5),
+ * the noop service still routes through /_image?href=... URLs that the Storybook
+ * dev server cannot serve.
+ *
+ * Pre-populating `globalThis.astroAsset.imageService` bypasses the dynamic import
+ * entirely — `getConfiguredImageService()` checks this global first and returns
+ * it without going through the broken virtual module. Our service returns the
+ * direct /@fs/... Vite URL from the ImageMetadata object, which Vite can serve
+ * as a static asset in the browser; in static (build-time prerender) mode the
+ * URL ends up being rewritten to a content-hashed Rollup asset.
+ *
+ * This must be called on the same Node process that hosts AstroContainer,
+ * before `container.renderToString()` is invoked.
+ */
+export function installPassthroughImageService() {
+  if (!globalThis.astroAsset) {
+    (globalThis as Record<string, unknown>).astroAsset = {};
+  }
+
+  (globalThis.astroAsset as Record<string, unknown>).imageService = {
+    propertiesToHash: ['src'],
+    validateOptions(options: Record<string, unknown>) {
+      return options;
+    },
+    getURL(options: { src: unknown }) {
+      const src = options.src;
+
+      if (
+        src != null &&
+        typeof src === 'object' &&
+        'src' in src &&
+        typeof (src as Record<string, unknown>).src === 'string'
+      ) {
+        // ImageMetadata object — return the /@fs/... Vite URL directly
+        return (src as Record<string, unknown>).src as string;
+      }
+
+      return typeof src === 'string' ? src : '';
+    },
+    getHTMLAttributes(options: Record<string, unknown>) {
+      const {
+        src,
+        width,
+        height,
+        format: _format,
+        quality: _quality,
+        densities: _densities,
+        widths: _widths,
+        formats: _formats,
+        layout: _layout,
+        priority: _priority,
+        fit: _fit,
+        position: _position,
+        background: _background,
+        ...attrs
+      } = options;
+      const srcObj = src != null && typeof src === 'object' ? (src as Record<string, unknown>) : null;
+
+      return {
+        ...attrs,
+        width: width ?? srcObj?.width,
+        height: height ?? srcObj?.height,
+        loading: (attrs.loading as string | undefined) ?? 'lazy',
+        decoding: (attrs.decoding as string | undefined) ?? 'async'
+      };
+    },
+    getSrcSet() {
+      return [];
+    }
+  };
+}

--- a/packages/@storybook-astro/framework/src/middleware.ts
+++ b/packages/@storybook-astro/framework/src/middleware.ts
@@ -1,6 +1,7 @@
 import { pathToFileURL } from 'node:url';
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { Integration } from './integrations/index.ts';
+import { installPassthroughImageService } from './lib/passthrough-image-service.ts';
 import type { SanitizationOptions } from './lib/sanitization.ts';
 import { resolveSanitizationOptions, sanitizeRenderPayload } from './lib/sanitization.ts';
 import { resolveStoryModuleMock, withStoryModuleMocks } from './module-mocks.ts';
@@ -39,51 +40,9 @@ type HandlerFactoryOptions = {
 };
 
 export async function handlerFactory(_integrations: Integration[], options?: HandlerFactoryOptions) {
-  // Inject a passthrough image service before any component renders.
-  //
-  // AstroContainer has no image service configuration API, and the default
-  // getConfiguredImageService() tries to dynamically import "virtual:image-service"
-  // which fails in astro6/Vite 7's module runner. Even when it succeeds (astro5),
-  // the noop service still routes through /_image?href=... URLs that the Storybook
-  // dev server cannot serve.
-  //
-  // Pre-populating globalThis.astroAsset.imageService bypasses the dynamic import
-  // entirely. Our service returns the direct /@fs/... Vite URL from the ImageMetadata
-  // object, which Vite can serve as a static asset in the browser.
-  if (!globalThis.astroAsset) {
-    (globalThis as Record<string, unknown>).astroAsset = {};
-  }
-  (globalThis.astroAsset as Record<string, unknown>).imageService = {
-    propertiesToHash: ['src'],
-    validateOptions(options: Record<string, unknown>) {
-      return options;
-    },
-    getURL(options: { src: unknown }) {
-      const src = options.src;
-
-      if (src != null && typeof src === 'object' && 'src' in src && typeof (src as Record<string, unknown>).src === 'string') {
-        // ImageMetadata object — return the /@fs/... Vite URL directly
-        return (src as Record<string, unknown>).src as string;
-      }
-
-      return typeof src === 'string' ? src : '';
-    },
-    getHTMLAttributes(options: Record<string, unknown>) {
-      const { src, width, height, format, quality, densities, widths, formats, layout, priority, fit, position, background, ...attrs } = options;
-      const srcObj = src != null && typeof src === 'object' ? src as Record<string, unknown> : null;
-
-      return {
-        ...attrs,
-        width: width ?? srcObj?.width,
-        height: height ?? srcObj?.height,
-        loading: (attrs.loading as string | undefined) ?? 'lazy',
-        decoding: (attrs.decoding as string | undefined) ?? 'async',
-      };
-    },
-    getSrcSet() {
-      return [];
-    }
-  };
+  // Inject a passthrough image service before any component renders. See
+  // `lib/passthrough-image-service.ts` for why this is necessary.
+  installPassthroughImageService();
 
   const container = await AstroContainer.create({
     // Somewhat hacky way to force client-side Storybook's Vite to resolve modules properly

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildPrerender.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildPrerender.ts
@@ -6,6 +6,7 @@ import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import { createServer, mergeConfig, type Plugin, type Rollup } from 'vite';
 import { importAstroConfig } from './importAstroConfig.ts';
 import type { Integration } from './integrations/index.ts';
+import { installPassthroughImageService } from './lib/passthrough-image-service.ts';
 import { ssrLoadModuleWithFsFallback } from './lib/ssr-load-module-with-fs-fallback.ts';
 import { resolveSanitizationOptions, sanitizeRenderPayload } from './lib/sanitization.ts';
 import { resolveStoryModuleMock, withStoryModuleMocks } from './module-mocks.ts';
@@ -190,6 +191,15 @@ async function prerenderStories(options: {
     options.resolveFrom
   );
   const rulesConfigModule = await loadRulesConfigModule(viteServer, options.storyRulesConfigFilePath);
+
+  // Inject a passthrough image service before the container renders any
+  // components. The `image: { service: passthroughImageService() }` config
+  // passed to Astro above is not sufficient on Astro 6: at render time
+  // `getConfiguredImageService()` still dynamically imports
+  // "virtual:image-service", which fails in Vite 7's module runner with
+  // `InvalidImageService`. Pre-populating globalThis.astroAsset.imageService
+  // short-circuits that dynamic import. See `lib/passthrough-image-service.ts`.
+  installPassthroughImageService();
 
   try {
     const container = await AstroContainer.create({


### PR DESCRIPTION
## Problem
On Astro 6 / Vite 7, the build-time prerender path (`renderMode: 'static'`) fails with:

```
[storybook-astro:build-prerender] There was an error loading the configured image service.
  at getConfiguredImageService (astro/dist/assets/internal.js:21:34)
  at async getImage (astro:assets:69:44)
  at async eval (./node_modules/astro/components/Image.astro:36:17)
```

This happens whenever a story renders any component that uses `<Image>` from `astro:assets` — which is common in the integration demo stories.

## Root cause
This is the exact same Astro 6 bug that `docs/how-it-works/astro6-compat.md` section 6 already documents for the dev/runtime path:

> Astro's `getConfiguredImageService()` calls `import("virtual:image-service")` to load the configured service. In Vite 7's module runner (used by Astro 6), this dynamic import fails with `InvalidImageService`.

`middleware.ts` already works around this at render time by pre-populating `globalThis.astroAsset.imageService` with an inline passthrough service before the AstroContainer renders. `getConfiguredImageService()` checks that global first and bypasses the broken dynamic import.

However, `vitePluginAstroBuildPrerender.ts` never applied the same shim. Its `image: { service: passthroughImageService() }` on the vite config alone is not enough: at render time, `getConfiguredImageService()` still goes through `virtual:image-service` and fails on Astro 6.

As a result, any static build of Astro 6 stories that use `<Image>` was broken, and the breakage was latent — it was only surfaced by the fix in PR #75 (switching the integration demos to `renderMode: 'static'`).

## Fix
- Extract the image-service shim from `middleware.ts` into a new shared helper `packages/@storybook-astro/framework/src/lib/passthrough-image-service.ts` (`installPassthroughImageService()`).
- Call it from `handlerFactory()` (no behavior change for dev).
- Call it from `prerenderStories()` in `vitePluginAstroBuildPrerender.ts`, just before `AstroContainer.create()`, so the static build path gets the same shim.

## Verification
Locally built `integration/astro6` with `renderMode: 'static'`:

- `yarn workspace @storybook-astro/integration-astro6 build-storybook` now completes successfully.
- `integration/astro6/storybook-static/astro-prerendered-stories.json` is produced with populated HTML for all 38 stories.

Also:
- `yarn lint` — clean.
- `yarn vitest run --root packages/@storybook-astro/framework` — 44 tests passing (including the existing `middleware.test.ts`).

## Relation to PR #75
PR #75 (`fix/storybook-static-render-mode`) switches the integration demos to `renderMode: 'static'`, which is what the Cloudflare preview needs. Without this PR, PR #75's Astro 6 Cloudflare build continues to fail with the image-service error. Once this PR merges to `develop`, PR #75 should be rebased on top and its Astro 6 build should go green.