### PR TITLE
fix: stub astro:toolbar:internal virtual module in Storybook context

### DIFF
--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -7,6 +7,7 @@ import { vitePluginAstroBuildPrerender } from './vitePluginAstroBuildPrerender.t
 import { vitePluginAstroBuildServer } from './vitePluginAstroBuildServer.ts';
 import { vitePluginAstroIntegrationOptsFallback } from './vitePluginAstroIntegrationOptsFallback.ts';
 import { vitePluginAstroVueFallback } from './vitePluginAstroVueFallback.ts';
+import { vitePluginAstroToolbarFallback } from './vitePluginAstroToolbarFallback.ts';
 import { resolveSanitizationOptions } from './lib/sanitization.ts';
 import { mergeWithAstroConfig } from './vitePluginAstro.ts';
 
@@ -52,6 +53,7 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, { conf
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vitePluginAstroComponentMarker() as any,
     vitePluginAstroIntegrationOptsFallback(),
+    vitePluginAstroToolbarFallback(),
     vitePluginAstroVueFallback(),
   );
 
@@ -127,7 +129,8 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, { conf
     'virtual:@astrojs/vue/app',
     'virtual:astro:vue-app',
     'astro:react:opts',
-    'astro:preact:opts'
+    'astro:preact:opts',
+    'astro:toolbar:internal'
   ];
 
   // Vite ≤7 (esbuild-based optimizer)

--- a/packages/@storybook-astro/framework/src/vitePluginAstroToolbarFallback.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroToolbarFallback.ts
@@ -1,0 +1,38 @@
+import type { Plugin } from 'vite';
+
+const TOOLBAR_INTERNAL_STUB = `
+export const loadDevToolbarApps = async () => [];
+`;
+
+/**
+ * Provides a fallback stub for Astro's dev toolbar virtual module.
+ *
+ * Astro's `astro/dist/runtime/client/dev-toolbar/entrypoint.js` imports
+ * from `astro:toolbar:internal`, a virtual module normally provided by
+ * Astro's own `vite-plugin-dev-toolbar` Vite plugin. In the Storybook
+ * context that plugin is not active, causing esbuild to fail during
+ * dependency optimisation when it encounters the unresolvable import.
+ *
+ * Storybook doesn't use Astro's dev toolbar, so a no-op stub is safe.
+ */
+export function vitePluginAstroToolbarFallback(): Plugin {
+  const VIRTUAL_ID = 'astro:toolbar:internal';
+  const RESOLVED_ID = '\0' + VIRTUAL_ID;
+
+  return {
+    name: 'storybook-astro-toolbar-fallback',
+    enforce: 'pre',
+
+    resolveId(id) {
+      if (id === VIRTUAL_ID) {
+        return RESOLVED_ID;
+      }
+    },
+
+    load(id) {
+      if (id === RESOLVED_ID) {
+        return { code: TOOLBAR_INTERNAL_STUB };
+      }
+    }
+  };
+}


### PR DESCRIPTION
Fixes #77.

## Summary

- Adds `vitePluginAstroToolbarFallback` — an `enforce: 'pre'` Vite plugin that stubs the `astro:toolbar:internal` virtual module with a no-op `loadDevToolbarApps` export
- Registers the plugin in `preset.ts` alongside the other fallback plugins
- Adds `astro:toolbar:internal` to the `integrationVirtualModules` external list so esbuild's dep pre-bundler skips it entirely

## Root cause

Astro's `dev-toolbar/entrypoint.js` imports from `astro:toolbar:internal`, a virtual module normally provided by Astro's own `vite-plugin-dev-toolbar`. In the Storybook context that plugin is absent, causing esbuild to fail during dependency optimisation. Since Storybook doesn't use Astro's dev toolbar, a no-op stub is safe.

## Test plan

- [ ] Run `yarn storybook` in a project using pnpm — confirm the `Could not resolve "astro:toolbar:internal"` error is gone
- [ ] Verify stories render correctly (no perpetual spinner)
- [ ] Run `yarn test` — all existing tests pass