### PR TITLE
fix: search dialog dark mode text colors

### DIFF
--- a/apps/website/src/styles/starlight-overrides.css
+++ b/apps/website/src/styles/starlight-overrides.css
@@ -123,7 +123,7 @@ mobile-starlight-toc .caret {
 :root #starlight__search {
   --pagefind-ui-primary: #24292f;
   --pagefind-ui-text: #24292f;
-  --pagefind-ui-background: #ffffff;
   --pagefind-ui-border: #e1e4e8;
+  --pagefind-ui-background: #ffffff;
   --pagefind-ui-tag: #eef0f2;
 }

--- a/apps/website/src/styles/starlight-overrides.css
+++ b/apps/website/src/styles/starlight-overrides.css
@@ -110,3 +110,20 @@ mobile-starlight-toc .caret {
 .sidebar-pane {
   border-color: #e1e4e8;
 }
+
+/* ── Pagefind search dialog: force light-theme colors ── */
+/*
+ * The site always uses a light body. When the OS is in dark mode, Starlight
+ * applies [data-theme="dark"] which makes --sl-color-text and --sl-color-gray-*
+ * light-colored. Pagefind UI inherits those via --pagefind-ui-primary/text, so
+ * result titles (.pagefind-ui__result-link) become unreadable on the white dialog
+ * background. Override with hardcoded light-theme values to stay readable regardless
+ * of OS color scheme.
+ */
+:root #starlight__search {
+  --pagefind-ui-primary: #24292f;
+  --pagefind-ui-text: #24292f;
+  --pagefind-ui-background: #ffffff;
+  --pagefind-ui-border: #e1e4e8;
+  --pagefind-ui-tag: #eef0f2;
+}

--- a/apps/website/src/styles/starlight-overrides.css
+++ b/apps/website/src/styles/starlight-overrides.css
@@ -113,12 +113,11 @@ mobile-starlight-toc .caret {
 
 /* ── Pagefind search dialog: force light-theme colors ── */
 /*
- * The site always uses a light body. When the OS is in dark mode, Starlight
- * applies [data-theme="dark"] which makes --sl-color-text and --sl-color-gray-*
- * light-colored. Pagefind UI inherits those via --pagefind-ui-primary/text, so
- * result titles (.pagefind-ui__result-link) become unreadable on the white dialog
- * background. Override with hardcoded light-theme values to stay readable regardless
- * of OS color scheme.
+ * The search dialog lives inside header.header, whose dark-header rules
+ * (header.header :is(a, button, label) { color: #f0f6fc }) set light text
+ * on every link and button. Because the search drawer has a white/light
+ * background, we must reset those colors to dark so titles, links, and
+ * buttons remain readable.
  */
 :root #starlight__search {
   --pagefind-ui-primary: #24292f;
@@ -126,4 +125,13 @@ mobile-starlight-toc .caret {
   --pagefind-ui-border: #e1e4e8;
   --pagefind-ui-background: #ffffff;
   --pagefind-ui-tag: #eef0f2;
+}
+
+/* Override the header's light-text rule for everything inside the search drawer */
+header.header #starlight__search :is(a, button, label) {
+  color: #24292f;
+}
+
+header.header #starlight__search a:hover {
+  color: #7c3aed;
 }


### PR DESCRIPTION
## Problem
When the OS is in dark mode, search result titles and buttons inside the Pagefind search dialog were unreadable — light text on a white background.

## Root cause
The search dialog renders inside `header.header`. The dark-header rule `header.header :is(a, button, label) { color: #f0f6fc }` was directly setting light text on all links and buttons, including search results. The existing pagefind CSS variable overrides couldn't override that direct `color` property.

## Fix
Added scoped rules targeting `header.header #starlight__search :is(a, button, label)` to reset text back to dark colors on the light dialog background.

Fixes #70