### PR TITLE
feat: support test/preview releases that skip latest dist-tag promotion

### DIFF
--- a/.agents/skills/release-manager/SKILL.md
+++ b/.agents/skills/release-manager/SKILL.md
@@ -26,7 +26,9 @@ Storybook Astro follows [Semantic Versioning](https://semver.org/):
 - **Minor** (`0.x.0`) — New features, backward-compatible
 - **Patch** (`0.0.x`) — Bug fixes, backward-compatible
 
-**Beta format**: `0.x.y-beta.z` (e.g., `0.1.0-beta.14`)
+**Beta format**: `0.x.y-beta.z` (e.g., `0.1.0-beta.14`) — promoted to `latest` automatically
+
+**Test/preview format**: `0.x.y-<label>.z` where `<label>` is one of `next`, `alpha`, `canary`, `rc`, or `test` (e.g., `0.1.0-next.1`, `0.1.0-canary.3`) — published under the matching dist-tag only, never promoted to `latest`
 
 Only packages under `packages/@storybook-astro/*` are versioned:
 - `@storybook-astro/framework`
@@ -194,6 +196,89 @@ If there are conflicts or just to keep branches in sync:
 git checkout develop
 git merge main
 git push origin develop
+```
+
+## Test/Preview Release Workflow
+
+Use this when you want to publish a version for testing or previewing unreleased changes without affecting what `npm install @storybook-astro/framework` gives to end users.
+
+The publish workflow detects the pre-release label in the version string and uses it as the dist-tag. Any label other than `beta` skips the "Promote to latest" step.
+
+| Version format | Dist-tag | Promoted to `latest`? |
+|---|---|---|
+| `0.1.0-beta.14` | `beta` | Yes |
+| `0.1.0-next.1` | `next` | No |
+| `0.1.0-alpha.1` | `alpha` | No |
+| `0.1.0-canary.1` | `canary` | No |
+| `0.1.0-rc.1` | `rc` | No |
+
+**When to use `next`**: Validating that a future `beta` release works before committing to it.
+
+**When to use `canary`**: Publishing work-in-progress builds for early feedback.
+
+**When to use `rc`**: Release candidates that are feature-complete and in final testing.
+
+### Steps
+
+**1. Bump versions to a test/preview identifier**
+
+In both `packages/@storybook-astro/*/package.json`:
+
+```json
+{
+  "version": "0.1.0-next.1"
+}
+```
+
+**2. Update CHANGELOG.md**
+
+Add an entry (same format as a normal release) under a section like `[0.1.0-next.1]`.
+
+**3. Commit and push**
+
+Do **not** add a CHANGELOG.md entry — test/preview releases are transient and the changes will be captured when the real beta ships.
+
+```bash
+git add packages/*/package.json
+git commit -m "chore: release v0.1.0-next.1 (test)"
+git push origin <branch>
+```
+
+**4. Tag on `main` and push**
+
+Same convention as a standard release — tag on `main` only:
+
+```bash
+git checkout main
+git merge --no-ff <branch>
+git tag v0.1.0-next.1
+git push origin main
+git push origin v0.1.0-next.1
+```
+
+**5. Verify it did NOT become latest**
+
+```bash
+npm dist-tag ls @storybook-astro/framework
+# Should show:  next: 0.1.0-next.1
+# Should NOT show:  latest: 0.1.0-next.1
+```
+
+**6. Consumers install via dist-tag**
+
+```bash
+npm install @storybook-astro/framework@next
+# or
+npm install @storybook-astro/framework@canary
+```
+
+### Cleanup After Testing
+
+Once the preview is no longer needed, remove the dist-tag to keep npm tidy:
+
+```bash
+npm dist-tag rm @storybook-astro/framework next
+npm dist-tag rm @storybook-astro/renderer next
 ```
 
 ## Hotfix Workflow
@@ -400,7 +485,7 @@ git push origin v0.1.0-beta.14
 
 ## Checklist
 
-Use this before releasing:
+### Standard release
 
 - [ ] All features/fixes on `develop` branch
 - [ ] Release branch created: `git checkout -b release/X.Y.Z-beta.N`
@@ -419,6 +504,16 @@ Use this before releasing:
 - [ ] Publish workflow completes successfully (includes automated smoke test)
 - [ ] `npm view @storybook-astro/framework versions --json` shows new version
 - [ ] `npm dist-tag ls @storybook-astro/framework` shows `latest` pointing to new version
+
+### Test/preview release
+
+- [ ] Version uses a non-`beta` pre-release label: `next`, `alpha`, `canary`, `rc`, or `test`
+- [ ] Both `packages/@storybook-astro/*/package.json` files updated to same version
+- [ ] Changes committed and pushed to branch (no CHANGELOG.md update)
+- [ ] Branch merged into `main`
+- [ ] Tag created on `main` and pushed: `git tag vX.Y.Z-<label>.N && git push origin vX.Y.Z-<label>.N`
+- [ ] Publish workflow completes successfully
+- [ ] `npm dist-tag ls @storybook-astro/framework` shows `<label>: X.Y.Z-<label>.N` but **not** `latest`
 
 ## References
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,19 +47,35 @@ jobs:
         env:
           STORYBOOK_DISABLE_TELEMETRY: 1
 
+      - name: Detect release channel
+        id: channel
+        run: |
+          VERSION=$(node -p "require('./packages/@storybook-astro/renderer/package.json').version")
+          # Extract pre-release label (e.g. "beta" from "0.1.0-beta.14", "next" from "0.1.0-next.1")
+          PRERELEASE=$(node -e "const v='$VERSION',m=v.match(/-([a-zA-Z]+)[.\d]/);process.stdout.write(m?m[1]:'')")
+          # Promote to latest only for beta and stable releases; test/preview labels (next, alpha, canary, rc, test) stay on their own dist-tag
+          if [ -z "$PRERELEASE" ] || [ "$PRERELEASE" = "beta" ]; then
+            echo "dist_tag=beta" >> "$GITHUB_OUTPUT"
+            echo "promote_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=$PRERELEASE" >> "$GITHUB_OUTPUT"
+            echo "promote_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish renderer
-        run: yarn workspace @storybook-astro/renderer npm publish --tag beta --access public
+        run: yarn workspace @storybook-astro/renderer npm publish --tag ${{ steps.channel.outputs.dist_tag }} --access public
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
 
       - name: Publish framework
-        run: yarn workspace @storybook-astro/framework npm publish --tag beta --access public
+        run: yarn workspace @storybook-astro/framework npm publish --tag ${{ steps.channel.outputs.dist_tag }} --access public
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
 
       - name: Promote to latest
+        if: steps.channel.outputs.promote_latest == 'true'
         run: |
           yarn npm tag add @storybook-astro/renderer@$(node -p "require('./packages/@storybook-astro/renderer/package.json').version") latest
           yarn npm tag add @storybook-astro/framework@$(node -p "require('./packages/@storybook-astro/framework/package.json').version") latest


### PR DESCRIPTION
## Summary

- Adds a `Detect release channel` step to `publish.yml` that reads the pre-release label from the package version (e.g. `next` from `0.1.0-next.1`) and uses it as the npm dist-tag
- The `Promote to latest` step is now conditional — it only runs for `beta` and stable versions, not for `next`, `alpha`, `canary`, `rc`, `test`, etc.
- Documents the full test/preview release workflow in the `release-manager` skill, including version format table, step-by-step instructions, dist-tag cleanup, and a dedicated checklist section

## Test plan

- [ ] Verify a tag like `v0.1.0-beta.14` still publishes to `beta` and promotes to `latest` (existing behavior unchanged)
- [ ] Verify a tag like `v0.1.0-next.1` publishes to the `next` dist-tag and does **not** update `latest`
- [ ] Check `npm dist-tag ls @storybook-astro/framework` after each scenario to confirm correct dist-tag state

🤖 Generated with [Claude Code](https://claude.com/claude-code)