### PR TITLE
fix: add vitePluginAstroComponentMarker to components vitest config

### DIFF
--- a/packages/@storybook-astro/framework/src/vitest/index.ts
+++ b/packages/@storybook-astro/framework/src/vitest/index.ts
@@ -1,2 +1,3 @@
 export { defineConfig, type TestingDefineConfig } from './config.ts';
 export { cjsInteropPlugin, vitestPatchForSolidJs } from './vite-plugins.ts';
+export { vitePluginAstroComponentMarker } from '../vitePluginAstroComponentMarker.ts';

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -25,6 +25,7 @@ const globalSetupPath = resolve(
 const vitestConfig = defineConfig({
   mode: 'test',
   plugins: [
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vitePluginAstroComponentMarker() as any,
     preact({
       include: ['**/preact/**'],

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -9,6 +9,7 @@ import solid from 'vite-plugin-solid';
 import alpinejs from '@astrojs/alpinejs';
 import { alpinejs as alpineIntegration } from '@storybook-astro/framework/integrations';
 import { registerTestingIntegrationsForRoot } from '@storybook-astro/framework/testing/integration-config';
+import { vitePluginAstroComponentMarker } from '@storybook-astro/framework/vitest';
 
 const root = import.meta.dirname;
 
@@ -24,6 +25,7 @@ const globalSetupPath = resolve(
 const vitestConfig = defineConfig({
   mode: 'test',
   plugins: [
+    vitePluginAstroComponentMarker() as any,
     preact({
       include: ['**/preact/**'],
       reactAliasesEnabled: false,


### PR DESCRIPTION
## Summary

- The `components` package vitest config was missing `vitePluginAstroComponentMarker`, causing Alpine component tests to fail
- Astro 6 no longer sets `isAstroComponentFactory` on the client-side `.astro` stub; the marker plugin patches this for the test environment
- Without the plugin, the portable stories `render` function couldn't identify Alpine `.astro` components as Astro components, throwing "Component appears to be a framework component but no renderer is specified"
- Also exports `vitePluginAstroComponentMarker` from `@storybook-astro/framework/vitest` for use in custom vitest configs like this one

## Test plan

- [x] `yarn vitest run --project=components` — all 12 tests pass including Alpine Accordion and Counter
- [ ] Confirm CI `build-and-test` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)