### PR TITLE
fix(framework): exclude fsevents and preview-api from optimizeDeps

### DIFF
--- a/apps/website/src/content/docs/guides/troubleshooting.md
+++ b/apps/website/src/content/docs/guides/troubleshooting.md
@@ -89,6 +89,55 @@ The framework now requires `vite@^6.4.1 || ^7.0.0 || ^8.0.0` for compatibility w
 
 ---
 
+### `No loader is configured for ".node" files` (fsevents)
+
+**Error message:**
+```
+Error: Error during dependency optimization:
+✘ [ERROR] No loader is configured for ".node" files:
+    node_modules/.../fsevents/fsevents.node
+```
+
+**Cause:**
+
+Vite's esbuild dependency prebundler scans installed packages and tries to bundle `fsevents`, a macOS-only native module used by Vite's HMR file watcher. esbuild has no loader for the `.node` binary it ships with, so the scan fails. The error is most commonly seen on macOS with pnpm because pnpm's directory layout makes `fsevents` visible to the scan path.
+
+**Solution:**
+
+Recent framework versions exclude `fsevents` from `optimizeDeps` automatically. If you're pinned to an older release, add it yourself in your `.storybook/main.ts`:
+
+```ts
+const config: StorybookConfig = {
+  // ...
+  viteFinal: async (config) => {
+    const { mergeConfig } = await import('vite');
+    return mergeConfig(config, {
+      optimizeDeps: { exclude: ['fsevents'] },
+    });
+  },
+};
+```
+
+---
+
+### `SyntaxError: redeclaration of import __vite__injectQuery` (portable stories)
+
+**Error message (browser console):**
+```
+Uncaught SyntaxError: redeclaration of import __vite__injectQuery
+    chunk-XXXXXXXX.js
+```
+
+**Cause:**
+
+When a story uses the CSF Next `preview.meta({...})` portable-stories shape, `storybook/internal/preview-api` can be processed by Vite's transform pipeline twice — once during dependency prebundling and again as a regular module. Each pass injects its own `__vite__injectQuery` helper import, producing a duplicate declaration in the generated chunk.
+
+**Solution:**
+
+Recent framework versions exclude `storybook/internal/preview-api` from `optimizeDeps` so it's only resolved once. If you're pinned to an older release, mirror the workaround from the fsevents entry above and add `'storybook/internal/preview-api'` to the same `optimizeDeps.exclude` list.
+
+---
+
 ### "Astro components cannot be used in the browser"
 
 **Error message:**

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -84,6 +84,55 @@ The framework now requires `vite@^6.4.1 || ^7.0.0 || ^8.0.0` to ensure compatibi
 
 ## Runtime Issues
 
+### `No loader is configured for ".node" files` (fsevents)
+
+**Error:**
+```
+Error: Error during dependency optimization:
+✘ [ERROR] No loader is configured for ".node" files:
+    node_modules/.../fsevents/fsevents.node
+```
+
+**Cause:**
+
+Vite's esbuild dependency prebundler scans installed packages and tries to bundle `fsevents`, a macOS-only native module used by Vite's HMR file watcher. esbuild has no loader for the `.node` binary it ships with, so the scan fails. The error is most commonly seen on macOS with pnpm because pnpm's directory layout makes `fsevents` visible to the scan path.
+
+**Solution:**
+
+Recent framework versions exclude `fsevents` from `optimizeDeps` automatically. If you're pinned to an older release, add it yourself in `.storybook/main.ts`:
+
+```ts
+const config: StorybookConfig = {
+  // ...
+  viteFinal: async (config) => {
+    const { mergeConfig } = await import('vite');
+    return mergeConfig(config, {
+      optimizeDeps: { exclude: ['fsevents'] },
+    });
+  },
+};
+```
+
+---
+
+### `SyntaxError: redeclaration of import __vite__injectQuery` (portable stories)
+
+**Error (browser console):**
+```
+Uncaught SyntaxError: redeclaration of import __vite__injectQuery
+    chunk-XXXXXXXX.js
+```
+
+**Cause:**
+
+When a story uses the CSF Next `preview.meta({...})` portable-stories shape, `storybook/internal/preview-api` can be processed by Vite's transform pipeline twice — once during dependency prebundling and again as a regular module. Each pass injects its own `__vite__injectQuery` helper import, producing a duplicate declaration in the generated chunk.
+
+**Solution:**
+
+Recent framework versions exclude `storybook/internal/preview-api` from `optimizeDeps` so it's only resolved once. If you're pinned to an older release, mirror the fsevents workaround above and add `'storybook/internal/preview-api'` to the same `optimizeDeps.exclude` list.
+
+---
+
 ### Storybook won't start / "Astro components cannot be used in the browser"
 
 **Error:**

--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -142,6 +142,16 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
   if (!finalConfig.optimizeDeps.exclude.includes('@storybook-astro/renderer')) {
     finalConfig.optimizeDeps.exclude.push('@storybook-astro/renderer');
   }
+  // fsevents is a macOS-only native chokidar dep with a .node binary that
+  // esbuild's prebundler can't load. storybook/internal/preview-api can pass
+  // through the transform pipeline twice when used by CSF Next portable
+  // stories, producing a duplicate __vite__injectQuery import in the
+  // generated chunk; excluding it from prebundling collapses the duplicate.
+  for (const pkg of ['fsevents', 'storybook/internal/preview-api']) {
+    if (!finalConfig.optimizeDeps.exclude.includes(pkg)) {
+      finalConfig.optimizeDeps.exclude.push(pkg);
+    }
+  }
   // Mark integration virtual modules as external so the dep bundler doesn't
   // try to resolve them (they are Vite virtual modules with no real package).
   // Set both esbuildOptions (Vite ≤7) and rolldownOptions (Vite 8+, Rolldown)


### PR DESCRIPTION
## Summary

- `fsevents`: a macOS-only native chokidar dep that Vite's esbuild prebundler tries to bundle but cannot, because esbuild has no loader for the `.node` binary it ships with. Surfaces as `No loader is configured for ".node" files` during dependency optimization, most commonly on macOS + pnpm where the file is exposed to the prebundler scan path.
- `storybook/internal/preview-api`: with CSF Next portable stories (`preview.meta({...})`), the preview API was being processed by Vite's transform pipeline twice — once during prebundling and again as a regular module — producing a duplicate `__vite__injectQuery` import in the generated chunk and a browser-side `SyntaxError: redeclaration of import __vite__injectQuery`. Excluding it from prebundling collapses the duplicate.

Both entries are appended to the existing `optimizeDeps.exclude` list in `preset.ts`. The troubleshooting guide gains entries describing each symptom and the manual workaround for anyone pinned to an older release.

## Test plan

- [x] `yarn build:packages` succeeds for framework + renderer.
- [x] `yarn test` — all astro5 and astro6 integration suites green (18 tests).
- [x] `yarn smoke` — fresh-install scenario passes on Astro 5 and Astro 6.
- [x] Storybook dev server starts cleanly with no `.node` loader error.
- [x] No duplicate `__vite__injectQuery` imports in any generated `.vite/deps/chunk-*.js`.

Closes #59