### PR TITLE
fix(framework): Astro 6 static prerender escaping slot HTML

### DIFF
--- a/packages/@storybook-astro/framework/src/storySsrVite.ts
+++ b/packages/@storybook-astro/framework/src/storySsrVite.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 import { createServer, mergeConfig, type Plugin, type ViteDevServer } from 'vite';
-import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import { ensureAstroPassthroughImageService } from './astroImageService.ts';
 import { importAstroConfig } from './importAstroConfig.ts';
 import type { Integration } from './integrations/index.ts';
@@ -110,7 +110,19 @@ export async function createProductionAstroContainer(options: {
 }) {
   ensureAstroPassthroughImageService();
 
-  const container = await AstroContainer.create({
+  // Astro 6's container wraps each slot value in a SlotString, and the
+  // rendering pipeline detects raw-HTML slot chunks via `instanceof SlotString`.
+  // If the container is loaded by Node's ESM resolver while components are
+  // loaded through Vite's SSR graph, the two paths produce different
+  // SlotString classes and the instanceof check fails — slot content then
+  // takes the escaping code path. Loading the container via the same Vite
+  // SSR server keeps the class identity consistent.
+  const containerModule = (await options.viteServer.ssrLoadModule('astro/container')) as {
+    experimental_AstroContainer: typeof AstroContainer;
+  };
+  const ViteAstroContainer = containerModule.experimental_AstroContainer;
+
+  const container = await ViteAstroContainer.create({
     resolve: async (specifier) => {
       const mockedModule = resolveStoryModuleMock(specifier);
 


### PR DESCRIPTION
## Summary

Fixes a regression in the Astro 6 static prerender path where slot content rendered as escaped HTML text (e.g. literal \`<h2>Welcome</h2>\` characters) instead of parsed DOM elements. The bug surfaced on the ImageText component but affected any Astro 6 component that received slot content from a story's \`args.slots\`.

## Root cause

Astro 6's container wraps each slot value in a \`SlotString\` instance (\`astro/dist/container/index.js\` ➜ \`markAllSlotsAsSlotString\`). The rendering pipeline then detects raw-HTML slot chunks via \`instanceof SlotString\` in \`renderSlotToString\` (\`astro/dist/runtime/server/render/slot.js\`).

The framework was importing \`astro/container\` statically at the top of \`storySsrVite.ts\` — Node's ESM resolver — while component code was being loaded through Vite's SSR graph (with \`ssr.noExternal: /^astro(\/.+)?\$/\` to keep Astro modules bundled). The two paths resolved \`astro/runtime/server/render/slot.js\` separately and produced two different \`SlotString\` classes. When the component's renderer asked \"is this chunk \`instanceof SlotString\`?\", the answer was \`false\` because it was comparing against a different class. The chunk then took the escaping branch.

Astro 5 happened to render correctly without this, likely a coincidence of its runtime layout. The dev server path (\`middleware.ts\`) was always fine because the container and components there share a single Storybook Vite instance.

## Fix

Load \`astro/container\` through the same \`viteServer.ssrLoadModule()\` pipeline used to load component code. With both sides going through Vite's SSR graph (and \`noExternal\` keeping \`astro/*\` bundled), there is one \`SlotString\` class and the \`instanceof\` check succeeds.

Single-file change in \`packages/@storybook-astro/framework/src/storySsrVite.ts\` with an inline comment explaining the class-identity constraint so this doesn't get refactored away.

## Test plan

- [x] \`yarn test\` passes
- [x] \`yarn lint\` passes
- [x] Astro 6 \`yarn workspace @storybook-astro/integration-astro6 build --test\` produces a static build whose ImageText \`Default\` story renders \`<h2>\` and \`<p>\` as DOM elements (verified via Playwright probe)
- [x] Astro 5 \`yarn workspace @storybook-astro/integration-astro5 build --test\` still renders ImageText correctly (no regression)
- [ ] Cloudflare preview deployments for this PR — confirm ImageText displays text content properly on both Astro 5 and Astro 6 previews
- [ ] PR #88's \`tests/imagetext.spec.ts\` slot-HTML assertion goes green when this lands on develop and #88 picks it up

## Related

- Surfaces the regression originally fixed in PR #86 and pinned by PR #88's regression tests.