### PR TITLE
fix: skip non-default-export files in the hydratable-component scan

### DIFF
--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
@@ -116,10 +116,31 @@ export async function collectHydratedComponentPaths(astroFilePath: string) {
       continue;
     }
 
+    // The component loader emits `export { default } from '<file>'` for each
+    // hydratable path, so a file without a default export would crash the
+    // build with `"default" is not exported`. Astro islands are default
+    // exports by convention, so skip files that have no default export.
+    if (!(await hasDefaultExport(resolvedImportPath))) {
+      continue;
+    }
+
     hydratedComponentPaths.push(resolvedImportPath);
   }
 
   return hydratedComponentPaths;
+}
+
+/** Reports whether a source file declares a default export (islands are default exports). */
+async function hasDefaultExport(absPath: string) {
+  try {
+    const source = await readFile(absPath, 'utf-8');
+
+    return /export\s+default\b/.test(source) || /export\s*\{[^}]*\bdefault\b/.test(source);
+  } catch {
+    // On read error keep the file to preserve prior behaviour rather than
+    // silently dropping a component that might be hydratable.
+    return true;
+  }
 }
 
 /** Collects framework client runtimes that must stay addressable after the preview is built. */


### PR DESCRIPTION
## Problem

`storybook build` crashes during the Rollup pass when a scanned root (e.g. `src/components`) contains a **hydratable file with no default export** — a component written `export const Foo = …`, a React context, a named-only helper, etc.:

```
"default" is not exported by "src/components/Foo.tsx", imported by
"virtual:astro-component-module/.../Foo.tsx"
```

`storybook dev` is unaffected (it wraps components lazily, on demand). Named exports for components are a common, valid convention, so a single named-only file — often unrelated to any story — breaks the whole catalog build.

**Repro:** add `export const Foo = () => <div/>;` (no default export) at `src/components/Foo.tsx`, add any unrelated story, run `storybook build`.

## Cause

`collectHydratedComponentPaths` (`vitePluginAstroBuildShared.ts`) collects every file passing `isHydratableSourceFile`, and the component loader emits `export { default } from '<file>'` per path. A file without a default export then crashes the Rollup build.

## Fix

Astro islands are default-export by convention, so **skip scanned files that have no default export** instead of emitting a crashing `export { default }`. Default-export islands are unaffected (they pre-bundle exactly as before); named-only helpers/contexts simply aren't pre-bundled — they can't be default-import islands anyway. On read error the file is kept, preserving prior behaviour.

## Testing

- `yarn build:packages`, the framework `vitest` project (48/48), and `lint` all pass.
- Confirms the crash is gone: a named-only `export const Foo` under the scan root no longer breaks `storybook build`.

Happy to add a dedicated regression-test fixture matching your test conventions if you'd like.

---

_Context: verified in a real Astro 5 + Storybook 10 project (whose component convention is named exports) before porting here against `develop`._
