### PR TITLE
fix: resolve tsconfig path aliases for embedded islands

### DIFF
--- a/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.ts
+++ b/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.ts
@@ -1,0 +1,118 @@
+import { readFileSync, statSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+// Islands embedded in `.astro` components are frequently imported through a
+// tsconfig path alias (for example `@/components/Counter`). The raw aliased
+// specifier is baked into `<astro-island component-url>` and `import()`d
+// verbatim, so it must be turned into an on-disk path before it can hydrate.
+// This helper resolves `compilerOptions.paths` aliases (with a `@/` -> `src/`
+// fallback) to an absolute file path, and is used as a last resort after the
+// existing resolution has already had its chance.
+
+const ALIAS_EXTS = ['.tsx', '.ts', '.jsx', '.js', '.vue', '.svelte', '.mts', '.mjs'];
+
+type AliasEntry = { prefix: string; target: string };
+
+const aliasCacheByRoot = new Map<string, AliasEntry[]>();
+
+/** Reads `<root>/tsconfig.json` path aliases, falling back to `@/` -> `src/`. */
+function readAliases(root: string): AliasEntry[] {
+  const cached = aliasCacheByRoot.get(root);
+
+  if (cached) {
+    return cached;
+  }
+
+  const entries: AliasEntry[] = [];
+
+  try {
+    const raw = readFileSync(resolve(root, 'tsconfig.json'), 'utf-8');
+    // tsconfig allows comments/trailing commas; strip the common cases so a
+    // plain JSON.parse can read the `compilerOptions.paths` map.
+    const cleaned = raw
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1')
+      .replace(/,(\s*[}\]])/g, '$1');
+    const parsed = JSON.parse(cleaned) as {
+      compilerOptions?: { paths?: Record<string, string[]> };
+    };
+    const paths = parsed.compilerOptions?.paths ?? {};
+
+    for (const [pattern, targets] of Object.entries(paths)) {
+      const target = targets?.[0];
+
+      if (!target) {
+        continue;
+      }
+
+      // Normalise both sides of the `"@/*": ["src/*"]` convention to a plain
+      // directory prefix so a startsWith check can match real specifiers.
+      entries.push({
+        prefix: pattern.replace(/\*$/, ''),
+        target: target.replace(/\*$/, '')
+      });
+    }
+  } catch {
+    // No (readable) tsconfig: fall through to the conventional default below.
+  }
+
+  if (!entries.some((entry) => entry.prefix === '@/')) {
+    entries.push({ prefix: '@/', target: 'src/' });
+  }
+
+  aliasCacheByRoot.set(root, entries);
+
+  return entries;
+}
+
+function isFile(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves a tsconfig-aliased island specifier (e.g. `@/components/Counter`) to
+ * an absolute on-disk file path, or `undefined` when it is not an alias or no
+ * file exists. Already-resolvable specifiers are skipped so this only runs as a
+ * genuine last resort.
+ */
+export function resolveAliasedIsland(specifier: string, root: string): string | undefined {
+  // Skip specifiers the existing resolution can already handle: relative,
+  // absolute, virtual, framework-internal and dev-server URLs.
+  if (
+    !specifier ||
+    specifier.startsWith('./') ||
+    specifier.startsWith('../') ||
+    specifier.startsWith('/') ||
+    isAbsolute(specifier) ||
+    specifier.startsWith('\0') ||
+    specifier.startsWith('virtual:') ||
+    specifier.startsWith('astro:') ||
+    specifier.startsWith('@astrojs/') ||
+    specifier.startsWith('@id/') ||
+    specifier.startsWith('/@fs/')
+  ) {
+    return undefined;
+  }
+
+  for (const { prefix, target } of readAliases(root)) {
+    if (!specifier.startsWith(prefix)) {
+      continue;
+    }
+
+    const rest = specifier.slice(prefix.length);
+    const base = resolve(root, target, rest);
+    const candidates = [base, ...ALIAS_EXTS.map((ext) => `${base}${ext}`)];
+
+    for (const candidate of candidates) {
+      if (isFile(candidate)) {
+        return candidate.replace(/\\/g, '/');
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/packages/@storybook-astro/framework/src/middleware.ts
+++ b/packages/@storybook-astro/framework/src/middleware.ts
@@ -7,6 +7,7 @@ import { createAstroRenderHandler, type HandlerProps } from './astroRenderHandle
 import type { Integration } from './integrations/index.ts';
 import type { SanitizationOptions } from './lib/sanitization.ts';
 import { resolveStoryModuleMock } from './module-mocks.ts';
+import { resolveAliasedIsland } from './lib/resolve-aliased-island.ts';
 import { addRenderers, resolveClientModules } from 'virtual:astro-container-renderers';
 
 type ResolveRulesConfigModule = () => unknown | Promise<unknown>;
@@ -50,6 +51,16 @@ export async function handlerFactory(
 
       if (resolution) {
         return resolution;
+      }
+
+      // Last resort: an island imported via a tsconfig path alias (e.g. `@/...`)
+      // has its raw aliased specifier baked into the island's component-url.
+      // Resolve it to an on-disk file and hand back a `/@fs/` URL the dev Vite
+      // server can serve so the island still hydrates.
+      const aliasedIsland = resolveAliasedIsland(specifier, process.cwd());
+
+      if (aliasedIsland) {
+        return `/@fs/${aliasedIsland}`;
       }
 
       return specifier;

--- a/packages/@storybook-astro/framework/src/storySsrVite.ts
+++ b/packages/@storybook-astro/framework/src/storySsrVite.ts
@@ -4,6 +4,7 @@ import type { experimental_AstroContainer as AstroContainer } from 'astro/contai
 import { ensureAstroPassthroughImageService } from './astroImageService.ts';
 import { importAstroConfig } from './importAstroConfig.ts';
 import type { Integration } from './integrations/index.ts';
+import { resolveAliasedIsland } from './lib/resolve-aliased-island.ts';
 import { ssrLoadModuleWithFsFallback } from './lib/ssr-load-module-with-fs-fallback.ts';
 import { resolveStoryModuleMock } from './module-mocks.ts';
 import { vitePluginAstroFontsFallback } from './vitePluginAstroFontsFallback.ts';
@@ -91,6 +92,15 @@ export function createClientModuleResolver(
 
     if (Object.hasOwn(staticModuleMap, normalizedSpecifier)) {
       return staticModuleMap[normalizedSpecifier];
+    }
+
+    // Last resort: an island imported via a tsconfig path alias (e.g. `@/...`)
+    // never matches the static map under its raw specifier. Resolve the alias
+    // to an on-disk path and look that up in the built module map instead.
+    const abs = resolveAliasedIsland(specifier, process.cwd());
+
+    if (abs && Object.hasOwn(staticModuleMap, abs)) {
+      return staticModuleMap[abs];
     }
 
     for (const integration of integrations) {


### PR DESCRIPTION
## Problem

An Astro island embedded inside an `.astro` component fails to hydrate when the island is imported via a **tsconfig `paths` alias** (e.g. `import Counter from '@/components/Counter'` used as `<Counter client:visible />`). The `.astro` renders, but the island never hydrates:

```
[astro-island] Error hydrating @/components/Counter
  TypeError: Failed to resolve module specifier '@/components/Counter'
```

Affects both `storybook dev` and `storybook build`. Adding the alias to Storybook's `viteFinal` or to `astro.config.mjs` `vite.resolve.alias` does **not** help — the specifier is baked into `<astro-island component-url>` as a runtime string and `import()`d verbatim, so no Vite resolver touches it.

## Cause

Astro core sets `component-url` via the container's `resolve(componentUrl)` callback, where `componentUrl` is the literal source import specifier (the aliased `@/...`). Both resolve callbacks fall through to returning the raw specifier when they can't resolve it:

- **dev** — `middleware.ts`'s `AstroContainer.create({ resolve })` returns the raw `specifier`;
- **static** — `createClientModuleResolver` (`storySsrVite.ts`) misses the `staticModuleMap` (keyed by absolute paths) and falls through to the integration loop.

## Fix

Add `lib/resolve-aliased-island.ts`, which resolves `compilerOptions.paths` aliases (comment/trailing-comma tolerant; `@/` → `src/` fallback) to an on-disk absolute path, guarding out already-resolvable specifiers so it only runs as a **last resort**. Use it in both callbacks:

- **dev**: return `/@fs/<abs>` (a URL the preview Vite server serves);
- **static**: look the resolved absolute path up in the existing `staticModuleMap`.

Consumers point `componentRoots` at the dirs where their islands live (existing option) so the static build emits those chunks.

## Testing

- `yarn build:packages`, the framework `vitest` project (48/48), and `lint` all pass.
- Verified end-to-end in a real project: dev islands hydrate (served as `/@fs/…`), and the static build bakes resolved chunk URLs (no raw `@/…` in `component-url`).
- The helper was exercised directly (alias resolution incl. a custom `~/`-style alias, missing-file → `undefined`, all guard cases, and the no-paths fallback).

Happy to add the helper's unit test to the suite matching your conventions.

---

_Note: uses `process.cwd()` as the project root (Storybook is invoked from the project root). A `resolveFrom`-threaded version would be more robust if you prefer._
