### PR TITLE
fix: resolve yarn dev startup errors and warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# nx cache
+.nx/
+
 # build and test output
 dist/
 coverage/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=20.16.0 || >=22.19.0 || >=24.0.0"
   },
   "scripts": {
-    "dev": "yarn workspaces foreach -A --parallel --interlaced run dev",
+    "dev": "yarn build:packages && yarn workspaces foreach -A --parallel --interlaced run dev",
     "dev:packages": "yarn workspaces foreach -A --parallel --interlaced --include '@storybook-astro/{framework,renderer}' run dev",
     "website": "yarn workspace @storybook-astro/website dev",
     "build": "yarn build:packages && yarn workspaces foreach -A --topological --interlaced --exclude '@storybook-astro/{framework,renderer}' run build",

--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch",
+    "dev": "tsup --watch --no-clean",
     "lint": "eslint .",
     "prepublishOnly": "tsup"
   },

--- a/packages/@storybook-astro/framework/src/importAstroConfig.ts
+++ b/packages/@storybook-astro/framework/src/importAstroConfig.ts
@@ -7,5 +7,5 @@ export async function importAstroConfig(resolveFrom: string) {
     paths: [resolveFrom]
   });
 
-  return import(pathToFileURL(astroConfigEntrypoint).href);
+  return import(/* @vite-ignore */ pathToFileURL(astroConfigEntrypoint).href);
 }

--- a/packages/@storybook-astro/renderer/package.json
+++ b/packages/@storybook-astro/renderer/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch",
+    "dev": "tsup --watch --no-clean",
     "lint": "eslint .",
     "prepublishOnly": "tsup"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3760,9 +3760,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@storybook-astro/integration-astro6-server-vercel@workspace:integration/astro6-server-vercel":
+"@storybook-astro/integration-astro6-server@workspace:integration/astro6-server":
   version: 0.0.0-use.local
-  resolution: "@storybook-astro/integration-astro6-server-vercel@workspace:integration/astro6-server-vercel"
+  resolution: "@storybook-astro/integration-astro6-server@workspace:integration/astro6-server"
   dependencies:
     "@astrojs/preact": "npm:5.0.0"
     "@hono/node-server": "npm:^1.19.6"


### PR DESCRIPTION
## Summary

- **Yarn workspace not found**: Running `yarn install` after the `astro6-server-vercel` → `astro6-server` rename registered the new workspace; `yarn.lock` updated accordingly
- **Race condition in `yarn dev`**: The root `dev` script ran all workspaces in parallel, so tsup's `clean: true` would wipe `dist/` at the exact moment Storybook integrations tried to import from it, causing `ERR_MODULE_NOT_FOUND`. Fixed by pre-building packages first (`build:packages &&`) then starting all watchers with `--no-clean`
- **Vite dynamic import warning**: Added `/* @vite-ignore */` to the intentionally-dynamic import in `importAstroConfig.ts` — the path is runtime-computed via `require.resolve` and can't be statically analyzed, which is expected behavior
- **`.nx/` not gitignored**: Added `.nx/` to `.gitignore` to suppress Nx cache files from appearing as untracked

## Test plan

- [ ] Run `yarn dev` and confirm `integration-astro6-server` starts without the "Package not found" Yarn error
- [ ] Run `yarn dev` and confirm `integration-astro6` starts without `ERR_MODULE_NOT_FOUND` for `dist/integrations/index.js`
- [ ] Confirm the Vite dynamic import warning no longer appears in any integration's output
- [ ] Confirm `git status` is clean after starting dev (no `.nx/` files showing as untracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)