### PR TITLE
fix(renderer): clear canvas when switching between framework renderers

### DIFF
--- a/packages/@storybook-astro/renderer/src/render.tsx
+++ b/packages/@storybook-astro/renderer/src/render.tsx
@@ -85,6 +85,10 @@ function cloneElementWithArgs(element: HTMLElement, args: Record<string, unknown
   return output;
 }
 
+// Tracks the renderer used in the previous renderToCanvas call so we can detect
+// framework switches and clear the canvas before the new framework mounts.
+let activeRenderer: string | undefined;
+
 export async function renderToCanvas(
   ctx: RenderContext<AstroRenderer>,
   canvasElement: HTMLElement
@@ -92,6 +96,13 @@ export async function renderToCanvas(
   const { storyFn, kind, name, showMain, showError, forceRemount, storyContext } = ctx;
   const renderer = ctx.storyContext.parameters?.renderer as string | undefined;
   const typedRenderers = renderers as RendererRegistry;
+
+  // When the framework changes, clear the canvas so the previous framework's DOM
+  // doesn't stack alongside the new one. Same-framework rerenders are unaffected.
+  if (renderer !== activeRenderer) {
+    canvasElement.innerHTML = '';
+  }
+  activeRenderer = renderer;
 
   if (renderer && Object.hasOwn(typedRenderers, renderer)) {
     showMain();


### PR DESCRIPTION
## Summary

- When navigating between stories that use different framework renderers (e.g. React → Svelte → Preact → Solid), the previous framework's DOM was not cleared before the new one mounted, causing components to stack in the canvas.
- React and Vue handle this internally (they detect and tear down existing roots on remount); Svelte, Preact, and Solid do not, so they accumulated.
- Fix: track the active renderer name in module scope and clear `canvasElement.innerHTML` whenever it changes. Same-framework rerenders are unaffected.

## Test plan

- [ ] Navigate React Accordion → Vue Accordion → Svelte Accordion → Preact Accordion → Solid Accordion — each should render a single, clean component
- [ ] Navigate back from Svelte → React/Vue — should still render correctly
- [ ] Refresh on any framework story — should render correctly
- [ ] Re-render the same story (args change via controls) — no regression, canvas should not flicker or clear unnecessarily

🤖 Generated with [Claude Code](https://claude.com/claude-code)