### PR TITLE
fix: skip named-export-only .jsx/.tsx files in hydratable component scan

### DIFF
--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.test.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.test.ts
@@ -1,0 +1,87 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { collectHydratedComponentPaths } from './vitePluginAstroBuildShared.ts';
+
+describe('collectHydratedComponentPaths', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'storybook-astro-build-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('excludes a .tsx file that has only named exports', async () => {
+    const astroFile = join(tmpDir, 'Island.astro');
+    const namedOnlyTsx = join(tmpDir, 'Helper.tsx');
+
+    await writeFile(astroFile, `---\nimport Helper from './Helper.tsx';\n---`);
+    await writeFile(namedOnlyTsx, `export const Helper = () => <div />;`);
+
+    const result = await collectHydratedComponentPaths(astroFile);
+
+    expect(result).not.toContain(namedOnlyTsx.replace(/\\/g, '/'));
+  });
+
+  test('includes a .tsx file that has a default export', async () => {
+    const astroFile = join(tmpDir, 'Island.astro');
+    const defaultTsx = join(tmpDir, 'Button.tsx');
+
+    await writeFile(astroFile, `---\nimport Button from './Button.tsx';\n---`);
+    await writeFile(defaultTsx, `export default function Button() { return <div />; }`);
+
+    const result = await collectHydratedComponentPaths(astroFile);
+
+    expect(result).toContain(defaultTsx.replace(/\\/g, '/'));
+  });
+
+  test('includes a .svelte file even though it has no literal export default in source', async () => {
+    // Svelte SFCs have no `export default` — the compiler generates one.
+    // If the check were applied to .svelte, these files would be falsely excluded.
+    const astroFile = join(tmpDir, 'Island.astro');
+    const svelteFile = join(tmpDir, 'Counter.svelte');
+
+    await writeFile(astroFile, `---\nimport Counter from './Counter.svelte';\n---`);
+    await writeFile(svelteFile, `<script>\n  let count = 0;\n</script>\n<button>{count}</button>`);
+
+    const result = await collectHydratedComponentPaths(astroFile);
+
+    expect(result).toContain(svelteFile.replace(/\\/g, '/'));
+  });
+
+  test('includes a .vue <script setup> file even though it has no literal export default in source', async () => {
+    // Vue <script setup> components have no `export default` — the compiler generates one.
+    const astroFile = join(tmpDir, 'Island.astro');
+    const vueFile = join(tmpDir, 'Counter.vue');
+
+    await writeFile(astroFile, `---\nimport Counter from './Counter.vue';\n---`);
+    await writeFile(
+      vueFile,
+      `<script setup>\nconst count = ref(0);\n</script>\n<template><button>{{ count }}</button></template>`
+    );
+
+    const result = await collectHydratedComponentPaths(astroFile);
+
+    expect(result).toContain(vueFile.replace(/\\/g, '/'));
+  });
+
+  test('includes a .tsx file on read error, preserving prior behaviour', async () => {
+    // When the file cannot be read, hasDefaultExport returns true so the file
+    // is kept rather than silently dropped.
+    const astroFile = join(tmpDir, 'Island.astro');
+    const missingTsx = join(tmpDir, 'Missing.tsx');
+
+    // Point the Astro file at a component path that won't exist on disk.
+    await writeFile(astroFile, `---\nimport Missing from './Missing.tsx';\n---`);
+
+    // Don't write missingTsx — resolveLocalImportPath will not find it,
+    // so it never reaches hasDefaultExport. Confirm the result is just empty.
+    const result = await collectHydratedComponentPaths(astroFile);
+
+    expect(result).not.toContain(missingTsx.replace(/\\/g, '/'));
+  });
+});

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
@@ -116,6 +116,16 @@ export async function collectHydratedComponentPaths(astroFilePath: string) {
       continue;
     }
 
+    // Only .jsx/.tsx files go through toComponentVirtualId, which emits
+    // `export { default } from '<file>'`. A file with no default export
+    // crashes Rollup with '"default" is not exported'. Svelte/Vue SFCs are
+    // passed directly to their compilers, which generate the default export —
+    // checking their source for a literal `export default` would falsely
+    // exclude them.
+    if (/\.(jsx|tsx)$/.test(resolvedImportPath) && !(await hasDefaultExport(resolvedImportPath))) {
+      continue;
+    }
+
     hydratedComponentPaths.push(resolvedImportPath);
   }
 
@@ -263,6 +273,24 @@ export async function copyRuntimeSnapshot(options: {
 
   for (const runtimeInputFile of runtimeInputFiles) {
     await copyLocalRuntimeDependencies(runtimeInputFile, options, copiedFiles);
+  }
+}
+
+/** Reports whether a JS/TS source file has a default export.
+ * Only call for .jsx/.tsx — Svelte and Vue SFCs have no literal `export default`
+ * in source, but their compilers generate one. On read error the file is kept,
+ * preserving prior behaviour rather than silently dropping a component.
+ *
+ * The regex scan is intentionally conservative: it can match inside comments
+ * or string literals, which produces a false-positive (file kept, Rollup crashes
+ * as before) rather than a false-negative (file silently dropped). */
+async function hasDefaultExport(absPath: string) {
+  try {
+    const source = await readFile(absPath, 'utf-8');
+
+    return /export\s+default\b/.test(source) || /export\s*\{[^}]*\bdefault\b/.test(source);
+  } catch {
+    return true;
   }
 }
 


### PR DESCRIPTION
## Problem

`storybook build` crashes during the Rollup pass when a scanned directory contains a `.jsx` or `.tsx` file with no default export — a named-only helper, context, or component written `export const Foo = …`:

```
"default" is not exported by "src/components/Foo.tsx", imported by
"virtual:astro-component-module/.../Foo.tsx"
```

`storybook dev` is unaffected. Named exports for components are a common convention, so a single named-only file — often unrelated to any story — breaks the whole catalog build.

## Cause

`collectHydratedComponentPaths` feeds resolved imports into `toComponentChunkId`, which for `.jsx`/`.tsx` files wraps them in `toComponentVirtualId`. That virtual module emits `export { default } from '<file>'`, so a file without a default export crashes Rollup.

## Fix

Skip `.jsx`/`.tsx` files that have no default export before they reach the virtual module wrapper. The scope is intentionally limited to those two extensions:

- `.svelte` and `.vue` files are routed directly through their SFC compilers by `toComponentChunkId` — they never go through `toComponentVirtualId` and cannot produce this crash.
- Both SFC formats commonly have no literal `export default` in source (Vue `<script setup>`, Svelte components) — their compilers generate it. Applying the check to them would silently drop real islands from the build.

The regex scan is conservative: it can false-positive on `export default` inside a comment or string, which keeps the file in the build and reverts to the prior Rollup crash rather than silently dropping a valid component.

## Testing

Regression tests added to `vitePluginAstroBuildShared.test.ts` covering:

- Named-only `.tsx` under the scan root → excluded (crash scenario fixed)
- Default-export `.tsx` → included (happy path unaffected)
- Svelte SFC with no literal `export default` → included (not falsely dropped)
- Vue `<script setup>` with no literal `export default` → included (not falsely dropped)
- Unresolvable path → excluded cleanly (existing behaviour)

All 53 framework tests pass.

---

Supersedes #90.