### PR TITLE
fix: revive Date objects lost during JSON serialization of story args

### DIFF
--- a/packages/@storybook-astro/framework/src/astroRenderHandler.ts
+++ b/packages/@storybook-astro/framework/src/astroRenderHandler.ts
@@ -1,6 +1,7 @@
 import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import type { SanitizationOptions } from './lib/sanitization.ts';
 import { resolveSanitizationOptions, sanitizeRenderPayload } from './lib/sanitization.ts';
+import { reviveDateStrings } from './lib/revive-dates.ts';
 import { runWithStoryRules, type ResolveRulesConfigModule } from './storyRulesRuntime.ts';
 import type { RenderStoryInput } from './types.ts';
 
@@ -86,9 +87,10 @@ export function createAstroRenderHandler(options: CreateAstroRenderHandlerOption
             selectedRules.moduleMocks.size === 0
           );
           const processedArgs = await processImageMetadata(data.args ?? {});
+          const revivedArgs = reviveDateStrings(processedArgs);
           const sanitizedPayload = sanitizeRenderPayload(
             {
-              args: processedArgs,
+              args: revivedArgs,
               slots: data.slots ?? {}
             },
             sanitizationOptions

--- a/packages/@storybook-astro/framework/src/lib/revive-dates.test.ts
+++ b/packages/@storybook-astro/framework/src/lib/revive-dates.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'vitest';
+import { reviveDateStrings } from './revive-dates.ts';
+
+describe('reviveDateStrings', () => {
+  test('converts an ISO 8601 date string to a Date object', () => {
+    const args = { pubDate: '2025-04-12T00:00:00.000Z' };
+    const result = reviveDateStrings(args);
+
+    expect(result.pubDate).toBeInstanceOf(Date);
+    expect((result.pubDate as Date).toISOString()).toBe('2025-04-12T00:00:00.000Z');
+  });
+
+  test('converts dates nested inside objects', () => {
+    const args = {
+      post: {
+        data: {
+          pubDate: '2025-04-12T00:00:00.000Z'
+        }
+      }
+    };
+    const result = reviveDateStrings(args);
+
+    expect((result.post as Record<string, unknown>)).toMatchObject({
+      data: {
+        pubDate: expect.any(Date)
+      }
+    });
+  });
+
+  test('converts dates inside arrays', () => {
+    const args = {
+      posts: [
+        { pubDate: '2025-04-12T00:00:00.000Z' },
+        { pubDate: '2025-03-08T00:00:00.000Z' }
+      ]
+    };
+    const result = reviveDateStrings(args);
+    const posts = result.posts as Array<{ pubDate: Date }>;
+
+    expect(posts[0].pubDate).toBeInstanceOf(Date);
+    expect(posts[1].pubDate).toBeInstanceOf(Date);
+    expect(posts[0].pubDate.toISOString()).toBe('2025-04-12T00:00:00.000Z');
+    expect(posts[1].pubDate.toISOString()).toBe('2025-03-08T00:00:00.000Z');
+  });
+
+  test('leaves non-date strings untouched', () => {
+    const args = {
+      title: 'Hello World',
+      description: 'A post about dates',
+      empty: ''
+    };
+    const result = reviveDateStrings(args);
+
+    expect(result.title).toBe('Hello World');
+    expect(result.description).toBe('A post about dates');
+    expect(result.empty).toBe('');
+  });
+
+  test('leaves date-only strings untouched (no time component)', () => {
+    const args = { date: '2025-04-12' };
+    const result = reviveDateStrings(args);
+
+    expect(result.date).toBe('2025-04-12');
+  });
+
+  test('leaves partial ISO strings untouched', () => {
+    const args = {
+      noMillis: '2025-04-12T00:00:00Z',
+      withOffset: '2025-04-12T00:00:00.000+00:00',
+      dateOnly: '2025-04-12'
+    };
+    const result = reviveDateStrings(args);
+
+    expect(result.noMillis).toBe('2025-04-12T00:00:00Z');
+    expect(result.withOffset).toBe('2025-04-12T00:00:00.000+00:00');
+    expect(result.dateOnly).toBe('2025-04-12');
+  });
+
+  test('preserves non-string values', () => {
+    const args = {
+      count: 42,
+      active: true,
+      missing: null,
+      tags: ['a', 'b']
+    };
+    const result = reviveDateStrings(args);
+
+    expect(result.count).toBe(42);
+    expect(result.active).toBe(true);
+    expect(result.missing).toBe(null);
+    expect(result.tags).toEqual(['a', 'b']);
+  });
+
+  test('handles an empty args object', () => {
+    expect(reviveDateStrings({})).toEqual({});
+  });
+
+  test('round-trips a Date through JSON serialization', () => {
+    const original = new Date('2025-06-04T14:30:00.000Z');
+    const serialized = JSON.parse(JSON.stringify({ date: original })) as Record<string, unknown>;
+    const result = reviveDateStrings(serialized);
+
+    expect(result.date).toBeInstanceOf(Date);
+    expect((result.date as Date).getTime()).toBe(original.getTime());
+  });
+});

--- a/packages/@storybook-astro/framework/src/lib/revive-dates.ts
+++ b/packages/@storybook-astro/framework/src/lib/revive-dates.ts
@@ -1,0 +1,51 @@
+/**
+ * Revives Date objects that were lost during JSON serialization.
+ *
+ * When story args travel over Vite HMR (dev) or HTTP (server mode), Date
+ * values are serialized by JSON.stringify into ISO 8601 strings like
+ * "2025-04-12T00:00:00.000Z". This function walks the args tree and
+ * converts those strings back into Date objects so Astro components
+ * receive the types they expect.
+ *
+ * Only the exact format produced by Date.toJSON() is matched
+ * (YYYY-MM-DDTHH:mm:ss.sssZ) to minimize false positives.
+ */
+
+// Matches the exact output of Date.toJSON() / JSON.stringify(date).
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+export function reviveDateStrings(args: Record<string, unknown>): Record<string, unknown> {
+  const revived: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(args)) {
+    revived[key] = reviveValue(value);
+  }
+
+  return revived;
+}
+
+function reviveValue(value: unknown): unknown {
+  if (typeof value === 'string' && ISO_DATE_PATTERN.test(value)) {
+    const date = new Date(value);
+
+    if (!Number.isNaN(date.getTime())) {
+      return date;
+    }
+
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(reviveValue);
+  }
+
+  if (isRecord(value)) {
+    return reviveDateStrings(value);
+  }
+
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Problem

Date props (e.g. `pubDate: new Date('2025-04-12')`) are serialized to ISO 8601 strings when story args travel over Vite HMR (dev mode) or HTTP (server mode). By the time they reach the Astro component, the value is a plain string like `"2025-04-12T00:00:00.000Z"` instead of a `Date` object, causing components that call `date.toISOString()` or `date.toLocaleDateString()` to throw:

```
Render error: date.toISOString is not a function
```

## Solution

Add `reviveDateStrings()` to `astroRenderHandler.ts`, which walks the args tree after image metadata processing and converts strings matching the exact `Date.toJSON()` output format (`YYYY-MM-DDTHH:mm:ss.sssZ`) back to `Date` objects. This covers both dev and production render paths since both go through the shared handler.

Only the strict format produced by `JSON.stringify(date)` is matched to minimize false positives on intentional string values.

## Changes

- **`lib/revive-dates.ts`** — New utility with recursive args traversal and strict ISO pattern matching
- **`lib/revive-dates.test.ts`** — 8 tests covering flat, nested, and array dates, non-date strings, partial ISO formats, and JSON round-trips
- **`astroRenderHandler.ts`** — Wire `reviveDateStrings()` into the render pipeline

## Testing

All existing tests pass. New test suite covers edge cases.

---
[Warp conversation](https://app.warp.dev/conversation/16004ede-cd9b-4f10-a796-3fdab2765cbb)