### PR TITLE
fix(framework): restore missing ./node export dropped during dist migration

### DIFF
--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/vitest/index.d.ts",
       "import": "./dist/vitest/index.js"
     },
+    "./node": {
+      "types": "./dist/node/index.d.ts",
+      "import": "./dist/node/index.js"
+    },
     "./preset": {
       "types": "./dist/preset.d.ts",
       "import": "./dist/preset.js"

--- a/packages/@storybook-astro/framework/tsup.config.ts
+++ b/packages/@storybook-astro/framework/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: [
     'src/index.ts',
+    'src/node/index.ts',
     'src/preset.ts',
     'src/testing.ts',
     'src/vitest/index.ts',
@@ -20,6 +21,7 @@ export default defineConfig({
     // It has no public API consumers, so DTS is not needed for it.
     entry: [
       'src/index.ts',
+      'src/node/index.ts',
       'src/preset.ts',
       'src/testing.ts',
       'src/vitest/index.ts',


### PR DESCRIPTION
## Summary

- The `./node` subpath export (`defineMain`/`definePreview` helpers) was omitted when package exports were migrated from `src/` paths to `dist/` paths
- Users importing `@storybook-astro/framework/node` in `.storybook/main.ts` hit a hard `ERR_PACKAGE_PATH_NOT_EXPORTED` crash before Storybook could start — a regression from v1.2.0
- Adds `src/node/index.ts` to tsup entry points so the dist output is built

## Changes

- `package.json`: adds `"./node"` export pointing at `dist/node/index.js`
- `tsup.config.ts`: adds `src/node/index.ts` to both JS and DTS entry arrays

## Test plan

- [ ] `yarn build` in `packages/@storybook-astro/framework` produces `dist/node/index.js` and `dist/node/index.d.ts`
- [ ] Install canary build in a project that uses `import { defineMain } from '@storybook-astro/framework/node'` in `.storybook/main.ts` — Storybook should start without `ERR_PACKAGE_PATH_NOT_EXPORTED`