### PR TITLE
fix(framework): remove preset re-export from index and exclude framework from optimizeDeps

### DIFF
--- a/packages/@storybook-astro/framework/src/index.ts
+++ b/packages/@storybook-astro/framework/src/index.ts
@@ -56,9 +56,6 @@ export type {
 } from './rules.ts';
 export { defineStoryRules } from './rules.ts';
 
-// Re-export preset functionality for framework usage
-export { core, viteFinal } from './preset.ts';
-
 // Preview configuration helper
 export function definePreview<Addons extends PreviewAddon<never>[] = []>(
   input: ProjectAnnotations<AstroRenderer> & { addons?: Addons }

--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -133,14 +133,22 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
       finalConfig.optimizeDeps.exclude.push(pkg);
     }
   }
-  // Exclude the renderer from Vite's esbuild pre-bundler so that
-  // import.meta.hot is preserved in the preview iframe. When installed
-  // via npm (not workspace:*), Vite would otherwise pre-bundle the
-  // renderer with esbuild, which strips import.meta.hot and causes the
-  // renderer to fall back to fetching astro-prerendered-stories.json
-  // (a 404 in dev mode) rather than using the Vite HMR channel.
-  if (!finalConfig.optimizeDeps.exclude.includes('@storybook-astro/renderer')) {
-    finalConfig.optimizeDeps.exclude.push('@storybook-astro/renderer');
+  // Exclude the renderer and framework from Vite's esbuild pre-bundler.
+  //
+  // Renderer: import.meta.hot must be preserved so the HMR channel works.
+  // When esbuild pre-bundles it, import.meta.hot is stripped and render
+  // responses are never received, producing an infinite loading spinner.
+  //
+  // Framework: the main entry re-exports browser-safe helpers (definePreview,
+  // composeStories, etc.) but also has subpath exports that depend on Vite
+  // server APIs. If Vite's dep optimizer scans the package transitively it
+  // can pull in createServer and other Node-only code, creating a >50k-line
+  // browser bundle that causes duplicate __vite__injectQuery declarations
+  // and a SyntaxError that crashes the preview iframe.
+  for (const pkg of ['@storybook-astro/renderer', '@storybook-astro/framework']) {
+    if (!finalConfig.optimizeDeps.exclude.includes(pkg)) {
+      finalConfig.optimizeDeps.exclude.push(pkg);
+    }
   }
   // fsevents is a macOS-only native chokidar dep with a .node binary that
   // esbuild's prebundler can't load. storybook/internal/preview-api can pass


### PR DESCRIPTION
## Summary

- The framework's main `index.ts` re-exported `core` and `viteFinal` from `preset.ts`, which pulled Vite's `createServer` and all server-side middleware code into any browser bundle that imported `@storybook-astro/framework` (e.g. `preview.ts` using `definePreview`)
- Vite's dep optimizer pre-bundled this into a ~54k-line chunk; importAnalysis then injected `__vite__injectQuery` twice within that chunk, throwing a `SyntaxError` that crashed the preview iframe before HMR listeners could register — producing an infinite loading spinner on every story
- `core` and `viteFinal` are Storybook preset internals that Storybook loads via the `./preset` subpath, not via the main entry — no user should ever be importing them from `@storybook-astro/framework` directly

## Changes

- **`index.ts`**: Remove `export { core, viteFinal } from './preset.ts'`. After this change, `dist/index.js` is 23 lines of browser-safe code (`definePreview`, `composeStories`, types)
- **`preset.ts`**: Add `@storybook-astro/framework` to `optimizeDeps.exclude` alongside the renderer, so Vite never pre-bundles framework files in the browser context even if a future change would otherwise re-introduce the issue

## Test plan

- [ ] `yarn build` in `packages/@storybook-astro/framework` — confirm `dist/index.js` does not contain `createServer`, `viteFinal`, or any Vite plugin code
- [ ] Install canary build in a project whose `preview.ts` imports `definePreview` from `@storybook-astro/framework` — confirm `@storybook-astro_framework.js` no longer appears in `node_modules/.vite/deps/` after clearing the cache
- [ ] Storybook starts and stories render without the infinite loading spinner
- [ ] `core` and `viteFinal` are still accessible via `@storybook-astro/framework/preset` (the correct subpath)