### PR TITLE
fix(framework): emit hydrated framework component styles in static prerender

### DIFF
--- a/packages/@storybook-astro/framework/src/lib/hydratedComponentBuild.ts
+++ b/packages/@storybook-astro/framework/src/lib/hydratedComponentBuild.ts
@@ -1,0 +1,216 @@
+import { createRequire } from 'node:module';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { build, type Rollup } from 'vite';
+import type { Integration } from '../integrations/index.ts';
+import { mergeWithAstroConfig } from '../vitePluginAstro.ts';
+import { collectHydratedComponentPaths } from '../vitePluginAstroBuildShared.ts';
+import type { StaticCssMap, StaticModuleMap } from './staticHtmlRewriting.ts';
+
+export type HydratedComponentAssets = {
+  staticModuleMap: StaticModuleMap;
+  staticCssMap: StaticCssMap;
+};
+
+export type BuildHydratedComponentAssetsOptions = {
+  componentPaths: string[];
+  integrations: Integration[];
+  resolveFrom: string;
+  outDir: string;
+};
+
+/**
+ * Bundles the framework components hydrated inside Astro stories into the static
+ * output directory and returns the path/CSS lookups needed to rewrite rendered HTML.
+ *
+ * Storybook's main Vite build does not include these framework files unless they
+ * are imported directly by a `.stories.*` file. Astro stories typically import
+ * only the `.astro` wrapper (which gets replaced by a client stub), so without
+ * this step their `client:load` islands have no built JS chunk and no extracted
+ * CSS — leading to unstyled, unhydrated previews in the static build.
+ *
+ * Component paths may be absolute filesystem paths, paths relative to `resolveFrom`,
+ * or bare package specifiers (e.g. `@my-pkg/components/Foo.astro`). All three are
+ * normalized to absolute filesystem paths before reading sources from disk.
+ */
+export async function buildHydratedComponentAssets(
+  options: BuildHydratedComponentAssetsOptions
+): Promise<HydratedComponentAssets> {
+  const resolveSpecifier = createSpecifierResolver(options.resolveFrom);
+  const resolvedComponentPaths = options.componentPaths
+    .map(resolveSpecifier)
+    .filter((path): path is string => Boolean(path));
+  const hydratedComponentPaths = Array.from(
+    new Set(
+      (
+        await Promise.all(
+          resolvedComponentPaths.map((componentPath) =>
+            collectHydratedComponentPaths(componentPath)
+          )
+        )
+      ).flat()
+    )
+  );
+
+  if (hydratedComponentPaths.length === 0) {
+    return { staticModuleMap: {}, staticCssMap: {} };
+  }
+
+  const clientEntrypoints = Array.from(
+    new Set(
+      options.integrations
+        .map((integration) => integration.renderer.client?.entrypoint)
+        .filter((entrypoint): entrypoint is string => Boolean(entrypoint))
+    )
+  );
+  const entryNames = Object.fromEntries([
+    ...hydratedComponentPaths.map((componentPath, index) => [`component-${index}`, componentPath]),
+    ...clientEntrypoints.map((entrypoint, index) => [`renderer-${index}`, entrypoint])
+  ]);
+  const buildConfig = {
+    root: options.resolveFrom,
+    build: {
+      write: false,
+      outDir: options.outDir,
+      emptyOutDir: false,
+      manifest: false,
+      rollupOptions: {
+        input: entryNames,
+        preserveEntrySignatures: 'strict',
+        output: {
+          entryFileNames: '_astro/[name]-[hash].js',
+          chunkFileNames: '_astro/[name]-[hash].js',
+          assetFileNames: '_astro/[name]-[hash][extname]'
+        }
+      }
+    }
+  };
+  const finalConfig = await mergeWithAstroConfig(
+    buildConfig,
+    options.integrations,
+    options.resolveFrom,
+    'production',
+    'build'
+  );
+  const buildOutput = await build(finalConfig);
+  const output = Array.isArray(buildOutput)
+    ? buildOutput.flatMap((result) => result.output)
+    : buildOutput.output;
+  const chunksByFileName = new Map<string, Rollup.OutputChunk>();
+
+  for (const item of output) {
+    await writeBuildOutputFile(options.outDir, item);
+
+    if (item.type === 'chunk') {
+      chunksByFileName.set(item.fileName, item);
+    }
+  }
+
+  const staticModuleMap: StaticModuleMap = {};
+  const staticCssMap: StaticCssMap = {};
+
+  for (const item of output) {
+    if (item.type !== 'chunk' || !item.facadeModuleId) {
+      continue;
+    }
+
+    const normalizedFacadeId = item.facadeModuleId.replace(/\\/g, '/');
+    const originalInputSpecifier = entryNames[item.name];
+
+    staticModuleMap[normalizedFacadeId] = `./${item.fileName}`;
+
+    if (originalInputSpecifier && originalInputSpecifier !== normalizedFacadeId) {
+      staticModuleMap[originalInputSpecifier] = `./${item.fileName}`;
+    }
+
+    // CSS Modules and other shared stylesheets get hoisted into shared chunks
+    // when multiple entries reference them. The entry chunk's own importedCss
+    // does not list those, so walk transitively through `imports` to find every
+    // stylesheet the browser must load alongside this hydrated component.
+    const importedCss = collectTransitiveImportedCss(item, chunksByFileName);
+
+    if (importedCss.length > 0) {
+      const cssPaths = importedCss.map((fileName) => `./${fileName}`);
+
+      staticCssMap[normalizedFacadeId] = cssPaths;
+
+      if (originalInputSpecifier && originalInputSpecifier !== normalizedFacadeId) {
+        staticCssMap[originalInputSpecifier] = cssPaths;
+      }
+    }
+  }
+
+  return { staticModuleMap, staticCssMap };
+}
+
+/** Collects every CSS file reachable from the chunk through its transitive JS imports. */
+function collectTransitiveImportedCss(
+  entry: Rollup.OutputChunk,
+  chunksByFileName: Map<string, Rollup.OutputChunk>
+): string[] {
+  const visited = new Set<string>();
+  const css = new Set<string>();
+  const queue: Rollup.OutputChunk[] = [entry];
+
+  while (queue.length > 0) {
+    const chunk = queue.shift();
+
+    if (!chunk || visited.has(chunk.fileName)) {
+      continue;
+    }
+
+    visited.add(chunk.fileName);
+
+    for (const file of chunk.viteMetadata?.importedCss ?? new Set<string>()) {
+      css.add(file);
+    }
+
+    for (const importedFileName of chunk.imports ?? []) {
+      const next = chunksByFileName.get(importedFileName);
+
+      if (next) {
+        queue.push(next);
+      }
+    }
+  }
+
+  return Array.from(css);
+}
+
+async function writeBuildOutputFile(outDir: string, item: Rollup.OutputAsset | Rollup.OutputChunk) {
+  const outputPath = resolve(outDir, item.fileName);
+
+  await mkdir(dirname(outputPath), { recursive: true });
+
+  if (item.type === 'asset') {
+    await writeFile(outputPath, item.source);
+
+    return;
+  }
+
+  await writeFile(outputPath, item.code);
+}
+
+/** Resolves Storybook story `componentPath` values (absolute, relative, or bare specifier) to absolute paths. */
+function createSpecifierResolver(resolveFrom: string) {
+  // createRequire needs a real filename in `resolveFrom`; package.json works
+  // even when it does not exist (require.resolve only reads it to find roots).
+  const require_ = createRequire(pathToFileURL(resolve(resolveFrom, 'package.json')));
+
+  return (componentPath: string): string | undefined => {
+    if (isAbsolute(componentPath)) {
+      return componentPath;
+    }
+
+    if (componentPath.startsWith('./') || componentPath.startsWith('../')) {
+      return resolve(resolveFrom, componentPath);
+    }
+
+    try {
+      return require_.resolve(componentPath);
+    } catch {
+      return undefined;
+    }
+  };
+}

--- a/packages/@storybook-astro/framework/src/lib/staticHtmlRewriting.test.ts
+++ b/packages/@storybook-astro/framework/src/lib/staticHtmlRewriting.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+import {
+  addStaticStylesheets,
+  rewriteBuiltModulePaths,
+  type StaticCssMap,
+  type StaticModuleMap
+} from './staticHtmlRewriting.ts';
+
+describe('rewriteBuiltModulePaths', () => {
+  test('rewrites raw absolute source paths to their built-asset URL', () => {
+    const html = `<astro-island component-url="/abs/src/CodeTabs.jsx" renderer-url="other"></astro-island>`;
+    const staticModuleMap: StaticModuleMap = {
+      '/abs/src/CodeTabs.jsx': './_astro/component-0-abc.js'
+    };
+
+    const result = rewriteBuiltModulePaths(html, staticModuleMap);
+
+    expect(result).toContain('component-url="./_astro/component-0-abc.js"');
+    expect(result).not.toContain('/abs/src/CodeTabs.jsx');
+  });
+
+  test('rewrites Vite /@fs/-prefixed paths too', () => {
+    const html = `<script src="/@fs/abs/src/CodeTabs.jsx"></script>`;
+    const staticModuleMap: StaticModuleMap = {
+      '/abs/src/CodeTabs.jsx': './_astro/component-0-abc.js'
+    };
+
+    const result = rewriteBuiltModulePaths(html, staticModuleMap);
+
+    expect(result).toContain('src="./_astro/component-0-abc.js"');
+  });
+});
+
+describe('addStaticStylesheets', () => {
+  test('prepends one <link> for each CSS file referenced by a built module in the HTML', () => {
+    const html = `<astro-island component-url="./_astro/component-0-abc.js"></astro-island>`;
+    const staticModuleMap: StaticModuleMap = {
+      '/abs/src/CodeTabs.jsx': './_astro/component-0-abc.js'
+    };
+    const staticCssMap: StaticCssMap = {
+      '/abs/src/CodeTabs.jsx': ['./_astro/component-0-xyz.css']
+    };
+
+    const result = addStaticStylesheets(html, { staticModuleMap, staticCssMap });
+
+    expect(result.startsWith('<link rel="stylesheet" href="./_astro/component-0-xyz.css">')).toBe(
+      true
+    );
+    expect(result).toContain(html);
+  });
+
+  test('matches via the original source path when the HTML still has it', () => {
+    const html = `<astro-island component-url="/abs/src/CodeTabs.jsx"></astro-island>`;
+    const staticModuleMap: StaticModuleMap = {};
+    const staticCssMap: StaticCssMap = {
+      '/abs/src/CodeTabs.jsx': ['./_astro/component-0-xyz.css']
+    };
+
+    const result = addStaticStylesheets(html, { staticModuleMap, staticCssMap });
+
+    expect(result).toContain('<link rel="stylesheet" href="./_astro/component-0-xyz.css">');
+  });
+
+  test('deduplicates shared CSS files across multiple matched modules', () => {
+    const html = `<astro-island component-url="./_astro/a.js"></astro-island><astro-island component-url="./_astro/b.js"></astro-island>`;
+    const staticModuleMap: StaticModuleMap = {
+      '/abs/a.jsx': './_astro/a.js',
+      '/abs/b.jsx': './_astro/b.js'
+    };
+    const staticCssMap: StaticCssMap = {
+      '/abs/a.jsx': ['./_astro/shared.css'],
+      '/abs/b.jsx': ['./_astro/shared.css']
+    };
+
+    const result = addStaticStylesheets(html, { staticModuleMap, staticCssMap });
+
+    const linkMatches = result.match(/<link rel="stylesheet" href="\.\/_astro\/shared\.css">/g) ?? [];
+
+    expect(linkMatches.length).toBe(1);
+  });
+
+  test('returns HTML unchanged when no built modules match', () => {
+    const html = `<div>no islands here</div>`;
+    const staticModuleMap: StaticModuleMap = {
+      '/abs/src/CodeTabs.jsx': './_astro/component-0-abc.js'
+    };
+    const staticCssMap: StaticCssMap = {
+      '/abs/src/CodeTabs.jsx': ['./_astro/component-0-xyz.css']
+    };
+
+    const result = addStaticStylesheets(html, { staticModuleMap, staticCssMap });
+
+    expect(result).toBe(html);
+  });
+});

--- a/packages/@storybook-astro/framework/src/lib/staticHtmlRewriting.ts
+++ b/packages/@storybook-astro/framework/src/lib/staticHtmlRewriting.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared helpers used by both the static prerender build and the standalone
+ * render server to turn dev-server rendered Astro HTML into production output.
+ *
+ * Both pipelines render Astro stories through a Vite SSR runtime, which leaves
+ * source-tree module paths (e.g. `/abs/path/Component.jsx`) inside emitted
+ * markup such as `<astro-island component-url="...">`. The browser receives
+ * built chunks at hashed `/_astro/*` URLs, so the source paths must be
+ * rewritten before the HTML is served. Hydrated framework component chunks
+ * also have their CSS extracted at build time — without an explicit `<link>`
+ * tag, those styles never reach the page.
+ */
+
+export type StaticModuleMap = Record<string, string>;
+export type StaticCssMap = Record<string, string[]>;
+
+/** Rewrites every reference to a source module path in the rendered HTML to its built-asset URL. */
+export function rewriteBuiltModulePaths(html: string, staticModuleMap: StaticModuleMap): string {
+  let output = html;
+  const entries = Object.entries(staticModuleMap).sort(
+    ([left], [right]) => right.length - left.length
+  );
+
+  for (const [sourcePath, builtPath] of entries) {
+    // Replace the /@fs/-prefixed form first so the bare-path replace below
+    // can't truncate it and leave a stray "/@fs" stub in the output.
+    output = output.split(toFsPath(sourcePath)).join(builtPath);
+    output = output.split(sourcePath).join(builtPath);
+  }
+
+  return output;
+}
+
+/** Prepends stylesheet links for any built framework chunks referenced by the rendered HTML. */
+export function addStaticStylesheets(
+  html: string,
+  options: { staticModuleMap: StaticModuleMap; staticCssMap: StaticCssMap }
+): string {
+  const stylesheets = new Set<string>();
+
+  for (const [sourcePath, cssPaths] of Object.entries(options.staticCssMap)) {
+    const builtModulePath = options.staticModuleMap[sourcePath];
+
+    // Match either the original source path or the rewritten built module URL.
+    if (!html.includes(sourcePath) && (!builtModulePath || !html.includes(builtModulePath))) {
+      continue;
+    }
+
+    cssPaths.forEach((cssPath) => stylesheets.add(cssPath));
+  }
+
+  if (stylesheets.size === 0) {
+    return html;
+  }
+
+  const stylesheetTags = Array.from(stylesheets)
+    .map((href) => `<link rel="stylesheet" href="${href}">`)
+    .join('');
+
+  return `${stylesheetTags}${html}`;
+}
+
+/** Converts one source file path into the Vite /@fs/ URL form used during SSR. */
+function toFsPath(sourcePath: string) {
+  const normalizedPath = sourcePath.replace(/\\/g, '/');
+
+  return normalizedPath.startsWith('/') ? `/@fs${normalizedPath}` : `/@fs/${normalizedPath}`;
+}

--- a/packages/@storybook-astro/framework/src/server/index.ts
+++ b/packages/@storybook-astro/framework/src/server/index.ts
@@ -7,6 +7,10 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import type { HandlerProps } from '../astroRenderHandler.ts';
 import { createProductionRenderRuntime } from '../productionRenderRuntime.ts';
+import {
+  addStaticStylesheets,
+  rewriteBuiltModulePaths
+} from '../lib/staticHtmlRewriting.ts';
 import sanitization from 'virtual:storybook-astro/sanitize-config';
 import {
   storybookAstroServerAuthHeader,
@@ -47,7 +51,12 @@ app.post('/render', async (context) => {
 
   // The server runtime renders against source modules, then rewrites the HTML
   // so the browser only sees built asset URLs and matching stylesheets.
-  return context.text(addStaticStylesheets(rewriteBuiltModulePaths(html)));
+  return context.text(
+    addStaticStylesheets(rewriteBuiltModulePaths(html, runtimeConfig.staticModuleMap), {
+      staticModuleMap: runtimeConfig.staticModuleMap,
+      staticCssMap: runtimeConfig.staticCssMap
+    })
+  );
 });
 
 export default app;
@@ -132,50 +141,3 @@ function isSecureEqual(actual: string, expected: string) {
   return timingSafeEqual(actualBuffer, expectedBuffer);
 }
 
-/** Rewrites source module paths in rendered HTML to the built asset paths emitted by Storybook. */
-function rewriteBuiltModulePaths(html: string) {
-  let output = html;
-  const entries = Object.entries(runtimeConfig.staticModuleMap).sort(
-    ([left], [right]) => right.length - left.length
-  );
-
-  for (const [sourcePath, builtPath] of entries) {
-    output = output.split(sourcePath).join(builtPath);
-    output = output.split(toFsPath(sourcePath)).join(builtPath);
-  }
-
-  return output;
-}
-
-/** Prepends stylesheet links for any built framework chunks referenced by the rendered HTML. */
-function addStaticStylesheets(html: string) {
-  const stylesheets = new Set<string>();
-
-  for (const [sourcePath, cssPaths] of Object.entries(runtimeConfig.staticCssMap)) {
-    const builtModulePath = runtimeConfig.staticModuleMap[sourcePath];
-
-    // Match either the original source path or the rewritten built module URL.
-    if (!html.includes(sourcePath) && (!builtModulePath || !html.includes(builtModulePath))) {
-      continue;
-    }
-
-    cssPaths.forEach((cssPath) => stylesheets.add(cssPath));
-  }
-
-  if (stylesheets.size === 0) {
-    return html;
-  }
-
-  const stylesheetTags = Array.from(stylesheets)
-    .map((href) => `<link rel="stylesheet" href="${href}">`)
-    .join('');
-
-  return `${stylesheetTags}${html}`;
-}
-
-/** Converts one source file path into the Vite /@fs/ URL form used during SSR. */
-function toFsPath(sourcePath: string) {
-  const normalizedPath = sourcePath.replace(/\\/g, '/');
-
-  return normalizedPath.startsWith('/') ? `/@fs${normalizedPath}` : `/@fs/${normalizedPath}`;
-}

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildPrerender.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildPrerender.ts
@@ -16,6 +16,13 @@ import {
   renderProductionStoryToHtml,
   type ProductionStoryEntry
 } from './productionRenderRuntime.ts';
+import { buildHydratedComponentAssets } from './lib/hydratedComponentBuild.ts';
+import {
+  addStaticStylesheets,
+  rewriteBuiltModulePaths,
+  type StaticCssMap,
+  type StaticModuleMap
+} from './lib/staticHtmlRewriting.ts';
 import { resolveRulesConfigFilePath } from './rules-options.ts';
 import type { FrameworkOptions } from './types.ts';
 
@@ -88,7 +95,7 @@ export function vitePluginAstroBuildPrerender(options: FrameworkOptions): Plugin
       _outputOptions: Rollup.NormalizedOutputOptions,
       bundle: Rollup.OutputBundle
     ) {
-      const staticModuleMap = buildStaticModuleMap(
+      const trackedModuleMap = buildStaticModuleMap(
         this,
         staticEntrypointRefs,
         componentEntrypointRefs
@@ -102,12 +109,33 @@ export function vitePluginAstroBuildPrerender(options: FrameworkOptions): Plugin
         return;
       }
 
+      const storyAstroComponentPaths = Array.from(
+        new Set(astroStories.map((story) => story.componentPath))
+      );
+      // Bundle the framework components hydrated inside Astro stories so the
+      // static preview has matching JS chunks and extracted CSS for them.
+      // Storybook's own iframe build skips these files when no per-framework
+      // .stories.* exists, which left CSS-module styling absent from the
+      // prerendered output.
+      const hydratedComponentAssets = await buildHydratedComponentAssets({
+        componentPaths: storyAstroComponentPaths,
+        integrations,
+        resolveFrom,
+        outDir
+      });
+      const staticModuleMap: StaticModuleMap = {
+        ...trackedModuleMap,
+        ...hydratedComponentAssets.staticModuleMap
+      };
+      const staticCssMap: StaticCssMap = hydratedComponentAssets.staticCssMap;
+
       const prerenderedStories = await prerenderAstroStories({
         astroStories,
         integrations,
         sanitization: options.sanitization,
         storyRulesConfigFilePath,
         staticModuleMap,
+        staticCssMap,
         trackedSpecifiers,
         resolveFrom,
         bundle
@@ -130,7 +158,8 @@ async function prerenderAstroStories(options: {
   integrations: Integration[];
   sanitization?: FrameworkOptions['sanitization'];
   storyRulesConfigFilePath?: string;
-  staticModuleMap: Record<string, string>;
+  staticModuleMap: StaticModuleMap;
+  staticCssMap: StaticCssMap;
   trackedSpecifiers: Set<string>;
   resolveFrom: string;
   bundle: Rollup.OutputBundle;
@@ -155,9 +184,24 @@ async function prerenderAstroStories(options: {
         resolveFrom: options.resolveFrom
       });
 
-      if (html !== undefined) {
-        output[story.id] = rewriteAssetPaths(html, assetPathMap);
+      if (html === undefined) {
+        continue;
       }
+
+      // Image asset URLs from Vite SSR still point at /@fs/ paths, so rewrite
+      // them first; then rewrite hydrated framework component module paths and
+      // prepend their extracted CSS so the static preview matches dev styling.
+      const htmlWithAssetUrls = rewriteAssetPaths(html, assetPathMap);
+      const htmlWithBuiltModules = rewriteBuiltModulePaths(
+        htmlWithAssetUrls,
+        options.staticModuleMap
+      );
+      const htmlWithStylesheets = addStaticStylesheets(htmlWithBuiltModules, {
+        staticModuleMap: options.staticModuleMap,
+        staticCssMap: options.staticCssMap
+      });
+
+      output[story.id] = htmlWithStylesheets;
     }
 
     return output;

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildServer.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildServer.ts
@@ -1,19 +1,18 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { mkdir, writeFile } from 'node:fs/promises';
 import { build, type Rollup } from 'vite';
 import { resolveRulesConfigFilePath } from './rules-options.ts';
 import type { FrameworkOptions } from './types.ts';
 import {
   buildStaticModuleMap,
   buildSnapshotFilePath,
-  collectHydratedComponentPaths,
   copyRuntimeSnapshot,
   collectTrackedSpecifiers,
   emitBuildEntrypoints,
   loadVirtualBuildModule,
   resolveVirtualBuildModuleId,
 } from './vitePluginAstroBuildShared.ts';
+import { buildHydratedComponentAssets } from './lib/hydratedComponentBuild.ts';
 import { mergeWithAstroConfig } from './vitePluginAstro.ts';
 import { viteAstroContainerRenderersPlugin } from './viteAstroContainerRenderersPlugin.ts';
 import { sanitizeConfigPlugin } from './vite/sanitizeConfigPlugin.ts';
@@ -75,14 +74,17 @@ export function vitePluginAstroBuildServer(options: FrameworkOptions) {
         resolveFrom,
         outDir: storybookStaticOutDir
       });
-      const staticModuleMap = addSnapshotModuleAliases({
-        ...trackedModuleMap,
-        ...hydratedComponentAssets.staticModuleMap
-      }, {
-        resolveFrom,
-        snapshotRoot: resolve(serverOutDir, snapshotDirName),
-        snapshotDirName
-      });
+      const staticModuleMap = addSnapshotModuleAliases(
+        {
+          ...trackedModuleMap,
+          ...hydratedComponentAssets.staticModuleMap
+        },
+        {
+          resolveFrom,
+          snapshotRoot: resolve(serverOutDir, snapshotDirName),
+          snapshotDirName
+        }
+      );
       const staticCssMap = hydratedComponentAssets.staticCssMap;
 
       await buildAstroServer({
@@ -205,113 +207,6 @@ async function collectAstroStories(outDir: string, resolveFrom: string) {
         : entry.componentPath
     }))
     .filter((entry): entry is { componentPath: string } => Boolean(entry.componentPath));
-}
-
-async function buildHydratedComponentAssets(options: {
-  componentPaths: string[];
-  integrations: NonNullable<FrameworkOptions['integrations']>;
-  resolveFrom: string;
-  outDir: string;
-}) {
-  const hydratedComponentPaths = Array.from(
-    new Set((await Promise.all(options.componentPaths.map((componentPath) => collectHydratedComponentPaths(componentPath)))).flat())
-  );
-
-  if (hydratedComponentPaths.length === 0) {
-    return {
-      staticModuleMap: {},
-      staticCssMap: {}
-    };
-  }
-
-  const clientEntrypoints = Array.from(
-    new Set(
-      options.integrations
-        .map((integration) => integration.renderer.client?.entrypoint)
-        .filter((entrypoint): entrypoint is string => Boolean(entrypoint))
-    )
-  );
-  const entryNames = Object.fromEntries(
-    [
-      ...hydratedComponentPaths.map((componentPath, index) => [`component-${index}`, componentPath]),
-      ...clientEntrypoints.map((entrypoint, index) => [`renderer-${index}`, entrypoint])
-    ]
-  );
-  const buildConfig = {
-    root: options.resolveFrom,
-    build: {
-      write: false,
-      outDir: options.outDir,
-      emptyOutDir: false,
-      manifest: false,
-      rollupOptions: {
-        input: entryNames,
-        preserveEntrySignatures: 'strict',
-        output: {
-          entryFileNames: '_astro/[name]-[hash].js',
-          chunkFileNames: '_astro/[name]-[hash].js',
-          assetFileNames: '_astro/[name]-[hash][extname]'
-        }
-      }
-    }
-  };
-  const finalConfig = await mergeWithAstroConfig(
-    buildConfig,
-    options.integrations,
-    options.resolveFrom,
-    'production',
-    'build'
-  );
-  const buildOutput = await build(finalConfig);
-  const output = Array.isArray(buildOutput) ? buildOutput.flatMap((result) => result.output) : buildOutput.output;
-  const staticModuleMap: Record<string, string> = {};
-  const staticCssMap: Record<string, string[]> = {};
-
-  for (const item of output) {
-    await writeBuildOutputFile(options.outDir, item);
-
-    if (item.type !== 'chunk' || !item.facadeModuleId) {
-      continue;
-    }
-
-    const normalizedFacadeId = item.facadeModuleId.replace(/\\/g, '/');
-    const originalInputSpecifier = entryNames[item.name];
-
-    staticModuleMap[normalizedFacadeId] = `./${item.fileName}`;
-
-    if (originalInputSpecifier && originalInputSpecifier !== normalizedFacadeId) {
-      staticModuleMap[originalInputSpecifier] = `./${item.fileName}`;
-    }
-
-    const importedCss = Array.from((item.viteMetadata?.importedCss ?? new Set<string>()).values());
-
-    if (importedCss.length > 0) {
-      staticCssMap[normalizedFacadeId] = importedCss.map((fileName) => `./${fileName}`);
-
-      if (originalInputSpecifier && originalInputSpecifier !== normalizedFacadeId) {
-        staticCssMap[originalInputSpecifier] = importedCss.map((fileName) => `./${fileName}`);
-      }
-    }
-  }
-
-  return {
-    staticModuleMap,
-    staticCssMap
-  };
-}
-
-async function writeBuildOutputFile(outDir: string, item: Rollup.OutputAsset | Rollup.OutputChunk) {
-  const outputPath = resolve(outDir, item.fileName);
-
-  await mkdir(dirname(outputPath), { recursive: true });
-
-  if (item.type === 'asset') {
-    await writeFile(outputPath, item.source);
-
-    return;
-  }
-
-  await writeFile(outputPath, item.code);
 }
 
 function addSnapshotModuleAliases(

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
@@ -177,29 +177,6 @@ export function buildStaticModuleMap(
   return map;
 }
 
-/** Builds the stylesheet map for emitted framework component entry chunks. */
-export function buildStaticCssMap(
-  pluginContext: Rollup.PluginContext,
-  bundle: Rollup.OutputBundle,
-  componentEntrypointRefs: Map<string, string>
-) {
-  const map: Record<string, string[]> = {};
-
-  componentEntrypointRefs.forEach((fileReferenceId, specifier) => {
-    const fileName = pluginContext.getFileName(fileReferenceId);
-    const chunk = fileName ? (bundle[fileName] as Rollup.OutputChunk | undefined) : undefined;
-    const importedCss = Array.from(
-      (chunk?.viteMetadata?.importedCss ?? new Set<string>()).values()
-    );
-
-    if (importedCss.length > 0) {
-      map[specifier] = importedCss.map((cssFileName) => toPublicPath(cssFileName));
-    }
-  });
-
-  return map;
-}
-
 /** Normalizes one emitted file name to the relative public path used in built HTML. */
 export function toPublicPath(fileName: string) {
   return `./${fileName}`;


### PR DESCRIPTION
## Summary
- Static prerender (`renderMode: 'static'`) was missing CSS and hydration chunks for Astro stories whose framework components only mount via `client:load` with no per-framework `.stories.*` file (e.g. Code Tabs). The `.astro` wrapper is replaced by a client stub in Storybook's iframe build, so the React/Solid/Vue/Svelte/Preact source files — and any CSS Modules they import — never enter the main Vite graph, leaving stories unstyled on the deployed demos.
- Lift the hydrated-component build and HTML post-processing into shared helpers under `src/lib/` and wire them into the static prerender plugin, matching the existing behaviour on the server-render path. Walk chunk imports transitively so CSS Modules that Vite hoists into shared chunks still surface as `<link>` tags on the matching hydrated entry. Drop the dead `buildStaticCssMap` helper that hinted this area was incomplete.

## Test plan
- [x] `yarn vitest run` in `packages/@storybook-astro/framework` — 68/68 pass, including 6 new tests in `lib/staticHtmlRewriting.test.ts`
- [x] `yarn lint` — clean
- [x] `yarn build` in `integration/astro5` and `integration/astro6` — both succeed
- [x] Inspect `storybook-static/astro-prerendered-stories.json` — Code Tabs (React/Solid/Preact/Svelte/Vue) all gain a `<link rel="stylesheet">` to the emitted CSS chunk; Alpine variant unchanged (uses inline `<style is:inline>`); other hydrated stories (GithubContributors, GithubStars) also gain correct CSS links — 19 of 41 prerendered stories now have stylesheet tags
- [x] `yarn test` in `integration/astro6` — 8/8 pass
- [x] Serve `storybook-static` locally — iframe, prerendered JSON, and `_astro/codeTabs-*.css` all return 200 with the expected `_installTabs_*` rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)