### PR TITLE
fix: move defineStoryRules and StoryRule types to node entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export default {
 // .storybook/story-rules.ts
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
-import { defineStoryRules } from '@storybook-astro/framework';
+import { defineStoryRules } from '@storybook-astro/framework/node';
 
 const server = setupServer();
 let isListening = false;

--- a/apps/website/src/content/docs/reference/configuration.md
+++ b/apps/website/src/content/docs/reference/configuration.md
@@ -156,7 +156,7 @@ export default {
 ```typescript
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
-import { defineStoryRules } from '@storybook-astro/framework';
+import { defineStoryRules } from '@storybook-astro/framework/node';
 
 const server = setupServer();
 let isListening = false;

--- a/integration/astro5/.storybook/story-rules.ts
+++ b/integration/astro5/.storybook/story-rules.ts
@@ -1,4 +1,4 @@
-import { defineStoryRules } from '@storybook-astro/framework';
+import { defineStoryRules } from '@storybook-astro/framework/node';
 import { HttpResponse, http } from 'msw';
 import { getMswServer } from './msw-server.ts';
 import type {

--- a/integration/astro6-server/.storybook/story-rules.ts
+++ b/integration/astro6-server/.storybook/story-rules.ts
@@ -1,4 +1,4 @@
-import { defineStoryRules } from '@storybook-astro/framework';
+import { defineStoryRules } from '@storybook-astro/framework/node';
 import { HttpResponse, http } from 'msw';
 import type {
   GithubContributor,

--- a/integration/astro6/.storybook/story-rules.ts
+++ b/integration/astro6/.storybook/story-rules.ts
@@ -1,4 +1,4 @@
-import { defineStoryRules } from '@storybook-astro/framework';
+import { defineStoryRules } from '@storybook-astro/framework/node';
 import { HttpResponse, http } from 'msw';
 import { getMswServer } from './msw-server.ts';
 import type {

--- a/packages/@storybook-astro/framework/src/index.ts
+++ b/packages/@storybook-astro/framework/src/index.ts
@@ -42,19 +42,6 @@ export type {
   StoryRulesOptions,
   StorybookConfig
 } from './types.ts';
-export type {
-  StoryRuleCleanup,
-  StoryRuleMock,
-  StoryRuleMockFactory,
-  StoryRule,
-  StoryRulesConfig,
-  StoryRuleSelection,
-  StoryRuleSelectionInput,
-  StoryRuleStory,
-  StoryRuleUse,
-  StoryRuleUseContext
-} from './rules.ts';
-export { defineStoryRules } from './rules.ts';
 
 // Preview configuration helper
 export function definePreview<Addons extends PreviewAddon<never>[] = []>(

--- a/packages/@storybook-astro/framework/src/node/index.ts
+++ b/packages/@storybook-astro/framework/src/node/index.ts
@@ -5,3 +5,17 @@ export function defineMain(config: StorybookConfig): StorybookConfig {
 }
 
 export type { StorybookConfig };
+
+export { defineStoryRules } from '../rules.ts';
+export type {
+  StoryRuleCleanup,
+  StoryRuleMock,
+  StoryRuleMockFactory,
+  StoryRule,
+  StoryRulesConfig,
+  StoryRuleSelection,
+  StoryRuleSelectionInput,
+  StoryRuleStory,
+  StoryRuleUse,
+  StoryRuleUseContext
+} from '../rules.ts';


### PR DESCRIPTION
## Problem

The main package entry (`index.ts`) is loaded in browser context when users import from `@storybook-astro/framework` in `preview.ts`. It re-exported `defineStoryRules` and `StoryRule*` types from `rules.ts`, which has a top-level `import { dirname, isAbsolute, resolve } from 'node:path'`.

When `@storybook-astro/framework` is excluded from Vite's dependency optimizer (as of #97), Vite serves `dist/index.js` as native ESM — the browser follows all static imports including `rules.ts`, hits the `node:path` import, and throws:

> Uncaught Error: Module "path" has been externalized for browser compatibility. Cannot access "path.dirname" in client code.

This causes the preview iframe to crash before the HMR listeners register, resulting in an infinite loading spinner.

## Fix

Move `defineStoryRules` and the `StoryRule*` types from the main browser entry (`src/index.ts`) to the node-only entry (`src/node/index.ts`).

These are server-side concerns used in `.storybook/main.ts` config files. They belong in the `@storybook-astro/framework/node` subpath alongside `defineMain`.

## Migration

If you use `defineStoryRules` or `StoryRule*` types, update your import:

```diff
- import { defineStoryRules } from '@storybook-astro/framework';
+ import { defineStoryRules } from '@storybook-astro/framework/node';
```