### PR TITLE
fix(framework): auto-load user astro.config integrations into Vite

### DIFF
--- a/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
+++ b/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
@@ -19,7 +19,10 @@ const CONFIG_FILENAMES = [
  */
 export async function loadUserAstroIntegrations(resolveFrom: string): Promise<AstroIntegration[]> {
   const configFile = CONFIG_FILENAMES.find(name => existsSync(resolve(resolveFrom, name)));
-  if (!configFile) return [];
+
+  if (!configFile) {
+    return [];
+  }
 
   try {
     const result = await loadConfigFromFile(
@@ -27,14 +30,21 @@ export async function loadUserAstroIntegrations(resolveFrom: string): Promise<As
       configFile,
       resolveFrom
     );
-    if (!result?.config) return [];
+
+    if (!result?.config) {
+      return [];
+    }
 
     const config = result.config as { integrations?: unknown };
     const raw = config.integrations;
-    if (!raw) return [];
+
+    if (!raw) {
+      return [];
+    }
 
     // Astro allows nested arrays from conditional spreads (e.g. ...whenX(() => mdx()))
     const flat = (Array.isArray(raw) ? raw : [raw]).flat(Infinity);
+
     return flat.filter(
       (i): i is AstroIntegration => Boolean(i) && typeof i === 'object' && 'name' in i && 'hooks' in i
     );
@@ -43,6 +53,7 @@ export async function loadUserAstroIntegrations(resolveFrom: string): Promise<As
       '[storybook-astro] Could not load astro.config to discover integrations:',
       err instanceof Error ? err.message : String(err)
     );
+
     return [];
   }
 }

--- a/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
+++ b/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
@@ -1,0 +1,48 @@
+import { loadConfigFromFile } from 'vite';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { AstroIntegration } from 'astro';
+
+const CONFIG_FILENAMES = [
+  'astro.config.ts',
+  'astro.config.mjs',
+  'astro.config.js',
+  'astro.config.cjs',
+];
+
+/**
+ * Loads integrations declared in the user's astro.config.* so that any Vite
+ * plugins they register (e.g. astro-icon's virtual:astro-icon resolver) are
+ * present in both the main Storybook Vite server and the internal Astro SSR
+ * server.  Returns an empty array on any failure so the calling code can
+ * continue with only the framework-level integrations.
+ */
+export async function loadUserAstroIntegrations(resolveFrom: string): Promise<AstroIntegration[]> {
+  const configFile = CONFIG_FILENAMES.find(name => existsSync(resolve(resolveFrom, name)));
+  if (!configFile) return [];
+
+  try {
+    const result = await loadConfigFromFile(
+      { command: 'serve', mode: 'development' },
+      configFile,
+      resolveFrom
+    );
+    if (!result?.config) return [];
+
+    const config = result.config as { integrations?: unknown };
+    const raw = config.integrations;
+    if (!raw) return [];
+
+    // Astro allows nested arrays from conditional spreads (e.g. ...whenX(() => mdx()))
+    const flat = (Array.isArray(raw) ? raw : [raw]).flat(Infinity);
+    return flat.filter(
+      (i): i is AstroIntegration => Boolean(i) && typeof i === 'object' && 'name' in i && 'hooks' in i
+    );
+  } catch (err) {
+    console.warn(
+      '[storybook-astro] Could not load astro.config to discover integrations:',
+      err instanceof Error ? err.message : String(err)
+    );
+    return [];
+  }
+}

--- a/packages/@storybook-astro/framework/src/vitePluginAstro.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstro.ts
@@ -1,6 +1,7 @@
 import { mergeConfig, type InlineConfig } from 'vite';
 import type { Integration } from './integrations/index.ts';
 import { importAstroConfig } from './importAstroConfig.ts';
+import { loadUserAstroIntegrations } from './loadUserAstroConfig.ts';
 
 const ASTRO_PLUGINS_THAT_ARE_SUPPOSEDLY_NOT_NEEDED_IN_STORYBOOK = [
   '@astro/plugin-actions',
@@ -38,13 +39,19 @@ export async function mergeWithAstroConfig(
   const { getViteConfig } = await importAstroConfig(resolveFrom);
   const safeIntegrations = integrations ?? [];
 
+  const frameworkIntegrations = await Promise.all(
+    safeIntegrations.map((integration) => integration.loadIntegration(resolveFrom))
+  );
+
+  const userIntegrations = await loadUserAstroIntegrations(resolveFrom);
+  const frameworkNames = new Set(frameworkIntegrations.map(i => i.name));
+  const extraIntegrations = userIntegrations.filter(i => !frameworkNames.has(i.name));
+
   const astroConfig = await getViteConfig(
     {},
     {
       configFile: false,
-      integrations: await Promise.all(
-        safeIntegrations.map((integration) => integration.loadIntegration(resolveFrom))
-      )
+      integrations: [...frameworkIntegrations, ...extraIntegrations]
     }
   )({
     mode,

--- a/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
+++ b/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
@@ -14,6 +14,7 @@ import { vitePluginAstroRoutesFallback } from './vitePluginAstroRoutesFallback.t
 import { vitePluginStoryModuleMocks } from './vitePluginStoryModuleMocks.ts';
 import { ssrLoadModuleWithFsFallback } from './lib/ssr-load-module-with-fs-fallback.ts';
 import { resolveRulesConfigFilePath } from './rules-options.ts';
+import { loadUserAstroIntegrations } from './loadUserAstroConfig.ts';
 
 export async function vitePluginStorybookAstroMiddleware(options: FrameworkOptions) {
   // The internal Vite server is created lazily inside configureServer (dev-only).
@@ -164,13 +165,19 @@ export async function createViteServer(
   const safeIntegrations = integrations ?? [];
   const projectAstroResolutionPlugin = createProjectAstroResolutionPlugin(resolveFrom);
 
+  const frameworkIntegrations = await Promise.all(
+    safeIntegrations.map((integration) => integration.loadIntegration(resolveFrom))
+  );
+
+  const userIntegrations = await loadUserAstroIntegrations(resolveFrom);
+  const frameworkNames = new Set(frameworkIntegrations.map(i => i.name));
+  const extraIntegrations = userIntegrations.filter(i => !frameworkNames.has(i.name));
+
   const config = await getViteConfig(
     { root: resolveFrom },
     {
       configFile: false,
-      integrations: await Promise.all(
-        safeIntegrations.map((integration) => integration.loadIntegration(resolveFrom))
-      ),
+      integrations: [...frameworkIntegrations, ...extraIntegrations],
       // Use the passthrough image service so nested components that use <Image>
       // from astro:assets render as plain <img> tags without triggering image
       // optimization (which fails in the Storybook SSR context).


### PR DESCRIPTION
## Problem

Third-party Astro integrations that register Vite virtual modules (e.g. `astro-icon`'s `virtual:astro-icon`) were never included in Storybook's Vite config. Both `getViteConfig` call sites used `configFile: false` and only received the framework's own `Integration` instances (React, Vue, etc.), so any integration not in that set was silently absent.

This caused `Cannot find module 'virtual:...'` SSR errors for any real-world project using such integrations — AstroWind being the first confirmed case.

## Solution

New `loadUserAstroIntegrations()` in `loadUserAstroConfig.ts` reads the project's `astro.config.*` using Vite's `loadConfigFromFile` (which handles TypeScript transparently), extracts the `integrations` array, and returns it. Missing configs and load failures are caught gracefully — a warning is logged and an empty array is returned so Storybook still starts.

The resolved integrations are merged into both `getViteConfig` call sites:

- `mergeWithAstroConfig` — main Storybook Vite server
- `createViteServer` — internal Astro SSR server (where the `virtual:astro-icon` error originated)

Integrations already loaded by a framework `Integration` instance are deduplicated by name.

## Result

`astro-icon` (and any other integration that registers Vite virtual modules) is now picked up automatically from `astro.config.*` with no changes required in `.storybook/main.js`.

## Test plan

- [ ] All existing tests pass (`yarn test`)
- [ ] AstroWind project starts without the `virtual:astro-icon` error
- [ ] Projects without a third-party icon integration are unaffected