### PR TITLE
fix(framework): resolve tsconfig path aliases for embedded island hydration

### DIFF
--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -145,6 +145,7 @@
     "@storybook-astro/renderer": "workspace:*",
     "hono": "^4.11.12",
     "sanitize-html": "^2.17.0",
+    "tsconfck": "^3.1.6",
     "vite": "^6.4.1 || ^7.0.0 || ^8.0.0"
   }
 }

--- a/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.test.ts
+++ b/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.test.ts
@@ -1,0 +1,145 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { resolveAliasedIsland } from './resolve-aliased-island.ts';
+
+describe('resolveAliasedIsland', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'storybook-astro-alias-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeTsconfig(content: object) {
+    await writeFile(join(tmpDir, 'tsconfig.json'), JSON.stringify(content, null, 2));
+  }
+
+  test('resolves a basic @/ alias to an absolute path', async () => {
+    await mkdir(join(tmpDir, 'src', 'components'), { recursive: true });
+    const counterFile = join(tmpDir, 'src', 'components', 'Counter.tsx');
+    await writeFile(counterFile, `export default function Counter() {}`);
+    await writeTsconfig({
+      compilerOptions: {
+        paths: { '@/*': ['src/*'] }
+      }
+    });
+
+    const result = await resolveAliasedIsland('@/components/Counter', tmpDir);
+
+    expect(result).toBe(counterFile.replace(/\\/g, '/'));
+  });
+
+  test('resolves when baseUrl shifts the path root', async () => {
+    await mkdir(join(tmpDir, 'src', 'components'), { recursive: true });
+    const counterFile = join(tmpDir, 'src', 'components', 'Counter.tsx');
+    await writeFile(counterFile, `export default function Counter() {}`);
+    // With baseUrl: "src", paths are relative to src/
+    await writeTsconfig({
+      compilerOptions: {
+        baseUrl: 'src',
+        paths: { '@/*': ['*'] }
+      }
+    });
+
+    const result = await resolveAliasedIsland('@/components/Counter', tmpDir);
+
+    expect(result).toBe(counterFile.replace(/\\/g, '/'));
+  });
+
+  test('falls back to second target when first does not exist on disk', async () => {
+    await mkdir(join(tmpDir, 'app', 'components'), { recursive: true });
+    const counterFile = join(tmpDir, 'app', 'components', 'Counter.tsx');
+    await writeFile(counterFile, `export default function Counter() {}`);
+    // First target points at a non-existent dir; second target resolves.
+    await writeTsconfig({
+      compilerOptions: {
+        paths: { '@/*': ['missing/*', 'app/*'] }
+      }
+    });
+
+    const result = await resolveAliasedIsland('@/components/Counter', tmpDir);
+
+    expect(result).toBe(counterFile.replace(/\\/g, '/'));
+  });
+
+  test('resolves an alias with an explicit file extension in the specifier', async () => {
+    await mkdir(join(tmpDir, 'src'), { recursive: true });
+    const file = join(tmpDir, 'src', 'Button.tsx');
+    await writeFile(file, `export default function Button() {}`);
+    await writeTsconfig({ compilerOptions: { paths: { '@/*': ['src/*'] } } });
+
+    const result = await resolveAliasedIsland('@/Button.tsx', tmpDir);
+
+    expect(result).toBe(file.replace(/\\/g, '/'));
+  });
+
+  test('returns undefined when aliased file does not exist on disk', async () => {
+    await writeTsconfig({ compilerOptions: { paths: { '@/*': ['src/*'] } } });
+
+    const result = await resolveAliasedIsland('@/components/Missing', tmpDir);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when tsconfig has no paths', async () => {
+    await mkdir(join(tmpDir, 'src'), { recursive: true });
+    await writeFile(join(tmpDir, 'src', 'Counter.tsx'), `export default function Counter() {}`);
+    await writeTsconfig({ compilerOptions: {} });
+
+    const result = await resolveAliasedIsland('@/Counter', tmpDir);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when tsconfig.json is absent', async () => {
+    const result = await resolveAliasedIsland('@/Counter', tmpDir);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for relative specifiers (already handled elsewhere)', async () => {
+    const result = await resolveAliasedIsland('./components/Counter', tmpDir);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for absolute paths', async () => {
+    const result = await resolveAliasedIsland('/abs/path/Counter.tsx', tmpDir);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for virtual: specifiers', async () => {
+    const result = await resolveAliasedIsland('virtual:astro-container-renderers', tmpDir);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for astro: specifiers', async () => {
+    const result = await resolveAliasedIsland('astro:scripts/page.js', tmpDir);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined for /@fs/ specifiers', async () => {
+    const result = await resolveAliasedIsland('/@fs/abs/path/Counter.tsx', tmpDir);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('resolves a custom alias prefix (not @/)', async () => {
+    await mkdir(join(tmpDir, 'src'), { recursive: true });
+    const file = join(tmpDir, 'src', 'Widget.vue');
+    await writeFile(file, `<template><div /></template>`);
+    await writeTsconfig({ compilerOptions: { paths: { '~/*': ['src/*'] } } });
+
+    const result = await resolveAliasedIsland('~/Widget', tmpDir);
+
+    expect(result).toBe(file.replace(/\\/g, '/'));
+  });
+});

--- a/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.test.ts
+++ b/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.test.ts
@@ -22,6 +22,7 @@ describe('resolveAliasedIsland', () => {
   test('resolves a basic @/ alias to an absolute path', async () => {
     await mkdir(join(tmpDir, 'src', 'components'), { recursive: true });
     const counterFile = join(tmpDir, 'src', 'components', 'Counter.tsx');
+
     await writeFile(counterFile, `export default function Counter() {}`);
     await writeTsconfig({
       compilerOptions: {
@@ -37,6 +38,7 @@ describe('resolveAliasedIsland', () => {
   test('resolves when baseUrl shifts the path root', async () => {
     await mkdir(join(tmpDir, 'src', 'components'), { recursive: true });
     const counterFile = join(tmpDir, 'src', 'components', 'Counter.tsx');
+
     await writeFile(counterFile, `export default function Counter() {}`);
     // With baseUrl: "src", paths are relative to src/
     await writeTsconfig({
@@ -54,6 +56,7 @@ describe('resolveAliasedIsland', () => {
   test('falls back to second target when first does not exist on disk', async () => {
     await mkdir(join(tmpDir, 'app', 'components'), { recursive: true });
     const counterFile = join(tmpDir, 'app', 'components', 'Counter.tsx');
+
     await writeFile(counterFile, `export default function Counter() {}`);
     // First target points at a non-existent dir; second target resolves.
     await writeTsconfig({
@@ -70,6 +73,7 @@ describe('resolveAliasedIsland', () => {
   test('resolves an alias with an explicit file extension in the specifier', async () => {
     await mkdir(join(tmpDir, 'src'), { recursive: true });
     const file = join(tmpDir, 'src', 'Button.tsx');
+
     await writeFile(file, `export default function Button() {}`);
     await writeTsconfig({ compilerOptions: { paths: { '@/*': ['src/*'] } } });
 
@@ -135,6 +139,7 @@ describe('resolveAliasedIsland', () => {
   test('resolves a custom alias prefix (not @/)', async () => {
     await mkdir(join(tmpDir, 'src'), { recursive: true });
     const file = join(tmpDir, 'src', 'Widget.vue');
+
     await writeFile(file, `<template><div /></template>`);
     await writeTsconfig({ compilerOptions: { paths: { '~/*': ['src/*'] } } });
 

--- a/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.ts
+++ b/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.ts
@@ -1,0 +1,96 @@
+import { access } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { parse } from 'tsconfck';
+
+// Islands embedded in `.astro` components are frequently imported through a
+// tsconfig path alias (e.g. `@/components/Counter`). The raw aliased specifier
+// is baked into `<astro-island component-url>` and `import()`d verbatim, so it
+// must be turned into an on-disk path before it can hydrate. This helper is
+// used as a last resort after the existing resolution has already had its
+// chance.
+
+const ALIAS_EXTS = ['.tsx', '.ts', '.jsx', '.js', '.vue', '.svelte', '.mts', '.mjs'];
+
+async function isFile(candidate: string): Promise<boolean> {
+  try {
+    await access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves a tsconfig-aliased island specifier (e.g. `@/components/Counter`)
+ * to an absolute on-disk file path, or `undefined` when it is not a tsconfig
+ * alias or no matching file exists. Already-resolvable specifiers are skipped
+ * so this runs only as a genuine last resort.
+ */
+export async function resolveAliasedIsland(
+  specifier: string,
+  resolveFrom: string
+): Promise<string | undefined> {
+  // Skip specifiers the existing resolution can already handle.
+  if (
+    !specifier ||
+    specifier.startsWith('./') ||
+    specifier.startsWith('../') ||
+    specifier.startsWith('/') ||
+    specifier.startsWith('\0') ||
+    specifier.startsWith('virtual:') ||
+    specifier.startsWith('astro:') ||
+    specifier.startsWith('@astrojs/') ||
+    specifier.startsWith('@id/') ||
+    specifier.startsWith('/@fs/')
+  ) {
+    return undefined;
+  }
+
+  let result;
+
+  try {
+    result = await parse(resolve(resolveFrom, 'tsconfig.json'));
+  } catch {
+    return undefined;
+  }
+
+  const compilerOptions = result.tsconfig?.compilerOptions ?? {};
+  const paths: Record<string, string[]> = compilerOptions.paths ?? {};
+
+  if (Object.keys(paths).length === 0) {
+    return undefined;
+  }
+
+  // tsconfig paths resolve relative to baseUrl when present, otherwise the
+  // tsconfig directory (which tsconfck gives us as the tsconfig file's dir).
+  const tsconfigDir = result.tsconfigFile
+    ? resolve(result.tsconfigFile, '..')
+    : resolveFrom;
+  const root = compilerOptions.baseUrl
+    ? resolve(tsconfigDir, compilerOptions.baseUrl)
+    : tsconfigDir;
+
+  for (const [pattern, targets] of Object.entries(paths)) {
+    const prefix = pattern.replace(/\*$/, '');
+
+    if (!specifier.startsWith(prefix)) {
+      continue;
+    }
+
+    const rest = specifier.slice(prefix.length);
+
+    for (const target of targets) {
+      const resolvedTarget = target.replace(/\*$/, '');
+      const base = resolve(root, resolvedTarget, rest);
+      const candidates = [base, ...ALIAS_EXTS.map((ext) => `${base}${ext}`)];
+
+      for (const candidate of candidates) {
+        if (await isFile(candidate)) {
+          return candidate.replace(/\\/g, '/');
+        }
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.ts
+++ b/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.ts
@@ -14,6 +14,7 @@ const ALIAS_EXTS = ['.tsx', '.ts', '.jsx', '.js', '.vue', '.svelte', '.mts', '.m
 async function isFile(candidate: string): Promise<boolean> {
   try {
     await access(candidate);
+
     return true;
   } catch {
     return false;

--- a/packages/@storybook-astro/framework/src/middleware.ts
+++ b/packages/@storybook-astro/framework/src/middleware.ts
@@ -6,6 +6,7 @@ import { ensureAstroPassthroughImageService } from './astroImageService.ts';
 import { createAstroRenderHandler, type HandlerProps } from './astroRenderHandler.ts';
 import type { Integration } from './integrations/index.ts';
 import type { SanitizationOptions } from './lib/sanitization.ts';
+import { resolveAliasedIsland } from './lib/resolve-aliased-island.ts';
 import { resolveStoryModuleMock } from './module-mocks.ts';
 import { addRenderers, resolveClientModules } from 'virtual:astro-container-renderers';
 
@@ -18,6 +19,7 @@ type HandlerFactoryOptions = {
   loadModule?: (id: string) => Promise<{ default: unknown }>;
   invalidateModuleGraph?: () => void;
   resolveModule?: (specifier: string) => string | undefined;
+  resolveFrom?: string;
 };
 
 export type { HandlerProps };
@@ -50,6 +52,19 @@ export async function handlerFactory(
 
       if (resolution) {
         return resolution;
+      }
+
+      // Last resort: an island imported via a tsconfig path alias (e.g. `@/...`)
+      // has its raw aliased specifier baked into the island's component-url.
+      // Resolve it to an on-disk file and hand back a `/@fs/` URL the dev Vite
+      // server can serve so the island still hydrates.
+      const aliasedIsland = await resolveAliasedIsland(
+        specifier,
+        options?.resolveFrom ?? process.cwd()
+      );
+
+      if (aliasedIsland) {
+        return `/@fs/${aliasedIsland}`;
       }
 
       return specifier;

--- a/packages/@storybook-astro/framework/src/productionRenderRuntime.ts
+++ b/packages/@storybook-astro/framework/src/productionRenderRuntime.ts
@@ -61,7 +61,8 @@ export async function createProductionRenderRuntime(
     const astroContainer = await createProductionAstroContainer({
       integrations: options.integrations,
       resolveClientModule,
-      viteServer
+      viteServer,
+      resolveFrom: options.resolveFrom
     });
 
     const loadModule = async (moduleId: string) => {

--- a/packages/@storybook-astro/framework/src/storySsrVite.ts
+++ b/packages/@storybook-astro/framework/src/storySsrVite.ts
@@ -4,6 +4,7 @@ import type { experimental_AstroContainer as AstroContainer } from 'astro/contai
 import { ensureAstroPassthroughImageService } from './astroImageService.ts';
 import { importAstroConfig } from './importAstroConfig.ts';
 import type { Integration } from './integrations/index.ts';
+import { resolveAliasedIsland } from './lib/resolve-aliased-island.ts';
 import { ssrLoadModuleWithFsFallback } from './lib/ssr-load-module-with-fs-fallback.ts';
 import { resolveStoryModuleMock } from './module-mocks.ts';
 import type { FrameworkOptions } from './types.ts';
@@ -109,6 +110,7 @@ export async function createProductionAstroContainer(options: {
   integrations: Integration[];
   resolveClientModule: (specifier: string) => string | undefined;
   viteServer: ViteDevServer;
+  resolveFrom: string;
 }) {
   ensureAstroPassthroughImageService();
 
@@ -136,6 +138,15 @@ export async function createProductionAstroContainer(options: {
 
       if (resolution) {
         return resolution;
+      }
+
+      // Last resort: an island imported via a tsconfig path alias (e.g. `@/...`)
+      // never matches the static map under its raw specifier. Resolve the alias
+      // to an on-disk path and look that up in the built module map instead.
+      const abs = await resolveAliasedIsland(specifier, options.resolveFrom);
+
+      if (abs) {
+        return options.resolveClientModule(abs) ?? specifier;
       }
 
       return specifier;

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.test.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.test.ts
@@ -91,6 +91,7 @@ describe('collectHydratedComponentPaths', () => {
     // inputs. This test confirms the alias is resolved and included.
     await mkdir(join(tmpDir, 'src', 'components'), { recursive: true });
     const counterFile = join(tmpDir, 'src', 'components', 'Counter.tsx');
+
     await writeFile(counterFile, `export default function Counter() { return null; }`);
     await writeFile(join(tmpDir, 'Island.astro'), `---\nimport Counter from '@/components/Counter';\n---\n<Counter client:visible />`);
     await writeFile(

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.test.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
@@ -22,7 +22,7 @@ describe('collectHydratedComponentPaths', () => {
     await writeFile(astroFile, `---\nimport Helper from './Helper.tsx';\n---`);
     await writeFile(namedOnlyTsx, `export const Helper = () => <div />;`);
 
-    const result = await collectHydratedComponentPaths(astroFile);
+    const result = await collectHydratedComponentPaths(astroFile, tmpDir);
 
     expect(result).not.toContain(namedOnlyTsx.replace(/\\/g, '/'));
   });
@@ -34,7 +34,7 @@ describe('collectHydratedComponentPaths', () => {
     await writeFile(astroFile, `---\nimport Button from './Button.tsx';\n---`);
     await writeFile(defaultTsx, `export default function Button() { return <div />; }`);
 
-    const result = await collectHydratedComponentPaths(astroFile);
+    const result = await collectHydratedComponentPaths(astroFile, tmpDir);
 
     expect(result).toContain(defaultTsx.replace(/\\/g, '/'));
   });
@@ -48,7 +48,7 @@ describe('collectHydratedComponentPaths', () => {
     await writeFile(astroFile, `---\nimport Counter from './Counter.svelte';\n---`);
     await writeFile(svelteFile, `<script>\n  let count = 0;\n</script>\n<button>{count}</button>`);
 
-    const result = await collectHydratedComponentPaths(astroFile);
+    const result = await collectHydratedComponentPaths(astroFile, tmpDir);
 
     expect(result).toContain(svelteFile.replace(/\\/g, '/'));
   });
@@ -64,7 +64,7 @@ describe('collectHydratedComponentPaths', () => {
       `<script setup>\nconst count = ref(0);\n</script>\n<template><button>{{ count }}</button></template>`
     );
 
-    const result = await collectHydratedComponentPaths(astroFile);
+    const result = await collectHydratedComponentPaths(astroFile, tmpDir);
 
     expect(result).toContain(vueFile.replace(/\\/g, '/'));
   });
@@ -80,8 +80,26 @@ describe('collectHydratedComponentPaths', () => {
 
     // Don't write missingTsx — resolveLocalImportPath will not find it,
     // so it never reaches hasDefaultExport. Confirm the result is just empty.
-    const result = await collectHydratedComponentPaths(astroFile);
+    const result = await collectHydratedComponentPaths(astroFile, tmpDir);
 
     expect(result).not.toContain(missingTsx.replace(/\\/g, '/'));
+  });
+
+  test('includes a tsconfig-aliased island (the static build fix)', async () => {
+    // Islands imported via path aliases never matched the staticModuleMap because
+    // readLocalImportSpecifiers filtered them out before they could become Rollup
+    // inputs. This test confirms the alias is resolved and included.
+    await mkdir(join(tmpDir, 'src', 'components'), { recursive: true });
+    const counterFile = join(tmpDir, 'src', 'components', 'Counter.tsx');
+    await writeFile(counterFile, `export default function Counter() { return null; }`);
+    await writeFile(join(tmpDir, 'Island.astro'), `---\nimport Counter from '@/components/Counter';\n---\n<Counter client:visible />`);
+    await writeFile(
+      join(tmpDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { paths: { '@/*': ['src/*'] } } }, null, 2)
+    );
+
+    const result = await collectHydratedComponentPaths(join(tmpDir, 'Island.astro'), tmpDir);
+
+    expect(result).toContain(counterFile.replace(/\\/g, '/'));
   });
 });

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
@@ -3,6 +3,7 @@ import { access, copyFile, mkdir, readFile, readdir, stat } from 'node:fs/promis
 import { dirname, resolve } from 'node:path';
 import type { Rollup } from 'vite';
 import type { Integration } from './integrations/index.ts';
+import { resolveAliasedIsland } from './lib/resolve-aliased-island.ts';
 
 /** Resolves the shared virtual module ids used by both build pipelines. */
 export function resolveVirtualBuildModuleId(id: string) {
@@ -77,7 +78,10 @@ export async function emitHydratedComponentEntriesFromAstroFile(options: {
   resolveFrom: string;
   componentEntrypointRefs: Map<string, string>;
 }) {
-  const hydratedComponentPaths = await collectHydratedComponentPaths(options.astroFilePath);
+  const hydratedComponentPaths = await collectHydratedComponentPaths(
+    options.astroFilePath,
+    options.resolveFrom
+  );
 
   for (const resolvedImportPath of hydratedComponentPaths) {
 
@@ -96,14 +100,18 @@ export async function emitHydratedComponentEntriesFromAstroFile(options: {
 }
 
 /** Collects the framework component files one Astro component hydrates in the browser. */
-export async function collectHydratedComponentPaths(astroFilePath: string) {
+export async function collectHydratedComponentPaths(astroFilePath: string, resolveFrom: string) {
   // Only Astro components create islands, so only their framework imports
   // need standalone client chunks in built Storybook output.
-  const localImportSpecifiers = await readLocalImportSpecifiers(astroFilePath);
+  const allImportSpecifiers = await readAllImportSpecifiers(astroFilePath);
   const hydratedComponentPaths: string[] = [];
 
-  for (const specifier of localImportSpecifiers) {
-    const resolvedImportPath = await resolveLocalImportPath(astroFilePath, specifier);
+  for (const specifier of allImportSpecifiers) {
+    // Resolve the specifier to an on-disk path — relative imports use the
+    // importer's directory; aliased imports go through the tsconfig paths map.
+    const resolvedImportPath = specifier.startsWith('.')
+      ? await resolveLocalImportPath(astroFilePath, specifier)
+      : await resolveAliasedIsland(specifier, resolveFrom);
 
     if (!resolvedImportPath) {
       continue;
@@ -385,20 +393,25 @@ async function copyLocalRuntimeDependencies(
   }
 }
 
-/** Reads local import specifiers from source files that can participate in the SSR runtime. */
-async function readLocalImportSpecifiers(filePath: string) {
+const IMPORT_RE =
+  /(?:import|export)\s+(?:[^'"`]*?\s+from\s+)?['"`]([^'"`]+)['"`]|import\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
+
+/** Returns all import specifiers found in the file (relative, aliased, and package). */
+async function readAllImportSpecifiers(filePath: string): Promise<string[]> {
   if (!/\.(astro|[cm]?[jt]sx?|vue|svelte)$/.test(filePath)) {
     return [];
   }
 
   const source = await readFile(filePath, 'utf-8');
-  const matches = source.matchAll(
-    /(?:import|export)\s+(?:[^'"`]*?\s+from\s+)?['"`]([^'"`]+)['"`]|import\(\s*['"`]([^'"`]+)['"`]\s*\)/g
-  );
 
-  return Array.from(matches, (match) => match[1] ?? match[2]).filter(
-    (specifier): specifier is string => Boolean(specifier) && specifier.startsWith('.')
+  return Array.from(source.matchAll(IMPORT_RE), (match) => match[1] ?? match[2]).filter(
+    (specifier): specifier is string => Boolean(specifier)
   );
+}
+
+/** Reads local (relative) import specifiers from source files that can participate in the SSR runtime. */
+async function readLocalImportSpecifiers(filePath: string) {
+  return (await readAllImportSpecifiers(filePath)).filter((s) => s.startsWith('.'));
 }
 
 /** Resolves one relative import the same way the project source tree would on disk. */

--- a/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
+++ b/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
@@ -45,7 +45,8 @@ export async function vitePluginStorybookAstroMiddleware(options: FrameworkOptio
         loadModule: (id: string) =>
           ssrLoadModuleWithFsFallback(viteServer!, id, {
             fixStacktrace: true
-          })
+          }),
+        resolveFrom
       });
 
       let handlerPromise = createHandler();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3657,6 +3657,7 @@ __metadata:
     hono: "npm:^4.11.12"
     sanitize-html: "npm:^2.17.0"
     storybook-solidjs: "npm:^1.0.0-beta.7"
+    tsconfck: "npm:^3.1.6"
     tsup: "npm:^8.5.1"
     vite: "npm:^6.4.1 || ^7.0.0 || ^8.0.0"
     vite-plugin-solid: "npm:^2.11.10"


### PR DESCRIPTION
## Problem

Islands embedded in `.astro` components fail to hydrate when imported via a tsconfig `paths` alias (e.g. `@/components/Counter`). The raw aliased specifier is baked into `<astro-island component-url>` and `import()`d verbatim at runtime, so no Vite resolver ever touches it:

```
[astro-island] Error hydrating @/components/Counter
  TypeError: Failed to resolve module specifier '@/components/Counter'
```

Closes the issue originally reported in #91 (contributor's PR stalled on review feedback).

## Root cause

Astro's `AstroContainer.create({ resolve })` callback receives `@/components/Counter` as a literal string. Both the dev and static build paths fall through without resolving it:

- **Dev** (`middleware.ts`): returns the raw specifier; island can't hydrate
- **Static** (`storySsrVite.ts` + `vitePluginAstroBuildShared.ts`): `readLocalImportSpecifiers` filters to `.`-relative imports only, so alias-based islands never enter `hydratedComponentPaths`, never become Rollup inputs, and never land in `staticModuleMap` — any lookup at render time always misses

## Fix

### `lib/resolve-aliased-island.ts` (new)

A last-resort resolver for aliased specifiers using `tsconfck` (already a transitive dep via Vite) rather than a homegrown JSON stripper:

- Handles `extends` chains, `baseUrl`, and multiple path targets correctly
- Async throughout (`node:fs/promises`)
- No implicit `@/→src/` fallback — requires an explicit `paths` entry
- No process-wide stale cache

### Static build fix (the critical gap in #91)

`collectHydratedComponentPaths` now also resolves non-relative specifiers via `resolveAliasedIsland`, so aliased islands become Rollup inputs and land in `staticModuleMap` before the container's `resolve` callback ever runs.

### `resolveFrom` threading

`handlerFactory` and `createProductionAstroContainer` now accept and use `resolveFrom` instead of `process.cwd()`, matching how every other piece of the framework handles project root resolution.

## Testing

- 13 new unit tests for `resolve-aliased-island.ts`: basic alias, `baseUrl`, multiple targets (fallback to second), custom alias prefix, missing file → `undefined`, no `paths` → `undefined`, absent tsconfig, and all guard cases
- Existing `collectHydratedComponentPaths` tests updated for the new `resolveFrom` parameter; new test confirms aliased islands are discovered for the static build
- All 90 framework unit tests pass; all integration tests (astro5, astro6, components) pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)