### PR TITLE
feat(framework): auto-load fonts and vite.plugins from astro.config

### DIFF
--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -23,7 +23,7 @@ Enable composing Astro components by passing them as props to other Astro compon
 
 ### Astro 6 Font Provider API Integration
 
-Shipped in 1.4.0. Pass the same `fonts` array from `astro.config.*` as `framework.options.fonts` in `.storybook/main.js` and the `<Font>` component renders real `@font-face` CSS in dev and static builds. See the [Styling guide](/guides/styling/#astro-font-provider-api) for setup.
+Shipped. The `<Font>` component renders real `@font-face` CSS in dev and static builds, driven by the `fonts:` array in your `astro.config.*` (auto-loaded — no mirror into `.storybook/main.js` required). See the [Styling guide](/guides/styling/#astro-font-provider-api).
 
 **Still to do**:
 - Preload `<link>` tag emission
@@ -31,15 +31,12 @@ Shipped in 1.4.0. Pass the same `fonts` array from `astro.config.*` as `framewor
 - Build-time font file emission to the static output (current builds rely on the remote URLs returned by the provider)
 - Wire fonts through the server-build pipeline (only the static prerender path is plumbed today)
 
-### Auto-detect CSS Frameworks from Astro Config
+### Auto-load Astro Config into Storybook
 
-Automatically detect and configure CSS utility frameworks (UnoCSS, Tailwind CSS, etc.) registered as Astro integrations, so their Vite plugins are available in Storybook without manual `viteFinal` configuration.
+Shipped. Anything declared in `astro.config.*` is picked up by Storybook automatically: `integrations:` (e.g. `astro-icon`, `unocss/astro`, `@astrojs/tailwind`), top-level `fonts:`, and `vite.plugins:` (e.g. `@tailwindcss/vite`, `unocss/vite`). Users no longer need to duplicate any of these into `.storybook/main.js`.
 
-**Partially shipped (1.4.0)**: Integrations declared in `astro.config.*` — including CSS-framework integrations like `unocss/astro` and `@astrojs/tailwind` — are now auto-loaded into both the Storybook Vite server and the internal Astro SSR server. Their Vite plugins are registered automatically; users no longer need to duplicate those integrations in `.storybook/main.js`.
-
-**Still to do**:
-- CSS frameworks added as raw Vite plugins rather than Astro integrations (e.g. `@tailwindcss/vite`, `unocss/vite`) still require manual `viteFinal` setup
-- Virtual module preview imports (e.g. `import 'virtual:uno.css'`) still must be added to `.storybook/preview.js` by hand
+**Intentionally out of scope**:
+- Virtual module preview imports (e.g. `import 'virtual:uno.css'`) — Storybook can't know which ones your preview should pull in, so these stay in `.storybook/preview.js` by hand.
 
 ### Decorator Support
 

--- a/apps/website/src/content/docs/guides/styling.md
+++ b/apps/website/src/content/docs/guides/styling.md
@@ -3,7 +3,7 @@ title: Styling
 description: Set up global CSS, CSS frameworks, fonts, and static assets in Storybook.
 ---
 
-Astro component scoped styles work automatically — Storybook Astro handles them during rendering. But global styles, CSS utility frameworks, and fonts loaded outside your components (e.g. in a layout's `<head>`) require manual setup.
+Astro component scoped styles work automatically — Storybook Astro handles them during rendering. Anything declared in your `astro.config.*` (integrations, `vite.plugins`, `fonts`) is also picked up automatically, so most projects need very little Storybook-specific wiring. The patterns below cover the cases that do need attention: global stylesheets and design tokens that live outside `astro.config.*`, path aliases, fonts loaded outside the Font Provider API, and static assets.
 
 ## Global CSS
 
@@ -72,17 +72,19 @@ Because Storybook never renders that component, the variables won't exist. Copy 
 
 ## CSS utility frameworks
 
-CSS frameworks like [Tailwind CSS](https://tailwindcss.com/) and [UnoCSS](https://unocss.dev/) can be wired into Storybook in two ways depending on how they're configured in your project.
-
-:::tip
-**As of 1.4.0**, integrations declared in `astro.config.*` (e.g. `unocss/astro`, `@astrojs/tailwind`) are auto-loaded into Storybook's Vite pipeline — no `viteFinal` step required. You still need to import the framework's CSS entry or virtual module in `.storybook/preview.js` so it reaches the story canvas.
-
-The examples below cover the case where the framework is added as a raw Vite plugin (`@tailwindcss/vite`, `unocss/vite`) rather than as an Astro integration; those still need `viteFinal` registration.
-:::
+CSS frameworks like [Tailwind CSS](https://tailwindcss.com/) and [UnoCSS](https://unocss.dev/) configured in `astro.config.*` — either as an Astro integration (`@astrojs/tailwind`, `unocss/astro`) or as a Vite plugin under `vite.plugins` (`@tailwindcss/vite`, `unocss/vite`) — are picked up by Storybook automatically. You only need to import the framework's CSS entry or virtual module in `.storybook/preview.js` so it reaches the story canvas.
 
 ### Tailwind CSS
 
-For Tailwind CSS v4+ (which uses a Vite plugin), register the plugin in `viteFinal` and import your Tailwind CSS entry file in `preview.js`:
+```javascript
+// .storybook/preview.js
+import '../src/styles/tailwind.css'; // your project's @import 'tailwindcss' entrypoint
+import './preview.css';
+```
+
+For Tailwind CSS v3 (which uses PostCSS), no plugin registration is needed at all — just ensure your global CSS with `@tailwind` directives is imported in `.storybook/preview.css` and your `postcss.config.js` is in place.
+
+If you want Tailwind enabled in Storybook *only* (not in your main Astro app), register the plugin yourself with `viteFinal`:
 
 ```javascript
 // .storybook/main.js
@@ -95,49 +97,24 @@ export default {
     options: {},
   },
   async viteFinal(config) {
-    config.plugins = config.plugins || [];
+    config.plugins = config.plugins ?? [];
     config.plugins.push(tailwindcss());
     return config;
   },
 };
 ```
 
-```javascript
-// .storybook/preview.js
-import '../src/styles/tailwind.css'; // your project's @import 'tailwindcss' entrypoint
-import './preview.css';
-```
-
-For Tailwind CSS v3 (which uses PostCSS), no `viteFinal` changes are needed — just ensure your global CSS with `@tailwind` directives is imported in `.storybook/preview.css` and your `postcss.config.js` is in place.
-
 ### UnoCSS
 
 ```javascript
-// .storybook/main.js
-import UnoCSS from 'unocss/vite';
-
-export default {
-  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  framework: {
-    name: '@storybook-astro/framework',
-    options: {},
-  },
-  async viteFinal(config) {
-    config.plugins = config.plugins || [];
-    config.plugins.push(UnoCSS());
-    return config;
-  },
-};
-```
-
-Then import UnoCSS's generated stylesheet in `.storybook/preview.js`:
-
-```javascript
+// .storybook/preview.js
 import 'virtual:uno.css';
 import './preview.css';
 ```
 
 UnoCSS reads your project's `uno.config.ts` automatically, so your presets (e.g. `presetWind`, `presetIcons`, `presetTypography`) will apply.
+
+The same Storybook-only `viteFinal` pattern shown for Tailwind works for UnoCSS — register `unocss/vite` if it isn't already in `astro.config.*`.
 
 ## Path aliases
 
@@ -171,48 +148,40 @@ Match whatever aliases you have in your `astro.config.*` — `@`, `~`, `#`, etc.
 
 ### Astro Font Provider API
 
-If your project uses Astro 6's [Font Provider API](https://docs.astro.build/en/reference/font-provider-reference/) — `fonts: [...]` in `astro.config.*` with providers like `fontProviders.google()`, `fontProviders.local()`, etc. — pass the same array through `framework.options.fonts` and the `<Font>` component will render real `@font-face` CSS in Storybook.
-
-The cleanest pattern is to export the array from `astro.config.*` and import it into `.storybook/main.js`:
+If your project uses Astro 6's [Font Provider API](https://docs.astro.build/en/reference/font-provider-reference/) — `fonts: [...]` in `astro.config.*` with providers like `fontProviders.google()`, `fontProviders.local()`, etc. — Storybook auto-loads the array and the `<Font>` component renders real `@font-face` CSS in stories with no extra wiring.
 
 ```javascript
 // astro.config.mjs
 import { defineConfig, fontProviders } from 'astro/config';
 
-export const fonts = [
-  {
-    provider: fontProviders.google(),
-    name: 'Inter',
-    cssVariable: '--font-inter',
-    weights: [400, 700],
-  },
-];
-
 export default defineConfig({
-  fonts,
-  // ...other config
+  fonts: [
+    {
+      provider: fontProviders.google(),
+      name: 'Inter',
+      cssVariable: '--font-inter',
+      weights: [400, 700],
+    },
+  ],
 });
 ```
 
+Use `<Font cssVariable="--font-inter" />` in your Astro components exactly as you would in a normal Astro page. The provider's `init` and `resolveFont` hooks run during Storybook's SSR setup, producing `@font-face` rules and a `:root { --font-inter: "Inter", sans-serif; }` binding.
+
+To override the auto-loaded array (e.g. use a different set of families in Storybook), pass `framework.options.fonts` explicitly. An explicit empty array renders with no fonts at all:
+
 ```javascript
 // .storybook/main.js
-import { fonts } from '../astro.config.mjs';
-
-export default {
-  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  framework: {
-    name: '@storybook-astro/framework',
-    options: {
-      fonts,
-    },
+framework: {
+  name: '@storybook-astro/framework',
+  options: {
+    fonts: [/* override here, or [] for none */],
   },
-};
+}
 ```
 
-The provider's `init` and `resolveFont` hooks run during Storybook's SSR setup, producing `@font-face` rules and a `:root { --font-inter: "Inter", sans-serif; }` binding. Use `<Font cssVariable="--font-inter" />` in your Astro components exactly as you would in a normal Astro page.
-
 :::caution
-Build-time font file emission, preload `<link>` tags, and Capsize-optimized fallback metrics are not yet covered — see the [Roadmap](/guides/roadmap/#astro-6-font-provider-api-integration). Stories rely on the provider's remote URLs (e.g. `fonts.gstatic.com`) at runtime, so an offline Storybook will fall through to fallback families.
+Stories rely on the provider's remote URLs (e.g. `fonts.gstatic.com`) at runtime — an offline Storybook will fall through to fallback families. Build-time font file emission, preload `<link>` tags, and Capsize-optimized fallback metrics are not generated.
 :::
 
 ### npm font packages
@@ -267,13 +236,12 @@ This makes files in `public/` available at the root URL path — e.g. `public/fo
 
 ## Full example
 
-Here's a complete setup for a project using Tailwind CSS v4, a path alias, an npm font package, and CSS custom properties:
+A typical project — Tailwind v4 and `fonts:` configured in `astro.config.*`, plus a path alias and CSS custom properties — needs very little in `.storybook/main.js`:
 
 ```javascript
 // .storybook/main.js
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import tailwindcss from '@tailwindcss/vite';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -284,21 +252,18 @@ export default {
     options: {},
   },
   async viteFinal(config) {
-    config.plugins = config.plugins ?? [];
-    config.plugins.push(tailwindcss());
-
     config.resolve = config.resolve ?? {};
     config.resolve.alias = config.resolve.alias ?? {};
     config.resolve.alias['~'] = path.resolve(__dirname, '../src');
-
     return config;
   },
 };
 ```
 
+Tailwind and the font families are picked up from `astro.config.*` automatically. Only the path alias and the preview imports need explicit wiring:
+
 ```javascript
 // .storybook/preview.js
-import '@fontsource-variable/inter';
 import '../src/assets/styles/tailwind.css';
 import './preview.css';
 

--- a/apps/website/src/content/docs/reference/feature-support.md
+++ b/apps/website/src/content/docs/reference/feature-support.md
@@ -14,7 +14,7 @@ This page tracks Astro's built-in framework features and their compatibility sta
 - **Client Directives** — `client:load`, `client:only`, etc. for framework components
 - **Static Builds** — `storybook build` with build-time pre-rendering of Astro component stories
 - **`astro:assets` (Image Optimization)** — Components that use `<Image>` from `astro:assets` render correctly in Storybook. Import image assets in story files as `ImageMetadata` and pass them as props — no workarounds required. See [Images](/guides/images/).
-- **Astro Font Provider API** — Pass the same `fonts` array from `astro.config.*` as `framework.options.fonts` in `.storybook/main.js` and the `<Font>` component renders real `@font-face` CSS with provider-resolved URLs (Google, Bunny, Fontsource, local, etc.) in dev and static builds. Preload links, Capsize-optimized fallback metrics, build-time font file emission, and the server-build pipeline are not yet covered — see the [Roadmap](/guides/roadmap/#astro-6-font-provider-api-integration). Setup details in the [Styling guide](/guides/styling/#astro-font-provider-api).
+- **Astro Font Provider API** — The `<Font>` component renders real `@font-face` CSS with provider-resolved URLs (Google, Bunny, Fontsource, local, etc.) in dev and static builds, driven by the `fonts:` array in your `astro.config.*` (auto-loaded). Preload links, Capsize-optimized fallback metrics, build-time font file emission, and the server-build pipeline are not yet covered — see the [Roadmap](/guides/roadmap/#astro-6-font-provider-api-integration). Setup details in the [Styling guide](/guides/styling/#astro-font-provider-api).
 
 ## Not yet supported
 

--- a/integration/astro6/.storybook/main.js
+++ b/integration/astro6/.storybook/main.js
@@ -9,7 +9,6 @@ import {
   svelte,
   alpinejs
 } from '@storybook-astro/framework/integrations';
-import { fonts } from '../astro.config.mjs';
 
 /** @type { import('@storybook-astro/framework').StorybookConfig } */
 const config = {
@@ -25,7 +24,6 @@ const config = {
     options: {
       renderMode: 'static',
       storyRules: './.storybook/story-rules.ts',
-      fonts,
       integrations: [
         react({
           include: ['**/react/**']

--- a/integration/astro6/astro.config.mjs
+++ b/integration/astro6/astro.config.mjs
@@ -7,19 +7,17 @@ import preact from '@astrojs/preact';
 import svelte from '@astrojs/svelte';
 import alpinejs from '@astrojs/alpinejs';
 
-export const fonts = [
-  {
-    provider: fontProviders.google(),
-    name: 'Inter',
-    cssVariable: '--font-inter',
-    weights: [400, 700],
-  },
-];
-
 // https://astro.build/config
 export default defineConfig({
   output: 'static',
-  fonts,
+  fonts: [
+    {
+      provider: fontProviders.google(),
+      name: 'Inter',
+      cssVariable: '--font-inter',
+      weights: [400, 700],
+    },
+  ],
   integrations: [
     react({
       include: ['**/react/**'],

--- a/packages/@storybook-astro/framework/src/loadUserAstroConfig.test.ts
+++ b/packages/@storybook-astro/framework/src/loadUserAstroConfig.test.ts
@@ -1,0 +1,149 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+  loadUserAstroFonts,
+  loadUserAstroIntegrations,
+  loadUserAstroVitePlugins
+} from './loadUserAstroConfig.ts';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'storybook-astro-user-config-'));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeConfig(body: string) {
+  await writeFile(join(tmpDir, 'astro.config.mjs'), body);
+}
+
+describe('loadUserAstroFonts', () => {
+  test('returns the fonts array from astro.config.*', async () => {
+    await writeConfig(`
+      export default {
+        fonts: [
+          {
+            provider: { name: 'fake', resolveFont: () => undefined },
+            name: 'Inter',
+            cssVariable: '--font-inter'
+          },
+          {
+            provider: { name: 'fake', resolveFont: () => undefined },
+            name: 'Roboto',
+            cssVariable: '--font-roboto'
+          }
+        ]
+      };
+    `);
+
+    const fonts = await loadUserAstroFonts(tmpDir);
+
+    expect(fonts).toHaveLength(2);
+    expect(fonts.map((f) => f.cssVariable)).toEqual(['--font-inter', '--font-roboto']);
+  });
+
+  test('returns [] when astro.config.* has no fonts', async () => {
+    await writeConfig(`export default { integrations: [] };`);
+
+    expect(await loadUserAstroFonts(tmpDir)).toEqual([]);
+  });
+
+  test('returns [] when no astro.config.* is present', async () => {
+    expect(await loadUserAstroFonts(tmpDir)).toEqual([]);
+  });
+
+  test('drops entries missing required font-family fields', async () => {
+    await writeConfig(`
+      export default {
+        fonts: [
+          { provider: { name: 'fake', resolveFont: () => undefined }, name: 'Inter', cssVariable: '--font-inter' },
+          { name: 'NoProvider', cssVariable: '--font-x' },
+          'not-an-object'
+        ]
+      };
+    `);
+
+    const fonts = await loadUserAstroFonts(tmpDir);
+
+    expect(fonts).toHaveLength(1);
+    expect(fonts[0].cssVariable).toBe('--font-inter');
+  });
+});
+
+describe('loadUserAstroVitePlugins', () => {
+  test('returns plugins from vite.plugins', async () => {
+    await writeConfig(`
+      export default {
+        vite: {
+          plugins: [
+            { name: 'tailwindcss', enforce: 'pre' },
+            { name: 'unocss/vite' }
+          ]
+        }
+      };
+    `);
+
+    const plugins = await loadUserAstroVitePlugins(tmpDir);
+
+    expect(plugins.map((p) => p.name)).toEqual(['tailwindcss', 'unocss/vite']);
+  });
+
+  test('flattens nested plugin arrays', async () => {
+    await writeConfig(`
+      export default {
+        vite: {
+          plugins: [
+            [{ name: 'a' }, { name: 'b' }],
+            { name: 'c' }
+          ]
+        }
+      };
+    `);
+
+    const plugins = await loadUserAstroVitePlugins(tmpDir);
+
+    expect(plugins.map((p) => p.name)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('returns [] when vite.plugins is missing', async () => {
+    await writeConfig(`export default { vite: {} };`);
+
+    expect(await loadUserAstroVitePlugins(tmpDir)).toEqual([]);
+  });
+
+  test('drops entries without a name', async () => {
+    await writeConfig(`
+      export default {
+        vite: {
+          plugins: [{ name: 'real' }, false, null, undefined, { foo: 'bar' }]
+        }
+      };
+    `);
+
+    const plugins = await loadUserAstroVitePlugins(tmpDir);
+
+    expect(plugins.map((p) => p.name)).toEqual(['real']);
+  });
+});
+
+describe('loadUserAstroIntegrations (regression)', () => {
+  test('still picks up integrations after the refactor', async () => {
+    await writeConfig(`
+      export default {
+        integrations: [
+          { name: 'astro-icon', hooks: {} },
+          { name: 'unocss/astro', hooks: {} }
+        ]
+      };
+    `);
+
+    const integrations = await loadUserAstroIntegrations(tmpDir);
+
+    expect(integrations.map((i) => i.name)).toEqual(['astro-icon', 'unocss/astro']);
+  });
+});

--- a/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
+++ b/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
@@ -1,7 +1,8 @@
-import { loadConfigFromFile } from 'vite';
+import { loadConfigFromFile, type Plugin } from 'vite';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { AstroIntegration } from 'astro';
+import type { StorybookFontFamily } from './vitePluginAstroFonts.ts';
 
 const CONFIG_FILENAMES = [
   'astro.config.ts',
@@ -10,18 +11,45 @@ const CONFIG_FILENAMES = [
   'astro.config.cjs',
 ];
 
-/**
- * Loads integrations declared in the user's astro.config.* so that any Vite
- * plugins they register (e.g. astro-icon's virtual:astro-icon resolver) are
- * present in both the main Storybook Vite server and the internal Astro SSR
- * server.  Returns an empty array on any failure so the calling code can
- * continue with only the framework-level integrations.
- */
-export async function loadUserAstroIntegrations(resolveFrom: string): Promise<AstroIntegration[]> {
-  const configFile = CONFIG_FILENAMES.find(name => existsSync(resolve(resolveFrom, name)));
+interface UserAstroConfigData {
+  integrations: AstroIntegration[];
+  fonts: StorybookFontFamily[];
+  vitePlugins: Plugin[];
+}
+
+const EMPTY: UserAstroConfigData = {
+  integrations: [],
+  fonts: [],
+  vitePlugins: []
+};
+
+// Cache by resolveFrom — config rarely changes during a Storybook session and
+// several call sites read the same data.  Each entry stores the in-flight
+// promise so concurrent callers share the same load.
+const configCache = new Map<string, Promise<UserAstroConfigData>>();
+
+async function loadUserAstroConfigData(resolveFrom: string): Promise<UserAstroConfigData> {
+  let cached = configCache.get(resolveFrom);
+
+  if (!cached) {
+    cached = readUserAstroConfig(resolveFrom);
+    configCache.set(resolveFrom, cached);
+  }
+
+  return cached;
+}
+
+async function readUserAstroConfig(resolveFrom: string): Promise<UserAstroConfigData> {
+  // Vite's loadConfigFromFile resolves a relative configFile against
+  // process.cwd(), not the configRoot argument, so we always hand it an
+  // absolute path to make the lookup deterministic regardless of where
+  // Storybook is invoked from.
+  const configFile = CONFIG_FILENAMES
+    .map((name) => resolve(resolveFrom, name))
+    .find((path) => existsSync(path));
 
   if (!configFile) {
-    return [];
+    return EMPTY;
   }
 
   try {
@@ -32,28 +60,101 @@ export async function loadUserAstroIntegrations(resolveFrom: string): Promise<As
     );
 
     if (!result?.config) {
-      return [];
+      return EMPTY;
     }
 
-    const config = result.config as { integrations?: unknown };
-    const raw = config.integrations;
+    const config = result.config as {
+      integrations?: unknown;
+      fonts?: unknown;
+      vite?: { plugins?: unknown };
+    };
 
-    if (!raw) {
-      return [];
-    }
-
-    // Astro allows nested arrays from conditional spreads (e.g. ...whenX(() => mdx()))
-    const flat = (Array.isArray(raw) ? raw : [raw]).flat(Infinity);
-
-    return flat.filter(
-      (i): i is AstroIntegration => Boolean(i) && typeof i === 'object' && 'name' in i && 'hooks' in i
-    );
+    return {
+      integrations: extractIntegrations(config.integrations),
+      fonts: extractFonts(config.fonts),
+      vitePlugins: extractVitePlugins(config.vite?.plugins)
+    };
   } catch (err) {
     console.warn(
-      '[storybook-astro] Could not load astro.config to discover integrations:',
+      '[storybook-astro] Could not load astro.config to discover integrations / fonts / vite plugins:',
       err instanceof Error ? err.message : String(err)
     );
 
+    return EMPTY;
+  }
+}
+
+function extractIntegrations(raw: unknown): AstroIntegration[] {
+  if (!raw) {
     return [];
   }
+
+  // Astro allows nested arrays from conditional spreads (e.g. ...whenX(() => mdx()))
+  const flat = (Array.isArray(raw) ? raw : [raw]).flat(Infinity);
+
+  return flat.filter(
+    (i): i is AstroIntegration =>
+      Boolean(i) && typeof i === 'object' && 'name' in i && 'hooks' in i
+  );
+}
+
+function extractFonts(raw: unknown): StorybookFontFamily[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw.filter(
+    (f): f is StorybookFontFamily =>
+      Boolean(f) &&
+      typeof f === 'object' &&
+      typeof (f as { name?: unknown }).name === 'string' &&
+      typeof (f as { cssVariable?: unknown }).cssVariable === 'string' &&
+      typeof (f as { provider?: unknown }).provider === 'object'
+  );
+}
+
+function extractVitePlugins(raw: unknown): Plugin[] {
+  if (!raw) {
+    return [];
+  }
+
+  // vite.plugins accepts Plugin | Plugin[] | (Plugin | false | null | undefined)[][] etc.
+  const flat = (Array.isArray(raw) ? raw : [raw]).flat(Infinity);
+
+  return flat.filter(
+    (p): p is Plugin =>
+      Boolean(p) && typeof p === 'object' && 'name' in p && typeof (p as Plugin).name === 'string'
+  );
+}
+
+/**
+ * Loads integrations declared in the user's astro.config.* so that any Vite
+ * plugins they register (e.g. astro-icon's virtual:astro-icon resolver) are
+ * present in both the main Storybook Vite server and the internal Astro SSR
+ * server.  Returns an empty array on any failure so the calling code can
+ * continue with only the framework-level integrations.
+ */
+export async function loadUserAstroIntegrations(resolveFrom: string): Promise<AstroIntegration[]> {
+  return (await loadUserAstroConfigData(resolveFrom)).integrations;
+}
+
+/**
+ * Loads the `fonts:` array from the user's astro.config.* so the Astro 6
+ * Font Provider API works in Storybook without duplicating the array into
+ * `framework.options.fonts`.  Returns [] if the project has no fonts
+ * configured or the config can't be read.
+ */
+export async function loadUserAstroFonts(resolveFrom: string): Promise<StorybookFontFamily[]> {
+  return (await loadUserAstroConfigData(resolveFrom)).fonts;
+}
+
+/**
+ * Loads raw Vite plugins declared at `vite.plugins` in the user's
+ * astro.config.* (e.g. `@tailwindcss/vite`, `unocss/vite`).  These are not
+ * registered through Astro's integration API so `loadUserAstroIntegrations`
+ * does not pick them up; this loader fills the gap so CSS frameworks added
+ * as raw Vite plugins work in Storybook without `viteFinal`.
+ */
+export async function loadUserAstroVitePlugins(resolveFrom: string): Promise<Plugin[]> {
+  return (await loadUserAstroConfigData(resolveFrom)).vitePlugins;
 }

--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -11,6 +11,7 @@ import { vitePluginAstroVueFallback } from './vitePluginAstroVueFallback.ts';
 import { vitePluginAstroToolbarFallback } from './vitePluginAstroToolbarFallback.ts';
 import { resolveSanitizationOptions } from './lib/sanitization.ts';
 import { mergeWithAstroConfig } from './vitePluginAstro.ts';
+import { loadUserAstroFonts, loadUserAstroVitePlugins } from './loadUserAstroConfig.ts';
 
 export const core = {
   builder: '@storybook/builder-vite',
@@ -27,9 +28,26 @@ export const core = {
 export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storybookOptions) => {
   const { configType, presets, configDir } = storybookOptions;
   const frameworkOptions = await presets.apply<FrameworkOptions>('frameworkOptions');
+  const resolveFrom = frameworkOptions.resolveFrom ?? dirname(configDir);
+
+  // Auto-load fonts from the user's astro.config.* when the framework option
+  // is omitted entirely. An explicit empty array means "I want no fonts" and
+  // is honored as-is.
+  const fonts =
+    frameworkOptions.fonts === undefined
+      ? await loadUserAstroFonts(resolveFrom)
+      : frameworkOptions.fonts;
+
+  if (frameworkOptions.fonts === undefined && fonts.length > 0) {
+    console.warn(
+      `[storybook-astro] Auto-loaded ${fonts.length} font famil${fonts.length === 1 ? 'y' : 'ies'} from astro.config: ${fonts.map((f) => f.cssVariable).join(', ')}`
+    );
+  }
+
   const options = {
     ...frameworkOptions,
-    resolveFrom: frameworkOptions.resolveFrom ?? dirname(configDir)
+    resolveFrom,
+    fonts
   } satisfies FrameworkOptions;
 
   if (!config.plugins) {
@@ -109,6 +127,31 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
     mode,
     command
   );
+
+  // Auto-merge raw Vite plugins declared at `vite.plugins` in the user's
+  // astro.config.*.  This covers CSS frameworks added as Vite plugins rather
+  // than Astro integrations (e.g. `@tailwindcss/vite`, `unocss/vite`) which
+  // the integration auto-loader does not pick up.
+  const userVitePlugins = await loadUserAstroVitePlugins(options.resolveFrom);
+
+  if (userVitePlugins.length > 0) {
+    const existingNames = new Set<string>();
+
+    for (const plugin of (finalConfig.plugins ?? []).flat(Infinity) as Array<{ name?: string }>) {
+      if (plugin && typeof plugin === 'object' && typeof plugin.name === 'string') {
+        existingNames.add(plugin.name);
+      }
+    }
+
+    const newPlugins = userVitePlugins.filter((plugin) => !existingNames.has(plugin.name));
+
+    if (newPlugins.length > 0) {
+      console.warn(
+        `[storybook-astro] Auto-loaded ${newPlugins.length} vite plugin${newPlugins.length === 1 ? '' : 's'} from astro.config: ${newPlugins.map((p) => p.name).join(', ')}`
+      );
+      finalConfig.plugins = [...(finalConfig.plugins ?? []), ...newPlugins];
+    }
+  }
 
   // Exclude Astro integration packages from dependency optimization because
   // they import virtual modules that esbuild cannot resolve.


### PR DESCRIPTION
## Summary
Extends the existing astro.config integration auto-loader to also pick up two things that previously required duplication in `.storybook/main.js`:

- **Top-level `fonts:` array** — fed into the existing font-provider plugin when `framework.options.fonts` is undefined. An explicit empty array still means "render with no fonts" and is honored as-is.
- **Raw `vite.plugins`** — merged into Storybook's Vite pipeline after `mergeWithAstroConfig`, with name-based de-duplication against plugins Storybook or Astro already register. Closes the gap for CSS frameworks added as Vite plugins (`@tailwindcss/vite`, `unocss/vite`) rather than Astro integrations.

Both paths log a one-line startup notice listing what they picked up.

## Bug fix included
The existing integration loader silently returned `[]` whenever Storybook was invoked from a directory other than the project root, because Vite's `loadConfigFromFile` resolves a relative config path against `process.cwd()`, not the `configRoot` argument. The loader now resolves to an absolute path before calling `loadConfigFromFile`, which fixes both the new fonts/plugins auto-loads and the existing integration auto-load.

## Reported by
[#105](https://github.com/storybook-astro/storybook-astro/issues/105) — third-party project where both `fonts:` and `vite.plugins: [tailwindcss()]` in `astro.config.ts` were silently ignored by Storybook.

## Files
- `loadUserAstroConfig.ts` — refactored to share a cached config-read across three loaders (`loadUserAstroIntegrations`, `loadUserAstroFonts`, `loadUserAstroVitePlugins`).
- `loadUserAstroConfig.test.ts` — new, 9 unit tests covering extraction, nested arrays, validation, and the regression case for the existing integration loader.
- `preset.ts` — wires the two new auto-loads into `viteFinal`.
- `integration/astro6/.storybook/main.js` + `astro.config.mjs` — drops the manual `fonts` re-export to prove the auto-load works in CI.
- `apps/website/src/content/docs/guides/styling.md` — Styling guide rewritten around auto-load; viteFinal examples remain as the Storybook-only path. Version-specific framing removed.

## Test plan
- [x] `yarn workspace @storybook-astro/framework vitest run` — 99/99 tests pass, including 9 new loader tests
- [x] `yarn lint` clean in `@storybook-astro/framework`
- [x] `yarn build:packages && yarn workspaces foreach -A --topological --interlaced run test` — full workspace suite green
- [x] `yarn workspace @storybook-astro/integration-astro6 build` — static prerender output for `astro-fontdemo--default` still contains `@font-face` rules with real `fonts.gstatic.com` URLs, proving the auto-load works without the manual mirror.
- [ ] Reviewer: sanity check the startup notices appear in dev mode (`yarn workspace @storybook-astro/integration-astro6 dev`) — should see `[storybook-astro] Auto-loaded N font famil... from astro.config: ...`.