### PR TITLE
fix(types): make AstroComponentFactory callable to match Astro language server shape

### DIFF
--- a/apps/website/src/content/docs/guides/troubleshooting.md
+++ b/apps/website/src/content/docs/guides/troubleshooting.md
@@ -218,6 +218,31 @@ Framework integration may not be configured or glob patterns are too restrictive
 
 ---
 
+### `@typescript-eslint/no-unsafe-assignment` on `.astro` imports
+
+**Error message (ESLint):**
+```
+Unsafe assignment of an error typed value.  @typescript-eslint/no-unsafe-assignment
+```
+
+**Cause:**
+
+ESLint's type-checker does not use the Astro language server. When it encounters `import Button from './Button.astro'`, it cannot resolve the `.astro` module and treats `Button` as an error-typed value — which fires `@typescript-eslint/no-unsafe-assignment` (and related rules like `no-unsafe-argument`, `no-unsafe-call`) when the component is passed to story objects or helper functions.
+
+**Solution:**
+
+Add a triple-slash reference directive to your project's `src/env.d.ts`:
+
+```ts
+/// <reference types="@storybook-astro/framework/shim" />
+```
+
+This pulls in an ambient `declare module '*.astro'` declaration that gives ESLint a concrete type for Astro component imports, resolving the rule violation.
+
+If your project does not have a `src/env.d.ts`, create one with just that line, or add it to any `.d.ts` file that is included in your `tsconfig.json`.
+
+---
+
 ## Known Limitations
 
 ### Vite 5 + Solid Integration

--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -51,13 +51,16 @@
       "types": "./dist/preset.d.ts",
       "import": "./dist/preset.js"
     },
+    "./shim": {
+      "types": "./src/shim.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node -e \"require('fs').copyFileSync('src/shim.d.ts','dist/shim.d.ts')\"",
     "dev": "tsup --watch --no-clean",
     "lint": "eslint .",
-    "prepublishOnly": "tsup"
+    "prepublishOnly": "tsup && node -e \"require('fs').copyFileSync('src/shim.d.ts','dist/shim.d.ts')\""
   },
   "devDependencies": {
     "@storybook/preact": "^10.0.0",

--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -57,10 +57,10 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsup && node -e \"require('fs').copyFileSync('src/shim.d.ts','dist/shim.d.ts')\"",
+    "build": "tsup",
     "dev": "tsup --watch --no-clean",
     "lint": "eslint .",
-    "prepublishOnly": "tsup && node -e \"require('fs').copyFileSync('src/shim.d.ts','dist/shim.d.ts')\""
+    "prepublishOnly": "tsup"
   },
   "devDependencies": {
     "@storybook/preact": "^10.0.0",

--- a/packages/@storybook-astro/framework/src/shim.d.ts
+++ b/packages/@storybook-astro/framework/src/shim.d.ts
@@ -5,9 +5,9 @@
 // treated as an error-typed value and fires
 // @typescript-eslint/no-unsafe-assignment on `component: Foo`.
 //
-// This file is automatically referenced from dist/index.d.ts via a triple-slash
-// directive, so any project that imports from @storybook-astro/framework gets
-// these declarations without any manual setup.
+// To opt in, add this to your project's src/env.d.ts:
+//
+//   /// <reference types="@storybook-astro/framework/shim" />
 
 declare module '*.astro' {
   type AstroComponentFactory = {

--- a/packages/@storybook-astro/framework/src/shim.d.ts
+++ b/packages/@storybook-astro/framework/src/shim.d.ts
@@ -1,0 +1,21 @@
+// Ambient type declarations for *.astro file imports.
+//
+// Without the Astro language server, TypeScript (and ESLint's type-checker)
+// cannot resolve `.astro` modules, so `import Foo from './Foo.astro'` is
+// treated as an error-typed value and fires
+// @typescript-eslint/no-unsafe-assignment on `component: Foo`.
+//
+// This file is automatically referenced from dist/index.d.ts via a triple-slash
+// directive, so any project that imports from @storybook-astro/framework gets
+// these declarations without any manual setup.
+
+declare module '*.astro' {
+  type AstroComponentFactory = {
+    (result: unknown, props: unknown, slots: unknown): unknown | Promise<unknown>;
+    isAstroComponentFactory?: boolean;
+    moduleId?: string | undefined;
+  };
+  const Component: AstroComponentFactory;
+
+  export default Component;
+}

--- a/packages/@storybook-astro/framework/tsup.config.ts
+++ b/packages/@storybook-astro/framework/tsup.config.ts
@@ -27,10 +27,6 @@ export default defineConfig({
       'src/vitest/index.ts',
       'src/integrations/index.ts',
     ],
-    // Prepend the shim reference to every generated .d.ts so TypeScript
-    // automatically loads dist/shim.d.ts and the declare module '*.astro'
-    // ambient declaration is globally available to any consumer project.
-    banner: '/// <reference path="./shim.d.ts" />',
   },
   sourcemap: true,
   clean: true,

--- a/packages/@storybook-astro/framework/tsup.config.ts
+++ b/packages/@storybook-astro/framework/tsup.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
       'src/vitest/index.ts',
       'src/integrations/index.ts',
     ],
+    // Prepend the shim reference to every generated .d.ts so TypeScript
+    // automatically loads dist/shim.d.ts and the declare module '*.astro'
+    // ambient declaration is globally available to any consumer project.
+    banner: '/// <reference path="./shim.d.ts" />',
   },
   sourcemap: true,
   clean: true,

--- a/packages/@storybook-astro/renderer/src/types.ts
+++ b/packages/@storybook-astro/renderer/src/types.ts
@@ -1,6 +1,18 @@
 import type { WebRenderer } from 'storybook/internal/types';
 
 /**
+ * Mirrors the shape that the Astro language server gives to `.astro` imports:
+ * a callable factory function with an optional `isAstroComponentFactory` marker.
+ * Keeping this structurally compatible ensures that assigning an imported Astro
+ * component to `component:` is clean under strict TypeScript / ESLint rules.
+ */
+export type AstroComponentFactory = {
+  (result: unknown, props: unknown, slots: unknown): unknown | Promise<unknown>;
+  isAstroComponentFactory?: boolean;
+  moduleId?: string | undefined;
+};
+
+/**
  * Storybook renderer type for Astro components.
  *
  * Astro components are server-side rendered, so storyResult can be an Astro component
@@ -10,12 +22,6 @@ export interface AstroRenderer extends WebRenderer {
   component: AstroComponentFactory | string | HTMLElement | ((...args: unknown[]) => unknown);
   storyResult: AstroComponentFactory | string | HTMLElement;
 }
-
-/** Minimal type for an Astro component factory as seen by the client-side renderer. */
-export type AstroComponentFactory = {
-  isAstroComponentFactory: boolean;
-  moduleId?: string;
-};
 
 export type RenderComponentInput = {
   component: string;


### PR DESCRIPTION
## Summary

- Makes `AstroComponentFactory` a callable type that matches the shape the Astro language server gives to `.astro` imports — fixes `@typescript-eslint/no-unsafe-assignment` when passing Astro components to story objects
- Adds `src/shim.d.ts` with an ambient `declare module '*.astro'` declaration, exported from the package as `@storybook-astro/framework/shim`
- The shim is **opt-in**: users add `/// <reference types="@storybook-astro/framework/shim" />` to their `src/env.d.ts` to suppress ESLint's no-unsafe-assignment on `.astro` imports
- Adds a Troubleshooting guide entry to the website documenting the ESLint issue and the fix

## Why opt-in

ESLint's type-checker doesn't use the Astro language server, so it can't resolve `.astro` modules. The shim provides a concrete type to fill that gap. Making it opt-in avoids automatically injecting an ambient `*.astro` module declaration into every consumer project — which could conflict with a project's own ambient types or with a future Astro-shipped version of the same declaration.

## Test plan

- [ ] Run `yarn lint` in `packages/@storybook-astro/framework` — no errors
- [ ] Confirm `dist/index.d.ts` no longer has a `/// <reference path="./shim.d.ts" />` banner after build
- [ ] Verify adding `/// <reference types="@storybook-astro/framework/shim" />` to a project's `src/env.d.ts` resolves `no-unsafe-assignment` on `.astro` imports
- [ ] Check the Troubleshooting page on the website renders the new section correctly