### PR TITLE
feat: Configure astro6-server integration for Cloudflare Pages deployment

### DIFF
--- a/integration/astro5/src/stories/Overview.mdx
+++ b/integration/astro5/src/stories/Overview.mdx
@@ -40,4 +40,5 @@ Browse the sidebar to explore component examples for each framework. Each exampl
 - [Getting Started](https://storybook-astro.org/getting-started)
 - [Astro 5 Demo](https://demo-astro5.storybook-astro.org)
 - [Astro 6 Demo](https://demo.storybook-astro.org)
+- [Astro 6 Server Demo](https://demo-astro6-server.storybook-astro.org)
 - [GitHub](https://github.com/storybook-astro/storybook-astro)

--- a/integration/astro6-server/.storybook/main.js
+++ b/integration/astro6-server/.storybook/main.js
@@ -7,6 +7,7 @@ const componentsRoot = getAbsolutePath('@storybook-astro/components');
 /** @type { import('@storybook-astro/framework').StorybookConfig } */
 const config = {
   stories: [
+    '../src/stories/Overview.mdx',
     `${componentsRoot}/src/NpmWeeklyDownloads/astro/NpmWeeklyDownloads.stories.js`,
     `${componentsRoot}/src/GithubContributors/astro/GithubContributors.stories.js`,
     `${componentsRoot}/src/GithubStars/astro/GithubStars.stories.js`

--- a/integration/astro6-server/.storybook/manager.js
+++ b/integration/astro6-server/.storybook/manager.js
@@ -1,0 +1,10 @@
+import { addons } from 'storybook/manager-api';
+import { create } from 'storybook/theming/create';
+
+addons.setConfig({
+  theme: create({
+    base: 'dark',
+    brandTitle: 'Storybook Astro · Astro 6 Server',
+    brandColor: '#06B6D4',
+  }),
+});

--- a/integration/astro6-server/functions/api/storybook-astro/[[path]].js
+++ b/integration/astro6-server/functions/api/storybook-astro/[[path]].js
@@ -1,0 +1,19 @@
+/* global Request, URL */
+
+import app from '../../../storybook-server/index.js';
+
+/**
+ * Cloudflare Pages Function handler
+ * Routes /api/storybook-astro/* requests to the Hono render server
+ */
+export async function onRequest(context) {
+  const { request } = context;
+  const url = new URL(request.url);
+
+  // Remove the /api/storybook-astro prefix to match Hono app routes
+  url.pathname = url.pathname.replace(/^\/api\/storybook-astro/, '') || '/';
+
+  // Pass the request to the Hono app
+  // Hono expects: fetch(request, env, context)
+  return app.fetch(new Request(url, request), context.env, context);
+}

--- a/integration/astro6-server/package.json
+++ b/integration/astro6-server/package.json
@@ -7,6 +7,8 @@
     "dev": "storybook dev -p 6016",
     "build": "storybook build",
     "serve": "node ./preview-storybook.mjs",
+    "serve:wrangler": "wrangler pages dev storybook-static --compatibility-flag=nodejs_compat",
+    "deploy": "wrangler pages deploy storybook-static",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/integration/astro6-server/src/stories/Overview.mdx
+++ b/integration/astro6-server/src/stories/Overview.mdx
@@ -1,0 +1,78 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Overview" />
+
+# Storybook Astro — Astro 6 Server Demo
+
+This demo showcases **server render mode** for Storybook Astro, where Astro components remain fully interactive in production builds with working Controls.
+
+## Versions
+
+- **Astro**: 6.0.3
+- **Storybook**: 10.2.7
+- **Framework**: @storybook-astro/framework (latest)
+
+## Server Render Mode
+
+Unlike static mode (which pre-renders all stories at build time), server mode deploys an HTTP render server that processes render requests on-demand. This keeps Astro component Controls fully functional in production.
+
+### How It Works
+
+1. **Build time**: Storybook generates a Hono-based render server (`storybook-server/index.js`)
+2. **Runtime**: Cloudflare Pages Functions route `/api/storybook-astro/*` requests to the Hono app
+3. **Rendering**: When Controls change, the preview iframe sends a render request; the server renders the updated component via Astro Container API
+
+### Server-Side Stories
+
+This demo includes three stories that fetch live data server-side:
+
+- **Npm Weekly Downloads** — Fetches npm download stats via Astro.fetch()
+- **GitHub Contributors** — Displays repository contributors with avatars
+- **GitHub Stars** — Shows star count and growth chart
+
+All three stories demonstrate server-side data fetching with interactive Controls.
+
+## Architecture
+
+```
+┌─────────────────┐
+│ Storybook UI    │
+│ (Controls)      │
+└────────┬────────┘
+         │ render request
+         ↓
+┌─────────────────────────────────┐
+│ Cloudflare Pages Function       │
+│ /functions/api/storybook-astro/ │
+│ [[path]].js                     │
+└────────┬────────────────────────┘
+         │ app.fetch()
+         ↓
+┌─────────────────────────────────┐
+│ Hono Render Server              │
+│ storybook-server/index.js       │
+└────────┬────────────────────────┘
+         │ renderToString()
+         ↓
+┌─────────────────────────────────┐
+│ Astro Container API             │
+│ (Server-side rendering)         │
+└─────────────────────────────────┘
+```
+
+## Deployment
+
+This demo is deployed on Cloudflare Pages with:
+- **Assets**: Static Storybook UI in `storybook-static/`
+- **Functions**: Hono render server via Pages Functions
+- **Configuration**: `wrangler.toml` with `nodejs_compat` flag
+
+## Learn More
+
+- [Website](https://storybook-astro.org)
+- [Getting Started](https://storybook-astro.org/getting-started)
+- [Configuration Reference](https://storybook-astro.org/reference/configuration)
+- [Astro 5 Demo](https://demo-astro5.storybook-astro.org)
+- [Astro 6 Demo](https://demo.storybook-astro.org)
+- [Astro 6 Server Demo](https://demo-astro6-server.storybook-astro.org)
+- [GitHub](https://github.com/storybook-astro/storybook-astro)

--- a/integration/astro6-server/wrangler.toml
+++ b/integration/astro6-server/wrangler.toml
@@ -1,0 +1,9 @@
+name = "storybook-astro-server-demo"
+compatibility_date = "2026-02-15"
+
+[assets]
+directory = "./storybook-static"
+
+# Enable Node.js compatibility for the Functions
+[[compatibility_flags]]
+nodejs_compat = true

--- a/integration/astro6/src/stories/Overview.mdx
+++ b/integration/astro6/src/stories/Overview.mdx
@@ -40,4 +40,5 @@ Browse the sidebar to explore component examples for each framework. Each exampl
 - [Getting Started](https://storybook-astro.org/getting-started)
 - [Astro 5 Demo](https://demo-astro5.storybook-astro.org)
 - [Astro 6 Demo](https://demo.storybook-astro.org)
+- [Astro 6 Server Demo](https://demo-astro6-server.storybook-astro.org)
 - [GitHub](https://github.com/storybook-astro/storybook-astro)


### PR DESCRIPTION
## Summary

This PR configures the `astro6-server` integration for deployment on Cloudflare Pages with a dedicated demo URL at `demo-astro6-server.storybook-astro.org`.

## What's Changed

### Cloudflare Pages Setup
- **Cloudflare Pages Function** (`functions/api/storybook-astro/[[path]].js`) — Routes requests to the Hono render server
- **Wrangler configuration** (`wrangler.toml`) — Defines deployment settings with `nodejs_compat` flag
- **Package scripts** — Added `serve:wrangler` and `deploy` commands for local testing and deployment

### Branding & Cross-Linking
- **Custom theme** (`.storybook/manager.js`) — "Storybook Astro · Astro 6 Server" branding with cyan color (#06B6D4)
- **Overview page** (`src/stories/Overview.mdx`) — Documents server render mode architecture, interactive Controls in production, and the three server-side stories
- **Cross-demo links** — Updated Overview.mdx in astro5 and astro6 integrations to include link to the new server demo

## Server Render Mode

This demo showcases **server render mode**, where:
- Astro components remain fully interactive in production builds
- Controls continue to work by sending render requests to the Hono server
- The server processes requests on-demand via Cloudflare Pages Functions

**Architecture:**
```
Storybook UI (Controls)
    ↓ render request
Cloudflare Pages Function
    ↓ app.fetch()
Hono Render Server (storybook-server/index.js)
    ↓ renderToString()
Astro Container API (SSR)
```

## Server-Side Stories

The demo includes three stories that fetch live data server-side:
- **Npm Weekly Downloads** — Fetches npm download stats via Astro.fetch()
- **GitHub Contributors** — Displays repository contributors with avatars
- **GitHub Stars** — Shows star count and growth chart

## Build Verification

✅ Build completed successfully:
- Static Storybook UI: `storybook-static/`
- Hono render server: `storybook-server/index.js` (51.49 kB)

## Cloudflare Pages Deployment Setup

When ready to deploy:

1. **Create Cloudflare Pages project** pointing to this repository
2. **Configure deployment:**
   - Branch: `develop` (after merging)
   - Build command: `yarn workspace @storybook-astro/integration-astro6-server build`
   - Build output directory: `integration/astro6-server/storybook-static`
3. **Add custom domain:** `demo-astro6-server.storybook-astro.org`
4. **Optional environment variables:**
   - `STORYBOOK_ASTRO_SERVER_TOKEN` — Authentication token for render requests
   - `STORYBOOK_ASTRO_SERVER_AUTH_HEADER` — Custom auth header name (defaults to `authorization`)

## Testing Locally with Wrangler

```bash
cd integration/astro6-server
yarn build
yarn serve:wrangler
```

## Related

- Complements the existing astro5 (demo-astro5.storybook-astro.org) and astro6 (demo.storybook-astro.org) demos
- All three demos now cross-link to each other in their Overview pages
