### PR TITLE
fix(framework): stub @storybook/blocks in SSR prerender to fix 'document is not defined'

### DIFF
--- a/packages/@storybook-astro/framework/src/storySsrVite.ts
+++ b/packages/@storybook-astro/framework/src/storySsrVite.ts
@@ -52,7 +52,8 @@ export async function createStorySsrViteServer(options: {
       vitePluginAstroVueFallback(),
       vitePluginAstroRoutesFallback(),
       vitePluginStoryModuleMocks(),
-      createTrackedSpecifierStubPlugin(options.trackedSpecifiers)
+      createTrackedSpecifierStubPlugin(options.trackedSpecifiers),
+      createStorybookBrowserStubPlugin()
     ]
   });
 
@@ -250,4 +251,30 @@ function createTrackedSpecifierStubPlugin(trackedSpecifiers: Set<string>): Plugi
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+// Stubs Storybook's browser-only packages so story files that import docs
+// blocks (e.g. `import { Controls } from '@storybook/blocks'`) don't
+// trigger `document is not defined` during SSR prerendering. We only need
+// component/args from story modules — docs block components are never called.
+function createStorybookBrowserStubPlugin(): Plugin {
+  const STUB_ID = '\0storybook-astro-browser-stub';
+
+  return {
+    name: 'storybook-astro:storybook-browser-stubs',
+    resolveId(id: string) {
+      if (id === '@storybook/blocks') {
+        return STUB_ID;
+      }
+
+      return null;
+    },
+    load(id: string) {
+      if (id === STUB_ID) {
+        return 'export {};';
+      }
+
+      return null;
+    }
+  } satisfies Plugin;
 }


### PR DESCRIPTION
## Summary

- Story files that import from `@storybook/blocks` (e.g. `import { Controls } from '@storybook/blocks'`) cause `storybook build` to fail with `[storybook-astro:build-prerender] document is not defined`
- During `writeBundle`, our SSR Vite server loads story modules for Astro prerendering; `@storybook/blocks` transitively loads `@storybook/addon-docs` browser chunks which access `document` at module level — crashing in Node.js
- Fix adds `createStorybookBrowserStubPlugin()` to the SSR Vite server, stubbing `@storybook/blocks` as an empty module — the same pattern already used for framework client runtimes; safe because prerendering only reads `component`/`args`, never calls docs block render functions

Closes #120

## Test plan

- [ ] `yarn test` passes (all 8 tests green)
- [ ] `yarn lint` passes clean
- [ ] Manually: add `import { Controls } from '@storybook/blocks'` to a story file in an integration app and confirm `storybook build` completes without `document is not defined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)