### PR TITLE
fix(framework): resolve TypeScript errors across framework package

### DIFF
--- a/packages/@storybook-astro/framework/src/lib/hydratedComponentBuild.ts
+++ b/packages/@storybook-astro/framework/src/lib/hydratedComponentBuild.ts
@@ -46,7 +46,7 @@ export async function buildHydratedComponentAssets(
       (
         await Promise.all(
           resolvedComponentPaths.map((componentPath) =>
-            collectHydratedComponentPaths(componentPath)
+            collectHydratedComponentPaths(componentPath, options.resolveFrom)
           )
         )
       ).flat()
@@ -68,6 +68,10 @@ export async function buildHydratedComponentAssets(
     ...hydratedComponentPaths.map((componentPath, index) => [`component-${index}`, componentPath]),
     ...clientEntrypoints.map((entrypoint, index) => [`renderer-${index}`, entrypoint])
   ]);
+
+  // build.watch is not set, so result is always a build output, never a watcher.
+  type BuiltOutput = { output: (Rollup.OutputAsset | Rollup.OutputChunk)[] };
+
   const buildConfig = {
     root: options.resolveFrom,
     build: {
@@ -77,7 +81,7 @@ export async function buildHydratedComponentAssets(
       manifest: false,
       rollupOptions: {
         input: entryNames,
-        preserveEntrySignatures: 'strict',
+        preserveEntrySignatures: 'strict' as const,
         output: {
           entryFileNames: '_astro/[name]-[hash].js',
           chunkFileNames: '_astro/[name]-[hash].js',
@@ -93,10 +97,10 @@ export async function buildHydratedComponentAssets(
     'production',
     'build'
   );
-  const buildOutput = await build(finalConfig);
-  const output = Array.isArray(buildOutput)
-    ? buildOutput.flatMap((result) => result.output)
-    : buildOutput.output;
+  const buildResult = (await build(finalConfig)) as BuiltOutput | BuiltOutput[];
+  const output = Array.isArray(buildResult)
+    ? buildResult.flatMap((result) => result.output)
+    : buildResult.output;
   const chunksByFileName = new Map<string, Rollup.OutputChunk>();
 
   for (const item of output) {

--- a/packages/@storybook-astro/framework/src/productionRenderRuntime.ts
+++ b/packages/@storybook-astro/framework/src/productionRenderRuntime.ts
@@ -108,9 +108,8 @@ export async function renderProductionStoryToHtml(options: {
   const componentPath = resolveProjectImportPath(options.story.componentPath, options.resolveFrom);
   const storyModule = await options.runtime.loadModule(storyModulePath);
   const defaultStoryMeta = isRecord(storyModule.default) ? storyModule.default : {};
-  const selectedStoryExport = isRecord(storyModule[options.story.exportName])
-    ? storyModule[options.story.exportName]
-    : {};
+  const rawStoryExport: unknown = storyModule[options.story.exportName];
+  const selectedStoryExport: Record<string, unknown> = isRecord(rawStoryExport) ? rawStoryExport : {};
 
   if (typeof defaultStoryMeta.component !== 'function') {
     throw new Error(

--- a/packages/@storybook-astro/framework/src/renderer/renderer-dev.ts
+++ b/packages/@storybook-astro/framework/src/renderer/renderer-dev.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import type {
   RenderComponentInput,
   RenderPromise,

--- a/packages/@storybook-astro/framework/src/vite/serverAuthPlugin.test.ts
+++ b/packages/@storybook-astro/framework/src/vite/serverAuthPlugin.test.ts
@@ -1,8 +1,8 @@
-import type { PluginOption } from 'vite';
+import type { Plugin, PluginOption } from 'vite';
 import { describe, expect, test } from 'vitest';
 import { SERVER_AUTH_MODULE_ID, serverAuthPlugin } from './serverAuthPlugin.ts';
 
-function getPlugin(pluginOption: PluginOption) {
+function getPlugin(pluginOption: PluginOption): Plugin {
   if (Array.isArray(pluginOption)) {
     throw new Error('Expected a single plugin object, but got a plugin array.');
   }
@@ -11,10 +11,10 @@ function getPlugin(pluginOption: PluginOption) {
     throw new Error('Expected plugin option to be an object.');
   }
 
-  return pluginOption;
+  return pluginOption as Plugin;
 }
 
-function getHookHandler<T extends (...args: unknown[]) => unknown>(hook: unknown): T {
+function getHookHandler<T>(hook: unknown): T {
   if (typeof hook === 'function') {
     return hook as T;
   }

--- a/packages/@storybook-astro/framework/src/vite/virtualModulePlugin.test.ts
+++ b/packages/@storybook-astro/framework/src/vite/virtualModulePlugin.test.ts
@@ -1,8 +1,8 @@
-import type { PluginOption } from 'vite';
+import type { Plugin, PluginOption } from 'vite';
 import { describe, expect, test, vi } from 'vitest';
 import { createVirtualModule } from './virtualModulePlugin.ts';
 
-function getPlugin(pluginOption: PluginOption) {
+function getPlugin(pluginOption: PluginOption): Plugin {
   if (Array.isArray(pluginOption)) {
     throw new Error('Expected a single plugin object, but got a plugin array.');
   }
@@ -11,10 +11,10 @@ function getPlugin(pluginOption: PluginOption) {
     throw new Error('Expected plugin option to be an object.');
   }
 
-  return pluginOption;
+  return pluginOption as Plugin;
 }
 
-function getHookHandler<T extends (...args: unknown[]) => unknown>(hook: unknown): T {
+function getHookHandler<T>(hook: unknown): T {
   if (typeof hook === 'function') {
     return hook as T;
   }

--- a/packages/@storybook-astro/framework/src/vitePluginAstro.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstro.ts
@@ -1,4 +1,4 @@
-import { mergeConfig, type InlineConfig } from 'vite';
+import { mergeConfig, type InlineConfig, type Plugin } from 'vite';
 import type { Integration } from './integrations/index.ts';
 import { importAstroConfig } from './importAstroConfig.ts';
 import { loadUserAstroIntegrations } from './loadUserAstroConfig.ts';
@@ -58,13 +58,11 @@ export async function mergeWithAstroConfig(
     command
   });
 
-  const filteredPlugins = astroConfig
-    .plugins!.flat()
-    .filter(
-      (plugin) =>
-        plugin &&
-        'name' in plugin &&
-        !ASTRO_PLUGINS_THAT_ARE_SUPPOSEDLY_NOT_NEEDED_IN_STORYBOOK.includes(plugin.name)
+  const filteredPlugins = (astroConfig.plugins!.flat() as (Plugin | null | undefined | false)[])
+    .filter((plugin): plugin is Plugin =>
+      plugin != null &&
+      plugin !== false &&
+      !ASTRO_PLUGINS_THAT_ARE_SUPPOSEDLY_NOT_NEEDED_IN_STORYBOOK.includes(plugin.name)
     );
 
   return mergeConfig(config, {


### PR DESCRIPTION
## Summary

Fixes all TypeScript errors surfaced by `tsc --noEmit` in the framework package. All are pre-existing from recent additions, none were regressions introduced by PR #121.

- **`hydratedComponentBuild.ts`**: pass missing `resolveFrom` arg to `collectHydratedComponentPaths`; cast `build()` result to exclude `RolldownWatcher` (unreachable without `build.watch`); add `as const` to `preserveEntrySignatures`
- **`productionRenderRuntime.ts`**: extract computed index access to a named variable so TypeScript can narrow it through the `isRecord` type guard
- **`renderer-dev.ts`**: add `/// <reference types="vite/client" />` so `import.meta.hot` is typed
- **`serverAuthPlugin.test.ts`, `virtualModulePlugin.test.ts`**: add `Plugin` return type to `getPlugin`, drop the `(...args: unknown[]) => unknown` constraint from `getHookHandler` (callers specify `T` explicitly; constraint caused a contra-variance error with typed hook signatures)
- **`vitePluginAstro.ts`**: import `Plugin`, cast `plugins.flat()` to a typed array, use a type-predicate filter

## Test plan

- [x] `npx tsc --noEmit` — no errors
- [x] `yarn lint` — no errors
- [x] `yarn test` — 8/8 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)