### PR TITLE
fix(framework): auto-apply *.astro shim via triple-slash reference in dist/index.d.ts

### DIFF
--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -57,10 +57,10 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/patch-shim-ref.mjs",
     "dev": "tsup --watch --no-clean",
     "lint": "eslint .",
-    "prepublishOnly": "tsup"
+    "prepublishOnly": "tsup && node scripts/patch-shim-ref.mjs"
   },
   "devDependencies": {
     "@storybook/preact": "^10.0.0",

--- a/packages/@storybook-astro/framework/scripts/patch-shim-ref.mjs
+++ b/packages/@storybook-astro/framework/scripts/patch-shim-ref.mjs
@@ -1,0 +1,13 @@
+// Prepend the shim reference directive to dist/index.d.ts after tsup finishes.
+// This makes `/// <reference types="@storybook-astro/framework/shim" />` apply
+// automatically when consumers import from @storybook-astro/framework, giving
+// them typed *.astro imports without any manual env.d.ts changes.
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const path = 'dist/index.d.ts';
+const header = '/// <reference types="@storybook-astro/framework/shim" />\n';
+const content = readFileSync(path, 'utf8');
+
+if (!content.startsWith(header)) {
+  writeFileSync(path, header + content);
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/patch-shim-ref.mjs` to the framework package — a small post-build script that prepends `/// <reference types="@storybook-astro/framework/shim" />` to `dist/index.d.ts`
- Updates `build` and `prepublishOnly` scripts to run the patch after `tsup` finishes
- No changes to the shim itself (`src/shim.d.ts`) — it already correctly declares `module '*.astro'` with a typed `AstroComponentFactory`

**Result**: consumers importing from `@storybook-astro/framework` (for `Meta`, `StoryObj`, `composeStories`, etc.) automatically get typed `.astro` imports without needing to add `/// <reference types="@storybook-astro/framework/shim" />` to their own `env.d.ts`.

**Why post-build script instead of `onSuccess`**: tsup's `onSuccess` fires after the ESM build but before DTS generation writes `dist/index.d.ts`, so the header would be overwritten. Running the patch as a separate step after `tsup` exits ensures the DTS file is fully written before we prepend the directive.

Closes #107

## Test plan

- [x] `yarn build:packages` succeeds
- [x] `dist/index.d.ts` starts with `/// <reference types="@storybook-astro/framework/shim" />`
- [x] `yarn lint` passes
- [x] `yarn test` passes (17 test suites, 36 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)