### PR TITLE
fix(framework): inject font CSS into render response so fonts load in browser

### DIFF
--- a/packages/@storybook-astro/framework/src/vitePluginAstroFonts.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroFonts.ts
@@ -163,6 +163,22 @@ export function vitePluginAstroFonts(
   };
 }
 
+/**
+ * Resolves all font families and returns a single CSS string containing
+ * all @font-face declarations and :root CSS variable bindings. Used to
+ * inject font CSS into the browser via Storybook's render response.
+ */
+export async function generateFontCss(families: StorybookFontFamily[], rootDir: string): Promise<string> {
+  if (families.length === 0) {
+    return '';
+  }
+
+  const root = pathToFileURL(rootDir.endsWith('/') ? rootDir : rootDir + '/');
+  const { componentEntries } = await resolveAllFamilies(families, root);
+
+  return componentEntries.map(([, { css }]) => css).join('\n');
+}
+
 async function resolveAllFamilies(
   families: StorybookFontFamily[],
   root: URL

--- a/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
+++ b/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
@@ -7,7 +7,7 @@ import type { FrameworkOptions } from './types.ts';
 import type { Integration } from './integrations/index.ts';
 import { importAstroConfig } from './importAstroConfig.ts';
 import { viteAstroContainerRenderersPlugin } from './viteAstroContainerRenderersPlugin.ts';
-import { vitePluginAstroFonts } from './vitePluginAstroFonts.ts';
+import { vitePluginAstroFonts, generateFontCss } from './vitePluginAstroFonts.ts';
 import { vitePluginAstroIntegrationOptsFallback } from './vitePluginAstroIntegrationOptsFallback.ts';
 import { vitePluginAstroVueFallback } from './vitePluginAstroVueFallback.ts';
 import { vitePluginAstroRoutesFallback } from './vitePluginAstroRoutesFallback.ts';
@@ -26,6 +26,8 @@ export async function vitePluginStorybookAstroMiddleware(options: FrameworkOptio
   const vitePlugin = {
     name: 'storybook-astro-middleware-plugin',
     async configureServer(server) {
+      const fontCss = await generateFontCss(options.fonts ?? [], resolveFrom);
+
       viteServer = await createViteServer(options.integrations ?? [], resolveFrom, options.fonts);
       const storyRulesConfigFilePath = resolveRulesConfigFilePath(options.storyRules, resolveFrom);
 
@@ -65,7 +67,14 @@ export async function vitePluginStorybookAstroMiddleware(options: FrameworkOptio
       server.ws.on('astro:render:request', async (data: RenderRequestMessage['data']) => {
         try {
           const handler = await handlerPromise;
-          const html = await handler(data);
+          const componentHtml = await handler(data);
+          // @font-face rules and :root CSS variable bindings must reach the
+          // browser. The Astro Container API renders a component fragment, not
+          // a full page, so Astro's font pipeline never gets to write them into
+          // a <head>. Prepending a <style> block to the fragment is the
+          // equivalent — @font-face and :root rules apply globally wherever
+          // the <style> element appears in the document.
+          const html = fontCss ? `<style>\n${fontCss}\n</style>${componentHtml}` : componentHtml;
 
           server.ws.send('astro:render:response', {
             html,


### PR DESCRIPTION
## Summary

- Exports `generateFontCss(families, rootDir)` from `vitePluginAstroFonts.ts` — resolves all font families and returns a combined CSS string (`@font-face` blocks + `:root` variable bindings)
- In `viteStorybookAstroMiddlewarePlugin.ts`, generates the font CSS once at server startup and prepends a `<style>` block to every Astro render response

## Root cause

The Astro Container API renders a component fragment, not a full HTML page. In a normal Astro app, the font pipeline writes `@font-face` declarations and `:root { --font-symbols: ... }` bindings into the page `<head>`. In Storybook's SSR context there is no `<head>`, so the browser never receives the font CSS and fonts fail to render — even though `vitePluginAstroFonts` was correctly resolving the virtual modules for SSR.

## Why this works

`@font-face` and `:root` rules apply globally regardless of where the `<style>` element appears in the document. Prepending a `<style>` to the component HTML fragment is equivalent to writing it into the `<head>`. The CSS is generated once at startup (not per-render), so there is no per-request overhead.

Closes #105

## Test plan

- [x] `yarn lint` passes
- [x] `yarn test` passes (all 8 tests across 6 suites)
- [ ] Manual: add a `Material Symbols Outlined` fontsource font to `astro.config`, start Storybook — verify the font CSS appears in the canvas and glyphs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)