### PR TITLE
fix(framework): apply default docs story height to CSF-factory previews

### DIFF
--- a/packages/@storybook-astro/framework/src/index.ts
+++ b/packages/@storybook-astro/framework/src/index.ts
@@ -8,7 +8,9 @@ export type {
 } from 'storybook/internal/types';
 
 import { definePreview as definePreviewBase, type PreviewAddon, type InferTypes, type Preview as CsfPreview } from 'storybook/internal/csf';
+import { combineParameters } from 'storybook/internal/preview-api';
 import type { ArgsStoryFn, ProjectAnnotations, RenderContext, Renderer } from 'storybook/internal/types';
+import { defaultPreviewParameters } from '@storybook-astro/renderer/preview-defaults';
 import type { AstroRenderer } from './portable-stories.ts';
 
 // CSF4 consumers reach `definePreview` from the preview iframe; Node test setup
@@ -99,7 +101,14 @@ export function definePreview<Addons extends PreviewAddon<never>[] = []>(
 
   return definePreviewBase<AstroRenderer, Addons>({
     ...input,
-    parameters: { renderer: 'astro' as const, ...input.parameters },
+    // CSF-factory stories compose only this `definePreview` chain — they never
+    // see the renderer's entry-preview annotation that carries our default
+    // parameters (e.g. the Docs story height). Merge those defaults here, under
+    // the user's parameters so their overrides still win.
+    parameters: combineParameters(defaultPreviewParameters, {
+      renderer: 'astro' as const,
+      ...input.parameters
+    }),
     render: input.render ?? composedRender,
     renderToCanvas: input.renderToCanvas ?? composedRenderToCanvas
   });

--- a/packages/@storybook-astro/renderer/package.json
+++ b/packages/@storybook-astro/renderer/package.json
@@ -37,7 +37,11 @@
       "types": "./dist/types.d.ts",
       "import": "./dist/types.js"
     },
-    "./entry-preview": "./dist/entry-preview.js"
+    "./entry-preview": "./dist/entry-preview.js",
+    "./preview-defaults": {
+      "types": "./dist/preview-defaults.d.ts",
+      "import": "./dist/preview-defaults.js"
+    }
   },
   "scripts": {
     "build": "tsup",

--- a/packages/@storybook-astro/renderer/src/entry-preview.ts
+++ b/packages/@storybook-astro/renderer/src/entry-preview.ts
@@ -2,14 +2,11 @@
 
 import * as astroRenderer from 'virtual:storybook-astro-renderer';
 
+import { defaultPreviewParameters } from './preview-defaults.ts';
+
 export const parameters = {
   renderer: 'astro',
-  docs: {
-    story: {
-      // Storybook's iframe default (150px) is too small for most components.
-      height: '400px',
-    },
-  },
+  ...defaultPreviewParameters,
 };
 
 function isAstroComponent(component: unknown): boolean {

--- a/packages/@storybook-astro/renderer/src/preview-defaults.ts
+++ b/packages/@storybook-astro/renderer/src/preview-defaults.ts
@@ -1,0 +1,16 @@
+// Default preview parameters applied to every Astro story.
+//
+// Kept free of virtual-module imports (unlike entry-preview.ts) so the
+// framework's `definePreview` can merge these synchronously without pulling in
+// the render chain — which breaks Node test setups. The renderer's
+// entry-preview re-exports these for the legacy (CSF3) annotation path, while
+// `definePreview` merges them for CSF-factory consumers, who otherwise bypass
+// the entry-preview annotation entirely (see framework/src/index.ts).
+export const defaultPreviewParameters = {
+  docs: {
+    story: {
+      // Storybook's iframe default (150px) is too small for most components.
+      height: '400px',
+    },
+  },
+};

--- a/packages/@storybook-astro/renderer/tsup.config.ts
+++ b/packages/@storybook-astro/renderer/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     'src/types.ts',
     'src/render.tsx',
     'src/entry-preview.ts',
+    'src/preview-defaults.ts',
     'src/index.ts',
   ],
   format: ['esm'],
@@ -13,9 +14,12 @@ export default defineConfig({
     // render.tsx and entry-preview.ts import virtual modules that cannot be
     // resolved during isolated DTS compilation. Both are runtime-only entries
     // loaded by Vite/Storybook — they have no public API consumers needing DTS.
+    // preview-defaults.ts is virtual-module-free, so the framework imports its
+    // types directly.
     entry: [
       'src/preset.ts',
       'src/types.ts',
+      'src/preview-defaults.ts',
       'src/index.ts',
     ],
   },


### PR DESCRIPTION
## Problem

The default Docs preview height (400px, added in `0cd18dc`) renders correctly in the integration environments but **not** in projects using the new **CSF Factory API** (`definePreview` + `preview.meta()` + `meta.story()`) — e.g. the `central-mosque-bogota` test project, where the Docs preview fell back to Storybook's ~150px default.

## Root cause

The 400px default lives in the renderer's `entry-preview.ts`, delivered via the legacy `previewAnnotations` preset. Confirmed in Storybook's own bundle — `processCSFFile` sets:

```js
csfFile.projectAnnotations = factoryStory.meta.preview.composed;
```

and `storyFromCSFFile` uses `csfFile.projectAnnotations ?? this.projectAnnotations`. So CSF-factory stories compose **only** the `definePreview` chain and **bypass** the store's global annotations where `entry-preview` lives. CSF3 plain-object stories never set it, fall back to the store, and get the height — which is why the integration envs (CSF3) were fine. Nothing was project-specific.

The framework's `definePreview` already bridged `render`/`renderToCanvas` from the renderer but never forwarded `entry-preview`'s `parameters`.

## Fix

Forward the default — don't remove it (it's useful and worked for CSF3 consumers):

- New `packages/@storybook-astro/renderer/src/preview-defaults.ts` — a virtual-module-free single source of truth for the defaults, so the framework can import it synchronously without pulling in the render chain (which breaks Node test setups).
- `entry-preview.ts` re-exports it (CSF3 path unchanged).
- `definePreview` merges it via `combineParameters`, **beneath** the user's `parameters` so overrides still win — closing the CSF4 gap.
- Wired `./preview-defaults` into the renderer's `tsup.config.ts` (build + dts) and `package.json` exports.

This also makes the existing `renderer-entry-preview.d.ts` comment — which already *claimed* parameters get "composed into CSF4 previews" — finally accurate.

## Verification

- Packages build cleanly; dist outputs correct.
- All 18 tests pass.
- Merge against the test project's real preview config (`docs: { codePanel, toc }`) yields `docs.story.height = 400px` while preserving the user's params, and a user override (`600px`) still wins.

> Note: `central-mosque-bogota` consumes the published `1.6.0-canary.1`, so it won't reflect this until a new canary is published (or the local build is linked in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)