### PR TITLE
fix(framework): replace deprecated tsconfck with get-tsconfig

### DIFF
--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -146,9 +146,9 @@
   },
   "dependencies": {
     "@storybook-astro/renderer": "workspace:*",
+    "get-tsconfig": "^4.14.0",
     "hono": "^4.11.12",
     "sanitize-html": "^2.17.0",
-    "tsconfck": "^3.1.6",
     "vite": "^6.4.1 || ^7.0.0 || ^8.0.0"
   }
 }

--- a/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.ts
+++ b/packages/@storybook-astro/framework/src/lib/resolve-aliased-island.ts
@@ -1,6 +1,6 @@
 import { access } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { parse } from 'tsconfck';
+import { getTsconfig } from 'get-tsconfig';
 
 // Islands embedded in `.astro` components are frequently imported through a
 // tsconfig path alias (e.g. `@/components/Counter`). The raw aliased specifier
@@ -47,15 +47,25 @@ export async function resolveAliasedIsland(
     return undefined;
   }
 
-  let result;
+  // getTsconfig walks up from `resolveFrom` to the nearest tsconfig and merges
+  // `extends` for us. We keep our own (deliberately lenient) path matching
+  // below rather than its strict `createPathsMatcher`, which rejects the
+  // non-relative-without-baseUrl paths that the Astro/Vite resolver accepts.
+  let found;
 
   try {
-    result = await parse(resolve(resolveFrom, 'tsconfig.json'));
+    found = getTsconfig(resolveFrom);
   } catch {
+    // Malformed tsconfig (bad JSON, circular extends). This is a last-resort
+    // resolver, so swallow it rather than crash hydration.
     return undefined;
   }
 
-  const compilerOptions = result.tsconfig?.compilerOptions ?? {};
+  if (!found) {
+    return undefined;
+  }
+
+  const compilerOptions = found.config.compilerOptions ?? {};
   const paths: Record<string, string[]> = compilerOptions.paths ?? {};
 
   if (Object.keys(paths).length === 0) {
@@ -63,10 +73,8 @@ export async function resolveAliasedIsland(
   }
 
   // tsconfig paths resolve relative to baseUrl when present, otherwise the
-  // tsconfig directory (which tsconfck gives us as the tsconfig file's dir).
-  const tsconfigDir = result.tsconfigFile
-    ? resolve(result.tsconfigFile, '..')
-    : resolveFrom;
+  // tsconfig directory (which get-tsconfig reports as `found.path`).
+  const tsconfigDir = resolve(found.path, '..');
   const root = compilerOptions.baseUrl
     ? resolve(tsconfigDir, compilerOptions.baseUrl)
     : tsconfigDir;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3654,10 +3654,10 @@ __metadata:
     alpinejs: "npm:^3.14.9"
     astro: "npm:^5.6.1 || ^6.0.0"
     eslint: "npm:^9.39.2"
+    get-tsconfig: "npm:^4.14.0"
     hono: "npm:^4.11.12"
     sanitize-html: "npm:^2.17.0"
     storybook-solidjs: "npm:^1.0.0-beta.7"
-    tsconfck: "npm:^3.1.6"
     tsup: "npm:^8.5.1"
     vite: "npm:^6.4.1 || ^7.0.0 || ^8.0.0"
     vite-plugin-solid: "npm:^2.11.10"
@@ -8088,6 +8088,15 @@ __metadata:
     "@sec-ant/readable-stream": "npm:^0.4.1"
     is-stream: "npm:^4.0.1"
   checksum: 10c0/d70e73857f2eea1826ac570c3a912757dcfbe8a718a033fa0c23e12ac8e7d633195b01710e0559af574cbb5af101009b42df7b6f6b29ceec8dbdf7291931b948
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.14.0":
+  version: 4.14.0
+  resolution: "get-tsconfig@npm:4.14.0"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/abc2b9275468eb589079a0b7a95eb5107c14fdd0ca6dda1bff116fe774ea1f79975421dcb22a0c86b4f820fcc69a7655dddf9b6d6a8a2c06fcb59e19794c0724
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

Installing `@storybook-astro/framework` surfaces warnings traced to its `tsconfck` dependency:

```
WARN  1 deprecated subdependencies found: tsconfck@3.1.6
WARN  @storybook-astro/framework → tsconfck → unmet peer typescript@^5.0.0: found 6.0.3
```

`tsconfck@3.1.6` is both the **latest** published version **and** marked deprecated (`'unmaintained'`) — so no version bump fixes it. It also declares a `typescript@^5` peer (optional, but it warns in TypeScript 6 projects like the `central-mosque-bogota` test project).

The other install warnings are **not** ours: the Node `>=24` engine notice comes from a transitive Storybook/Astro dep (our packages allow Node 20/22/24), and the `eslint-plugin-*` peer warnings are the consuming project's own devDependencies.

## Fix

`tsconfck` had a single consumer — `resolve-aliased-island.ts`, which parses a project's `tsconfig.json` to resolve path-aliased islands (e.g. `@/components/Counter`) to disk during hydration. Swap it for the maintained, peer-dependency-free [`get-tsconfig`](https://github.com/privatenumber/get-tsconfig) (used by tsx/esbuild-kit).

- `get-tsconfig` handles tsconfig discovery + `extends` merging.
- We deliberately **keep our own lenient path-matching loop** rather than adopt its strict `createPathsMatcher`, which throws on non-relative `paths` targets without a `baseUrl` (TS5090) — configs the Astro/Vite resolver and our existing tests accept. This keeps resolution behavior identical.
- Preserved the malformed-tsconfig guard (returns `undefined` rather than crashing hydration).

## Verification

- All 13 `resolve-aliased-island` tests pass unchanged.
- Full suite passes; packages build clean.
- Confirmed `tsconfck` is gone from the framework `dist` and `get-tsconfig` is imported as an external dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)