### PR TITLE
fix(renderer): re-run Astro component scripts on story navigation

### DIFF
--- a/packages/@storybook-astro/renderer/src/render.tsx
+++ b/packages/@storybook-astro/renderer/src/render.tsx
@@ -266,6 +266,15 @@ function cssEscape(value: string) {
   return value.replace(/(["\\])/g, '\\$1');
 }
 
+// Each story render re-injects the component's scripts. The browser executes a
+// given module URL at most once per realm, so re-inserting an external module
+// script (`<script type="module" src="…">` — what Astro compiles hoisted
+// `<script>` blocks into) is a silent no-op on story navigation: client setup
+// runs on the first view and never again until a full page reload. Bump a
+// unique query on the src so the browser re-imports and re-runs it against the
+// freshly rendered DOM. Inline and classic scripts already re-run on insertion.
+let scriptReloadToken = 0;
+
 function invokeScriptTags(element: HTMLElement) {
   Array.from<HTMLScriptElement>(element.querySelectorAll('script')).forEach((oldScript) => {
     const newScript = document.createElement('script');
@@ -273,6 +282,14 @@ function invokeScriptTags(element: HTMLElement) {
     Array.from(oldScript.attributes).forEach((attribute) => {
       newScript.setAttribute(attribute.name, attribute.value);
     });
+
+    const src = newScript.getAttribute('src');
+
+    if (src && newScript.type === 'module') {
+      const separator = src.includes('?') ? '&' : '?';
+
+      newScript.setAttribute('src', `${src}${separator}sbAstroReload=${(scriptReloadToken += 1)}`);
+    }
 
     newScript.appendChild(document.createTextNode(oldScript.innerHTML));
     oldScript.parentNode?.replaceChild(newScript, oldScript);


### PR DESCRIPTION
## Problem

An Astro component's client `<script>` (e.g. one that mounts filter tabs / search) works on a fresh page reload but **stops working when navigating to the story from another story** — until the page is refreshed.

## Root cause

Astro compiles a hoisted `<script>` block into an **external module script** (`<script type="module" src="…component.astro?astro&type=script…">`). The browser executes a given module URL **at most once per realm**, and Storybook navigates between stories inside a single persistent preview iframe without a page reload.

`invokeScriptTags` (render.tsx) re-creates each `<script>` on every story render and copies its attributes — including `src` — verbatim. So after the first view, re-inserting the identical module `src` is a silent no-op: the script's top-level code (`onReady(mountPostFeeds)` etc.) runs once and never again. A full reload gives a fresh realm, which is why reloading "fixes" it.

## Fix

In `invokeScriptTags`, append a unique query (`sbAstroReload=N`) to external **module** script `src` values, so the browser re-imports and re-runs them against the freshly rendered DOM on each story render. Inline and classic scripts already re-run on insertion and are left untouched.

The re-imported entry script's *own* top-level code re-runs (re-invoking the mount fn), while its imported submodules stay cached — so shared helpers keep their identity and idempotency guards (e.g. `data-ready`) still apply.

## Verification

- Confirmed against the running Vite dev server: the cache-busted URL (`…lang.ts&sbAstroReload=1`) returns **200 `text/javascript`** with the identical transformed module (`import { onReady } …; onReady(mountPostFeeds)`) — the only delta was an inlined sourcemap.
- Full test suite passes; packages build clean.
- Manually validated in the `astro-tone` test project (PostFeed filter tabs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)