### PR TITLE
fix(framework): make build-storybook prerender work with docs addon and CSF4

### DIFF
--- a/packages/@storybook-astro/framework/src/index.ts
+++ b/packages/@storybook-astro/framework/src/index.ts
@@ -97,7 +97,14 @@ export function definePreview<Addons extends PreviewAddon<never>[] = []>(
 ): CsfPreview<AstroRenderer & InferTypes<Addons>> {
   // Kick off the renderer load eagerly so the impl is ready by the time
   // Storybook calls renderToCanvas — but don't await, so this stays sync.
-  void loadRendererEntryPreview();
+  // Only do this in a browser: the renderer's entry-preview imports browser-only
+  // modules (and the `virtual:storybook-astro-renderer` graph) that aren't
+  // available when `.storybook/preview.ts` is evaluated under Node during build
+  // prerendering. renderToCanvas never runs there, and the browser path still
+  // loads the renderer lazily via `composedRenderToCanvas`.
+  if (typeof document !== 'undefined') {
+    void loadRendererEntryPreview();
+  }
 
   return definePreviewBase<AstroRenderer, Addons>({
     ...input,

--- a/packages/@storybook-astro/framework/src/productionRenderRuntime.test.ts
+++ b/packages/@storybook-astro/framework/src/productionRenderRuntime.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  renderProductionStoryToHtml,
+  type ProductionRenderRuntime,
+  type ProductionStoryEntry
+} from './productionRenderRuntime.ts';
+
+const resolveFrom = '/project';
+
+const story: ProductionStoryEntry = {
+  id: 'components-button--primary',
+  importPath: './src/Button.stories.ts',
+  componentPath: './src/Button.astro',
+  exportName: 'Primary',
+  title: 'Components/Button',
+  name: 'Primary'
+};
+
+/** A stand-in Astro component factory; only its identity and `function`-ness matter here. */
+function ButtonAstro() {
+  return '';
+}
+
+function createRuntime(storyModule: Record<string, unknown>): {
+  runtime: ProductionRenderRuntime;
+  renderAstroStory: ReturnType<typeof vi.fn>;
+} {
+  const renderAstroStory = vi.fn(async () => '<button>rendered</button>');
+
+  return {
+    runtime: {
+      loadModule: async () => storyModule,
+      renderAstroStory,
+      close: async () => {}
+    },
+    renderAstroStory
+  };
+}
+
+describe('renderProductionStoryToHtml', () => {
+  test('CSF3: reads component from the default export and merges meta + story args', async () => {
+    const { runtime, renderAstroStory } = createRuntime({
+      default: { component: ButtonAstro, args: { label: 'Meta', size: 'lg' } },
+      Primary: { args: { label: 'Primary' } }
+    });
+
+    const html = await renderProductionStoryToHtml({ story, runtime, resolveFrom });
+
+    expect(html).toBe('<button>rendered</button>');
+    expect(renderAstroStory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: '/project/src/Button.astro',
+        args: { label: 'Primary', size: 'lg' }
+      })
+    );
+  });
+
+  test('CSF4 factory: reads component and args from the story export meta with no default export', async () => {
+    const { runtime, renderAstroStory } = createRuntime({
+      // Shape produced by `meta.story()` in Storybook's CSF factories.
+      Primary: {
+        _tag: 'Story',
+        input: { args: { label: 'Primary' } },
+        meta: {
+          _tag: 'Meta',
+          input: { component: ButtonAstro, args: { label: 'Meta', size: 'lg' } }
+        }
+      }
+    });
+
+    const html = await renderProductionStoryToHtml({ story, runtime, resolveFrom });
+
+    expect(html).toBe('<button>rendered</button>');
+    expect(renderAstroStory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: '/project/src/Button.astro',
+        args: { label: 'Primary', size: 'lg' }
+      })
+    );
+  });
+
+  test('skips stories that override the component with a non-Astro render', async () => {
+    function OtherComponent() {
+      return '';
+    }
+
+    const { runtime, renderAstroStory } = createRuntime({
+      default: { component: ButtonAstro },
+      Primary: { component: OtherComponent }
+    });
+
+    const html = await renderProductionStoryToHtml({ story, runtime, resolveFrom });
+
+    expect(html).toBeUndefined();
+    expect(renderAstroStory).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@storybook-astro/framework/src/productionRenderRuntime.ts
+++ b/packages/@storybook-astro/framework/src/productionRenderRuntime.ts
@@ -107,25 +107,23 @@ export async function renderProductionStoryToHtml(options: {
   const storyModulePath = resolveProjectImportPath(options.story.importPath, options.resolveFrom);
   const componentPath = resolveProjectImportPath(options.story.componentPath, options.resolveFrom);
   const storyModule = await options.runtime.loadModule(storyModulePath);
-  const defaultStoryMeta = isRecord(storyModule.default) ? storyModule.default : {};
-  const rawStoryExport: unknown = storyModule[options.story.exportName];
-  const selectedStoryExport: Record<string, unknown> = isRecord(rawStoryExport) ? rawStoryExport : {};
+  const { metaComponent, metaArgs, storyComponent, storyLevelArgs } = resolveStoryAnnotations(
+    storyModule,
+    options.story.exportName
+  );
 
-  if (typeof defaultStoryMeta.component !== 'function') {
+  if (typeof metaComponent !== 'function') {
     throw new Error(
-      `Unable to prerender story "${options.story.id}". Missing default export component in ${options.story.importPath}.`
+      `Unable to prerender story "${options.story.id}". Missing component in ${options.story.importPath}.`
     );
   }
 
   // Build-time prerender only supports stories that keep the meta-level Astro component.
-  if (selectedStoryExport.component && selectedStoryExport.component !== defaultStoryMeta.component) {
+  if (storyComponent && storyComponent !== metaComponent) {
     return undefined;
   }
 
-  const storyArgs = mergeMetaArgsWithStoryArgs(
-    toRecord(defaultStoryMeta.args),
-    toRecord(selectedStoryExport.args)
-  );
+  const storyArgs = mergeMetaArgsWithStoryArgs(metaArgs, storyLevelArgs);
   const { componentArgs, storySlots } = separateStorySlots(storyArgs);
 
   return options.runtime.renderAstroStory({
@@ -138,6 +136,43 @@ export async function renderProductionStoryToHtml(options: {
       name: options.story.name
     }
   });
+}
+
+/**
+ * Reads the meta- and story-level component and args for one story export,
+ * supporting both authoring styles:
+ *
+ * - CSF3: the meta is the module's default export and the named export holds the
+ *   story's own args/component.
+ * - CSF4 factories: there is no default export. The named export is a
+ *   `{ _tag: 'Story', input, meta }` object produced by `meta.story()`, where the
+ *   meta-level annotations live on `meta.input`.
+ */
+function resolveStoryAnnotations(storyModule: LoadedStoryModule, exportName: string) {
+  const rawStoryExport: unknown = storyModule[exportName];
+
+  if (isRecord(rawStoryExport) && rawStoryExport._tag === 'Story') {
+    const storyInput = toRecord(rawStoryExport.input) ?? {};
+    const meta = isRecord(rawStoryExport.meta) ? rawStoryExport.meta : {};
+    const metaInput = toRecord(meta.input) ?? {};
+
+    return {
+      metaComponent: metaInput.component,
+      metaArgs: toRecord(metaInput.args),
+      storyComponent: storyInput.component,
+      storyLevelArgs: toRecord(storyInput.args)
+    };
+  }
+
+  const defaultStoryMeta = isRecord(storyModule.default) ? storyModule.default : {};
+  const selectedStoryExport = isRecord(rawStoryExport) ? rawStoryExport : {};
+
+  return {
+    metaComponent: defaultStoryMeta.component,
+    metaArgs: toRecord(defaultStoryMeta.args),
+    storyComponent: selectedStoryExport.component,
+    storyLevelArgs: toRecord(selectedStoryExport.args)
+  };
 }
 
 function resolveProjectImportPath(importPath: string, resolveFrom: string) {

--- a/packages/@storybook-astro/framework/src/storySsrVite.ts
+++ b/packages/@storybook-astro/framework/src/storySsrVite.ts
@@ -253,17 +253,34 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-// Stubs Storybook's browser-only packages so story files that import docs
-// blocks (e.g. `import { Controls } from '@storybook/blocks'`) don't
-// trigger `document is not defined` during SSR prerendering. We only need
-// component/args from story modules — docs block components are never called.
+// Stubs Storybook's browser-only docs packages so a project's preview config
+// doesn't crash the SSR prerender. Stories import `@storybook/preview`, which
+// loads `.storybook/preview.ts`, which commonly registers the docs addon
+// (`import addonDocs from '@storybook/addon-docs'`). The docs addon pulls in
+// Storybook's UI kit, which reads `document.documentElement` at module load and
+// throws `document is not defined` under Node. The docs UI never runs during
+// prerendering — we only need each story's component and args — so replacing it
+// with a no-op is safe.
+//
+// `@storybook/addon-docs`'s default export is called as a function in preview
+// config (`addonDocs()`), so the stub exports a callable no-op. `blocks` are the
+// docs block components (used only inside MDX, which is not prerendered), and
+// `@storybook/blocks` is the pre-Storybook-10 path for those same blocks.
 function createStorybookBrowserStubPlugin(): Plugin {
+  const STUBBED_SPECIFIERS = new Set([
+    '@storybook/addon-docs',
+    '@storybook/addon-docs/blocks',
+    '@storybook/blocks'
+  ]);
   const STUB_ID = '\0storybook-astro-browser-stub';
 
   return {
     name: 'storybook-astro:storybook-browser-stubs',
+    // Must run before Astro's resolvers, which would otherwise resolve these
+    // bare specifiers to their real (browser-only) files before we can stub them.
+    enforce: 'pre',
     resolveId(id: string) {
-      if (id === '@storybook/blocks') {
+      if (STUBBED_SPECIFIERS.has(id)) {
         return STUB_ID;
       }
 
@@ -271,7 +288,7 @@ function createStorybookBrowserStubPlugin(): Plugin {
     },
     load(id: string) {
       if (id === STUB_ID) {
-        return 'export {};';
+        return 'export default () => ({});';
       }
 
       return null;


### PR DESCRIPTION
## Summary

Fixes #120. Static `build-storybook` failed during the Astro story prerender with `[storybook-astro:build-prerender] document is not defined`. The error originates in our build-prerender step (`writeBundle`), which spins up an Astro SSR server and loads each `.astro` story under Node. Peeling it back revealed three independent root causes, all triggered when the prerender SSR-loads a project's preview config under Node.

## Root causes & fixes

1. **The docs addon crashes on load.** Stories `import preview from "@storybook/preview"` → the project's `.storybook/preview.ts` → `import addonDocs from "@storybook/addon-docs"`. The docs addon pulls in Storybook's browser UI kit (`storybook/internal/components`), which reads `document.documentElement` at module load → crash under Node.
   - `storySsrVite.ts`: extend the browser-stub plugin to also stub `@storybook/addon-docs` and `@storybook/addon-docs/blocks` (Storybook 10 moved blocks there). The stub exports a callable no-op since `addonDocs()` is invoked in preview config, and runs with `enforce: 'pre'` so it intercepts the bare specifier before Astro's resolvers resolve it to real browser code.

2. **`definePreview` eagerly loaded the browser renderer.** It fired `void loadRendererEntryPreview()` unconditionally, importing the browser-only renderer entry (no DOM, no `virtual:storybook-astro-renderer`) during the Node prerender.
   - `index.ts`: only kick off the eager load when a `document` exists (browser). `renderToCanvas` never runs during prerender, and the browser path still lazy-loads the renderer via `composedRenderToCanvas`.

3. **The prerender only understood CSF3.** The affected project uses the CSF4 factory pattern (`const meta = preview.meta(...)`; `export const Default = meta.story({})`) with no default export, so `renderProductionStoryToHtml` reported "Missing component."
   - `productionRenderRuntime.ts`: add `resolveStoryAnnotations` to read the component/args from both CSF3 (default export) and CSF4 (`{ _tag: 'Story', input, meta }`) shapes.

## Tests

- New `productionRenderRuntime.test.ts` covering CSF3, CSF4, and the component-override skip path (the repo had no CSF4 coverage, which is why this regressed).
- Full test suite passes.

## Verification

- The reported CSF4 project now builds successfully — **86 stories prerendered** with real Astro HTML and args applied.
- The CSF3 integration app still builds — **42 stories prerendered**.
- `eslint` clean on all changed files.
