### PR TITLE
fix(renderer): warn when an Astro component is passed as slot content (#128)

### DIFF
--- a/packages/@storybook-astro/renderer/src/render.tsx
+++ b/packages/@storybook-astro/renderer/src/render.tsx
@@ -178,6 +178,39 @@ function isAstroComponent(element: unknown): element is AstroComponentFactory {
   );
 }
 
+// Slot content crosses the render boundary as JSON, so it must be an HTML
+// string — an Astro component reference (a factory function) can't be
+// serialized and the Astro Container expects string slots. Passing a component
+// today renders nothing at all, so warn loudly instead of failing silently.
+// Tracked for first-class support in NESTED_COMPONENT_SUPPORT.md (issue #128).
+function warnIfComponentPassedAsSlotContent(
+  slots: Record<string, unknown>,
+  componentArgs: Record<string, unknown>
+): void {
+  Object.entries(slots).forEach(([name, value]) => {
+    if (isAstroComponent(value)) {
+      console.warn(dedent`
+        Astro slot "${name}" received a component reference, which can't be rendered yet.
+        Slot content must be an HTML string, e.g. slots: { ${name}: '<span>...</span>' }.
+        Passing Astro components as slot content is on the roadmap (issue #128).
+      `);
+    }
+  });
+
+  // A component sitting at the top level of args (React "children" style) is
+  // read as a prop the template never uses, so the slot renders empty.
+  Object.entries(componentArgs).forEach(([name, value]) => {
+    if (isAstroComponent(value)) {
+      console.warn(dedent`
+        Arg "${name}" is an Astro component reference passed as a prop, so it is ignored.
+        To place it in a slot, nest it under args.slots — and note slot content must
+        currently be an HTML string, e.g. slots: { ${name}: '<span>...</span>' }.
+        Passing Astro components as slot content is on the roadmap (issue #128).
+      `);
+    }
+  });
+}
+
 async function renderAstroToCanvas(
   element: AstroComponentFactory,
   args: Record<string, unknown>,
@@ -189,6 +222,9 @@ async function renderAstroToCanvas(
   }
 
   const { slots = {}, ...componentArgs } = args;
+
+  warnIfComponentPassedAsSlotContent(slots, componentArgs);
+
   const response = await astroRenderer.render({
     component: element.moduleId,
     args: componentArgs,


### PR DESCRIPTION
## Summary

Closes the "silent failure" half of #128. When an Astro component is passed as slot content, the slot renders empty with no feedback. This adds a clear `console.warn` for both ways a user hits it.

Slot content crosses the render boundary as JSON, so it must be an HTML string — an Astro component is a factory function that can't be serialized, and the Astro Container expects string slots. Passing a component renders nothing at all, so we now warn instead of failing quietly.

## What it warns on

- A component inside `args.slots` (e.g. `slots: { default: ChildComponent }`).
- A component sitting at the top level of `args` (React `children` style, e.g. `args: { default: ChildComponent }`) — read as a prop the template never uses, so the slot renders empty. This is the exact case from #128.

Detection reuses the existing `isAstroComponent` helper (`isAstroComponentFactory === true`), so it won't false-positive on Storybook action spies, which are plain functions without the factory flag.

## Scope

This is the short-term fix only. First-class support for passing Astro components as slot content remains tracked on the roadmap under "Support Astro Components as Props and Slot Content" (Phase 2) and in `docs/NESTED_COMPONENT_SUPPORT.md`.

## Verification

- `yarn workspace @storybook-astro/renderer build` — passes, including DTS typecheck
- `yarn workspace @storybook-astro/renderer lint` — clean
- Warning string confirmed present in built `dist`

Refs #128
