### PR TITLE
fix(renderer): render Docs stories inline so Controls update the preview (#129)

### DIFF
--- a/packages/@storybook-astro/renderer/src/preview-defaults.ts
+++ b/packages/@storybook-astro/renderer/src/preview-defaults.ts
@@ -9,6 +9,12 @@
 export const defaultPreviewParameters = {
   docs: {
     story: {
+      // Render Docs (autodocs) stories inline rather than in a nested iframe.
+      // Storybook's default (inline: false) embeds each story in an iframe, and
+      // the Docs Controls panel cannot live-update an iframe-embedded story — so
+      // changing controls there does nothing. Inline rendering drives our
+      // `renderToCanvas` directly on every args change, matching the Canvas tab.
+      inline: true,
       // Storybook's iframe default (150px) is too small for most components.
       height: '400px',
     },


### PR DESCRIPTION
## Summary

Fixes #129 — changing props via the Controls panel on the **Docs (autodocs)** page does not update the component preview.

## Root cause

Storybook decides how to render a story inside an autodocs page from `parameters.docs.story.inline`:

- **`inline: true`** → the story renders directly into a `<div>` via the renderer's `renderToCanvas`. The Docs Controls panel re-runs `renderToCanvas` with new args on every change → live updates work.
- **`inline: false`** (Storybook's default) → each story renders in a nested `<iframe>`. The Controls panel on the Docs page cannot live-update an iframe-embedded story — exactly the reported symptom.

Other renderers opt in (e.g. `@storybook/react` sets `docs: { story: { inline: true } }`). The Astro renderer never did — `preview-defaults.ts` only set the story `height`, so `inline` fell through to `false` and autodocs stories rendered as iframes.

## Fix

Set `docs.story.inline: true` in `preview-defaults.ts`. This is merged into both the CSF3 entry-preview path and the CSF4 `definePreview` path, so it covers all consumers. Our `renderToCanvas` already writes into any target element (sets `innerHTML`, hoists/dedupes stylesheets into `document.head`, re-runs scripts), so inline rendering works without a legacy `prepareForInline`.

## Verification

- `yarn build:packages` succeeds; `inline: true` confirmed in built `renderer/dist`.
- Loading the Astro/Card Docs page now shows the story rendered **inline** (0 nested `<iframe>` story embeds), instead of in an iframe.
- To confirm behavior: `yarn workspace @storybook-astro/integration-astro6 dev`, open **Astro/Card → Docs**, change the `title`/`content`/`highlight` controls, and the preview updates live. (In dev mode `isStaticMode` is always `false`, so controls are live even in the static-configured integration.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)