### PR TITLE
feat: Astro components as props and slot content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Astro components can now be passed as **props** (`args: { Icon }`, rendered by the parent via `<Comp />`) and as **slot content** (`args.slots.default`, the React `children` pattern) — closes #128. Component slot content keeps its own rendered markup; plain-string slots are still sanitized.
 - Astro 7 support — verified against Astro 7's Rust compiler (now the default) and Vite 8 (Rolldown). No configuration changes are required to move an Astro 6 setup to Astro 7.
 - New `integration/astro7` and `integration/astro7-server` example apps, plus an `astro7` smoke-test template. CI build, browser-test, smoke-test, and publish workflows now cover Astro 5, 6, and 7.
 

--- a/apps/website/src/content/docs/reference/changelog.md
+++ b/apps/website/src/content/docs/reference/changelog.md
@@ -8,19 +8,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-- Astro 7 support — verified against Astro 7's Rust compiler (now the default) and Vite 8 (Rolldown). No configuration changes are required to move an Astro 6 setup to Astro 7.
-- New `integration/astro7` and `integration/astro7-server` example apps, plus an `astro7` smoke-test template. CI build, browser-test, smoke-test, and publish workflows now cover Astro 5, 6, and 7.
-
-### Changed
-- Peer dependency ranges widened to accept Astro 7 (`astro`, and the `@astrojs/*` framework integrations at their Astro 7 majors) and `@vitejs/plugin-react@6`.
-- `get-tsconfig` dependency aligned to the exact version Astro pins (`5.0.0-beta.4`), so Astro 6.4+/7 and the framework resolve a single deduped copy that exposes both `getTsconfig` and `readTsconfig`.
-
-### Fixed
-- `optimizeDeps.esbuildOptions` is now only set on Vite ≤7, removing the deprecation warning emitted under Vite 8 (the Rolldown optimizer reads `rolldownOptions`).
-
 ## [1.6.0] - 2026-06-19
 
 ### Added

--- a/apps/website/src/content/docs/writing-stories/props.md
+++ b/apps/website/src/content/docs/writing-stories/props.md
@@ -75,6 +75,42 @@ export const MultipleOpen = {
 };
 ```
 
+## Component props
+
+A prop can be another Astro component. The parent renders it from `Astro.props` with `<Comp />`, and Storybook resolves the real component so it renders natively:
+
+```astro
+---
+// IconButton.astro
+const { Icon, label } = Astro.props;
+---
+
+<button>
+  {Icon ? <Icon /> : null}
+  <span>{label}</span>
+</button>
+```
+
+```jsx
+// IconButton.stories.jsx
+import IconButton from './IconButton.astro';
+import StarIcon from './StarIcon.astro';
+
+export default {
+  title: 'Components/IconButton',
+  component: IconButton,
+};
+
+export const WithIcon = {
+  args: {
+    label: 'Favorite',
+    Icon: StarIcon,
+  },
+};
+```
+
+The component is passed as a bare reference and renders with its default props. To place a component inside a `<slot />` rather than a prop, see [Slots](/writing-stories/slots/#passing-a-component-as-slot-content).
+
 ## Shared default args
 
 Set default args at the metadata level so every story inherits them:

--- a/apps/website/src/content/docs/writing-stories/slots.md
+++ b/apps/website/src/content/docs/writing-stories/slots.md
@@ -48,7 +48,7 @@ export const Warning = {
 };
 ```
 
-Slot content is passed as an **HTML string**. You can include any valid HTML — elements, nested markup, inline styles, etc.
+Slot content can be an **HTML string** (any valid HTML — elements, nested markup, inline styles) or an **Astro component** (see [Passing a component as slot content](#passing-a-component-as-slot-content)).
 
 ## Named slots
 
@@ -96,6 +96,50 @@ export const Default = {
 
 Each key in the `slots` object corresponds to a slot name in the component. The `default` key maps to the unnamed `<slot />`.
 
+## Passing a component as slot content
+
+A `slots` entry can be another Astro component instead of an HTML string — the equivalent of React's `children`:
+
+```astro
+---
+// Panel.astro
+const { title } = Astro.props;
+---
+
+<section class="panel">
+  <h2>{title}</h2>
+  <div class="panel-body"><slot /></div>
+</section>
+```
+
+```jsx
+// Panel.stories.jsx
+import Panel from './Panel.astro';
+import Badge from './Badge.astro';
+
+export default {
+  title: 'Components/Panel',
+  component: Panel,
+};
+
+export const WithComponent = {
+  args: {
+    title: 'Status',
+    slots: {
+      default: Badge,
+    },
+  },
+};
+```
+
+The component is server-rendered and its markup is placed into the slot, with its scoped styles intact. This also works for named slots.
+
+A component passed this way renders with its **default props** — the bare component reference is what's placed in the slot. To render slot content with specific props or text, use an HTML string instead.
+
+:::note
+Component slot content keeps its own rendered markup as-is. Plain **string** slot content is still run through HTML [sanitization](/guides/sanitization/), which strips attributes outside the allowlist (e.g. `data-*`).
+:::
+
 ## Combining props and slots
 
 Props and slots are passed together in the same `args` object. Regular properties become `Astro.props`, and the `slots` property is handled separately by the renderer:
@@ -117,7 +161,7 @@ export const Default = {
 
 ## Tips
 
-- **Slot content is HTML** — You write raw HTML strings, not JSX or Astro template syntax.
+- **Slot content is an HTML string or a component** — write raw HTML strings (not JSX or Astro template syntax), or pass an imported Astro component.
 - **Multi-line content** — Use template literals (backtick strings) for readable multi-line slot content.
 - **No slot fallback in stories** — If you don't provide a `slots` entry, the component's `<slot>` fallback content (if any) will render.
 - **Static in builds** — Like other Astro component args, slot content is pre-rendered at build time. It's fully interactive in dev mode.

--- a/docs/NESTED_COMPONENT_SUPPORT.md
+++ b/docs/NESTED_COMPONENT_SUPPORT.md
@@ -12,6 +12,8 @@ Two distinct nesting patterns were identified:
 
 ## Pattern B: Props-based nesting
 
+> **Status: Implemented.** A story can pass an Astro component as a prop (`args: { Icon }`) or as slot content (`args.slots.default`). The client serializes each component to a `{ __astroComponent: true, moduleId }` marker; the server reconstructs it. **Props** resolve back to the real component factory and pass through, so the parent template renders them with `<Comp />` (the Astro Container renders factory-valued props natively — the `<Fragment set:html>` workaround described below is **not** needed and was incorrect). **Slots** render the child to an HTML string, since the Container only accepts string slots; this happens *after* sanitization so a component's own markup isn't stripped, while plain-string slots still are. Implemented across `astroComponentMarker.ts` (renderer), `lib/reconstruct-component-args.ts`, `render.tsx`, `astroRenderHandler.ts`, and `testing/astro-runtime.ts`. Closes #128. The original analysis is kept below for context.
+
 When a story passes an Astro component as a prop (e.g. `<Link Icon={icon}>`), the middleware receives the parent component's `moduleId` but has no knowledge of the nested component — it arrives as a JSX element object, not an Astro component reference. The serialized JSON payload from the client to the server cannot carry live component factories.
 
 ### Proposed Solution

--- a/integration/astro6/package.json
+++ b/integration/astro6/package.json
@@ -23,7 +23,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.6",
     "alpinejs": "^3.14.9",
-    "astro": "6.0.3",
+    "astro": "6.4.4",
     "preact": "^10.28.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/packages/@storybook-astro/framework/src/astroRenderHandler.ts
+++ b/packages/@storybook-astro/framework/src/astroRenderHandler.ts
@@ -2,6 +2,7 @@ import type { experimental_AstroContainer as AstroContainer } from 'astro/contai
 import type { SanitizationOptions } from './lib/sanitization.ts';
 import { resolveSanitizationOptions, sanitizeRenderPayload } from './lib/sanitization.ts';
 import { reviveDateStrings } from './lib/revive-dates.ts';
+import { reconstructProps, reconstructSlots } from './lib/reconstruct-component-args.ts';
 import { runWithStoryRules, type ResolveRulesConfigModule } from './storyRulesRuntime.ts';
 import type { RenderStoryInput } from './types.ts';
 
@@ -86,7 +87,13 @@ export function createAstroRenderHandler(options: CreateAstroRenderHandlerOption
             data.component,
             selectedRules.moduleMocks.size === 0
           );
-          const processedArgs = await processImageMetadata(data.args ?? {});
+          // Resolve Astro components passed as props back to real factories
+          // before the other arg processing (factories pass through those
+          // untouched), so the parent template can render them with `<Comp />`.
+          const reconstructedArgs = await reconstructProps(data.args ?? {}, {
+            loadComponent: (moduleId) => loadPatchedComponent(moduleId)
+          });
+          const processedArgs = await processImageMetadata(reconstructedArgs);
           const revivedArgs = reviveDateStrings(processedArgs);
           const sanitizedPayload = sanitizeRenderPayload(
             {
@@ -96,11 +103,23 @@ export function createAstroRenderHandler(options: CreateAstroRenderHandlerOption
             sanitizationOptions
           );
 
+          // Render component slots to HTML *after* sanitization so a component's
+          // own markup isn't stripped by the slot allowlist (string slots above
+          // still are). Markers pass through sanitization untouched.
+          const renderedSlots = await reconstructSlots(sanitizedPayload.slots, {
+            loadComponent: (moduleId) => loadPatchedComponent(moduleId),
+            renderToHtml: (component) =>
+              options.container.renderToString(
+                component as Parameters<typeof options.container.renderToString>[0],
+                {}
+              )
+          });
+
           return options.container.renderToString(
             patchedComponent as Parameters<typeof options.container.renderToString>[0],
             {
               props: sanitizedPayload.args,
-              slots: sanitizedPayload.slots
+              slots: renderedSlots
             }
           );
         }

--- a/packages/@storybook-astro/framework/src/astroRenderHandler.ts
+++ b/packages/@storybook-astro/framework/src/astroRenderHandler.ts
@@ -1,4 +1,5 @@
 import type { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { markHTMLString } from 'astro/runtime/server/index.js';
 import type { SanitizationOptions } from './lib/sanitization.ts';
 import { resolveSanitizationOptions, sanitizeRenderPayload } from './lib/sanitization.ts';
 import { reviveDateStrings } from './lib/revive-dates.ts';
@@ -119,7 +120,7 @@ export function createAstroRenderHandler(options: CreateAstroRenderHandlerOption
             patchedComponent as Parameters<typeof options.container.renderToString>[0],
             {
               props: sanitizedPayload.args,
-              slots: renderedSlots
+              slots: markRawSlots(renderedSlots)
             }
           );
         }
@@ -135,6 +136,23 @@ export function createAstroRenderHandler(options: CreateAstroRenderHandlerOption
 
     return resultPromise;
   };
+}
+
+/**
+ * Marks each slot's HTML string as already-rendered so the Astro Container emits
+ * it raw instead of escaping it. Astro 5 and 7 render string slots raw anyway,
+ * but Astro 6 escapes an unmarked string slot — this normalizes all versions.
+ * `markHTMLString` tags the string via a global symbol, so it's recognized even
+ * across Astro module instances.
+ */
+export function markRawSlots(slots: Record<string, unknown>): Record<string, unknown> {
+  const marked: Record<string, unknown> = {};
+
+  for (const [name, value] of Object.entries(slots)) {
+    marked[name] = typeof value === 'string' ? markHTMLString(value) : value;
+  }
+
+  return marked;
 }
 
 export function patchCreateAstroCompat(component: unknown): AstroComponentFactory {

--- a/packages/@storybook-astro/framework/src/lib/astro-component-marker.test.ts
+++ b/packages/@storybook-astro/framework/src/lib/astro-component-marker.test.ts
@@ -1,0 +1,48 @@
+import { test, expect, vi } from 'vitest';
+import {
+  ASTRO_COMPONENT_MARKER,
+  isAstroComponentMarker,
+  serializeAstroComponentMarkers
+} from '@storybook-astro/renderer/types';
+
+const factory = (moduleId: string | undefined) =>
+  Object.assign(() => undefined, { isAstroComponentFactory: true as const, moduleId });
+
+test('isAstroComponentMarker requires both the flag and a string moduleId', () => {
+  expect(isAstroComponentMarker({ [ASTRO_COMPONENT_MARKER]: true, moduleId: '/A.astro' })).toBe(true);
+  // A plain object that happens to share one key is not a marker.
+  expect(isAstroComponentMarker({ [ASTRO_COMPONENT_MARKER]: true })).toBe(false);
+  expect(isAstroComponentMarker({ moduleId: '/A.astro' })).toBe(false);
+  expect(isAstroComponentMarker({ [ASTRO_COMPONENT_MARKER]: 'yes', moduleId: '/A.astro' })).toBe(false);
+});
+
+test('serializeAstroComponentMarkers replaces factories with markers, including when nested', () => {
+  const result = serializeAstroComponentMarkers({
+    Icon: factory('/Icon.astro'),
+    nested: { Inner: factory('/Inner.astro') },
+    list: [factory('/A.astro'), 'keep']
+  }) as Record<string, unknown>;
+
+  expect(result.Icon).toEqual({ [ASTRO_COMPONENT_MARKER]: true, moduleId: '/Icon.astro' });
+  expect((result.nested as Record<string, unknown>).Inner).toEqual({
+    [ASTRO_COMPONENT_MARKER]: true,
+    moduleId: '/Inner.astro'
+  });
+  expect((result.list as unknown[])[0]).toEqual({ [ASTRO_COMPONENT_MARKER]: true, moduleId: '/A.astro' });
+  expect((result.list as unknown[])[1]).toBe('keep');
+});
+
+test('serializeAstroComponentMarkers drops a factory with no moduleId and reports it', () => {
+  const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  const result = serializeAstroComponentMarkers({ Icon: factory(undefined) }) as Record<string, unknown>;
+
+  expect(result.Icon).toBeUndefined();
+  expect(error).toHaveBeenCalled();
+
+  error.mockRestore();
+});
+
+test('serializeAstroComponentMarkers leaves non-component values untouched', () => {
+  expect(serializeAstroComponentMarkers({ a: 1, b: 'x', c: null })).toEqual({ a: 1, b: 'x', c: null });
+});

--- a/packages/@storybook-astro/framework/src/lib/reconstruct-component-args.test.ts
+++ b/packages/@storybook-astro/framework/src/lib/reconstruct-component-args.test.ts
@@ -1,0 +1,97 @@
+import { test, expect, vi } from 'vitest';
+import { reconstructProps, reconstructSlots } from './reconstruct-component-args.ts';
+
+const marker = (moduleId: string) => ({ __astroComponent: true as const, moduleId });
+
+// A fake Astro factory: a function carrying the detection flag + moduleId.
+const factory = (moduleId: string) =>
+  Object.assign(() => undefined, { isAstroComponentFactory: true as const, moduleId });
+
+test('reconstructProps resolves a marker to the loaded factory', async () => {
+  const loaded = factory('/Icon.astro');
+  const loadComponent = vi.fn().mockResolvedValue(loaded);
+
+  const result = await reconstructProps({ Icon: marker('/Icon.astro') }, { loadComponent });
+
+  expect(loadComponent).toHaveBeenCalledWith('/Icon.astro');
+  expect(result.Icon).toBe(loaded);
+});
+
+test('reconstructProps passes a raw factory through (testing path)', async () => {
+  const raw = factory('/Icon.astro');
+  const loadComponent = vi.fn();
+
+  const result = await reconstructProps({ Icon: raw }, { loadComponent });
+
+  expect(result.Icon).toBe(raw);
+  expect(loadComponent).not.toHaveBeenCalled();
+});
+
+test('reconstructProps resolves markers nested in objects and arrays', async () => {
+  const loadComponent = vi.fn(async (id: string) => factory(id));
+
+  const result = await reconstructProps(
+    { wrap: { Icon: marker('/A.astro') }, list: [marker('/B.astro'), 'x'] },
+    { loadComponent }
+  );
+
+  const resolvedIcon = (result.wrap as Record<string, unknown>).Icon as { moduleId?: string };
+  const resolvedListItem = (result.list as Array<{ moduleId?: string }>)[0];
+
+  expect(resolvedIcon.moduleId).toBe('/A.astro');
+  expect(resolvedListItem.moduleId).toBe('/B.astro');
+  expect((result.list as unknown[])[1]).toBe('x');
+});
+
+test('reconstructProps preserves identity when there are no component references', async () => {
+  const args = { title: 'hi', meta: { src: '/img.png', width: 10 } };
+  const result = await reconstructProps(args, { loadComponent: vi.fn() });
+
+  expect(result.meta).toBe(args.meta);
+});
+
+test('reconstructSlots renders a marker to HTML via the loaded component', async () => {
+  const loaded = factory('/Child.astro');
+  const loadComponent = vi.fn().mockResolvedValue(loaded);
+  const renderToHtml = vi.fn().mockResolvedValue('<span>child</span>');
+
+  const result = await reconstructSlots({ default: marker('/Child.astro') }, {
+    loadComponent,
+    renderToHtml
+  });
+
+  expect(loadComponent).toHaveBeenCalledWith('/Child.astro');
+  expect(renderToHtml).toHaveBeenCalledWith(loaded);
+  expect(result.default).toBe('<span>child</span>');
+});
+
+test('reconstructSlots renders a raw factory slot and passes strings through', async () => {
+  const renderToHtml = vi.fn().mockResolvedValue('<b>x</b>');
+
+  const result = await reconstructSlots(
+    { default: factory('/Child.astro'), footer: '<p>plain</p>' },
+    { loadComponent: vi.fn(), renderToHtml }
+  );
+
+  expect(result.default).toBe('<b>x</b>');
+  expect(result.footer).toBe('<p>plain</p>');
+});
+
+test('reconstructSlots concatenates an array slot into one HTML string', async () => {
+  const renderToHtml = vi.fn().mockResolvedValue('<i>c</i>');
+
+  const result = await reconstructSlots({ default: [marker('/C.astro'), ' and ', '<u>d</u>'] }, {
+    loadComponent: vi.fn(async (id: string) => factory(id)),
+    renderToHtml
+  });
+
+  expect(result.default).toBe('<i>c</i> and <u>d</u>');
+});
+
+test('reconstructSlots wraps a render failure with the slot name', async () => {
+  const renderToHtml = vi.fn().mockRejectedValue(new Error('boom'));
+
+  await expect(
+    reconstructSlots({ header: factory('/C.astro') }, { loadComponent: vi.fn(), renderToHtml })
+  ).rejects.toThrow(/slot "header".*boom/);
+});

--- a/packages/@storybook-astro/framework/src/lib/reconstruct-component-args.ts
+++ b/packages/@storybook-astro/framework/src/lib/reconstruct-component-args.ts
@@ -1,0 +1,155 @@
+import { isAstroComponentFactory, isAstroComponentMarker } from '@storybook-astro/renderer/types';
+
+/**
+ * Resolves Astro component references that a story passed as props or slot
+ * content back into something the Astro Container can render.
+ *
+ * A component reference arrives either as a serialized marker (the browser /
+ * dev / server path, where it crossed a JSON boundary) or as a real component
+ * factory (the Vitest / portable-stories path, which imports `.astro` files
+ * directly). Both are handled.
+ *
+ * - **Props**: resolved to the real component factory and passed through, so the
+ *   parent template renders them with `<Comp />` (the Container supports this).
+ * - **Slots**: rendered to an HTML string, because the Container only accepts
+ *   string slot content — a factory passed as a slot is stringified verbatim.
+ *
+ * Both callbacks are injected so this is reusable across the dev/server handler
+ * (which loads by moduleId and renders via its container) and the testing path
+ * (where factories are already in hand).
+ */
+type LoadComponent = (moduleId: string) => Promise<unknown>;
+type RenderToHtml = (component: unknown) => Promise<string>;
+
+// Guards against pathological/cyclic arg objects. Component references are leaf
+// replacements, so real nesting is shallow; this is just insurance.
+const MAX_DEPTH = 10;
+
+/**
+ * Resolves component references in **props** back to real component factories,
+ * so the parent template renders them with `<Comp />`. Run this before the
+ * normal arg processing (image/date/sanitize) — factories pass through those
+ * untouched, and a resolved prop must exist before the parent renders.
+ */
+export async function reconstructProps(
+  args: Record<string, unknown>,
+  callbacks: { loadComponent: LoadComponent }
+): Promise<Record<string, unknown>> {
+  return (await resolvePropValue(args, callbacks, 0)) as Record<string, unknown>;
+}
+
+/**
+ * Resolves component references in **slots** to HTML strings (the Container only
+ * accepts string slots). Run this *after* sanitization so a component's rendered
+ * markup — trusted, like a prop-rendered component — isn't stripped by the slot
+ * HTML allowlist, while plain-string slots still are.
+ */
+export async function reconstructSlots(
+  slots: Record<string, unknown>,
+  callbacks: { loadComponent: LoadComponent; renderToHtml: RenderToHtml }
+): Promise<Record<string, unknown>> {
+  const out: Record<string, unknown> = {};
+
+  for (const [name, value] of Object.entries(slots)) {
+    out[name] = await resolveSlotValue(name, value, callbacks);
+  }
+
+  return out;
+}
+
+/**
+ * Walks a prop value, replacing component references with real factories.
+ * Returns the original reference untouched when nothing changed, so unrelated
+ * args keep their identity (e.g. `ImageMetadata` objects the image pipeline
+ * later inspects).
+ */
+async function resolvePropValue(
+  value: unknown,
+  callbacks: { loadComponent: LoadComponent },
+  depth: number
+): Promise<unknown> {
+  if (isAstroComponentMarker(value)) {
+    return callbacks.loadComponent(value.moduleId);
+  }
+
+  // Already a real factory (testing path) — pass it straight through as a prop.
+  if (isAstroComponentFactory(value)) {
+    return value;
+  }
+
+  if (depth >= MAX_DEPTH) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const resolved = await Promise.all(
+      value.map((item) => resolvePropValue(item, callbacks, depth + 1))
+    );
+
+    return resolved.some((item, index) => item !== value[index]) ? resolved : value;
+  }
+
+  if (isPlainObject(value)) {
+    let changed = false;
+    const out: Record<string, unknown> = {};
+
+    for (const [key, nested] of Object.entries(value)) {
+      const resolved = await resolvePropValue(nested, callbacks, depth + 1);
+
+      if (resolved !== nested) {
+        changed = true;
+      }
+
+      out[key] = resolved;
+    }
+
+    return changed ? out : value;
+  }
+
+  return value;
+}
+
+async function resolveSlotValue(
+  name: string,
+  value: unknown,
+  callbacks: { loadComponent: LoadComponent; renderToHtml: RenderToHtml }
+): Promise<unknown> {
+  // An array slot (list of components and/or strings) is concatenated into one
+  // HTML string, which is what the Container expects for a single slot.
+  if (Array.isArray(value)) {
+    const parts = await Promise.all(value.map((item) => resolveSlotValue(name, item, callbacks)));
+
+    return parts.join('');
+  }
+
+  if (isAstroComponentMarker(value)) {
+    const component = await callbacks.loadComponent(value.moduleId);
+
+    return renderSlotComponent(name, component, callbacks);
+  }
+
+  if (isAstroComponentFactory(value)) {
+    return renderSlotComponent(name, value, callbacks);
+  }
+
+  // Plain HTML string (or anything else) passes through unchanged.
+  return value;
+}
+
+async function renderSlotComponent(
+  name: string,
+  component: unknown,
+  callbacks: { renderToHtml: RenderToHtml }
+): Promise<string> {
+  try {
+    return await callbacks.renderToHtml(component);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    throw new Error(`Failed to render Astro component passed to slot "${name}": ${message}`);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/@storybook-astro/framework/src/lib/separate-story-slots.ts
+++ b/packages/@storybook-astro/framework/src/lib/separate-story-slots.ts
@@ -1,0 +1,20 @@
+/**
+ * Splits a story's `args` into component props and slot content. Slot content
+ * lives under the reserved `slots` key (`args.slots.<name>`); everything else is
+ * a prop. Returns `{}` for slots when `args.slots` is absent or not an object.
+ */
+export function separateStorySlots(storyArgs: Record<string, unknown>): {
+  componentArgs: Record<string, unknown>;
+  storySlots: Record<string, unknown>;
+} {
+  const componentArgs = { ...storyArgs };
+  const storySlots = componentArgs.slots;
+
+  delete componentArgs.slots;
+
+  if (typeof storySlots !== 'object' || storySlots === null) {
+    return { componentArgs, storySlots: {} };
+  }
+
+  return { componentArgs, storySlots: storySlots as Record<string, unknown> };
+}

--- a/packages/@storybook-astro/framework/src/productionRenderRuntime.ts
+++ b/packages/@storybook-astro/framework/src/productionRenderRuntime.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
 import { createAstroRenderHandler, type HandlerProps } from './astroRenderHandler.ts';
+import { separateStorySlots } from './lib/separate-story-slots.ts';
 import type { Integration } from './integrations/index.ts';
 import type { SanitizationOptions } from './lib/sanitization.ts';
 import type { FrameworkOptions } from './types.ts';
@@ -190,25 +191,6 @@ function mergeMetaArgsWithStoryArgs(
   return {
     ...(metaArgs ?? {}),
     ...(storyArgs ?? {})
-  };
-}
-
-function separateStorySlots(storyArgs: Record<string, unknown>) {
-  const componentArgs = { ...storyArgs };
-  const storySlots = componentArgs.slots;
-
-  delete componentArgs.slots;
-
-  if (!isRecord(storySlots)) {
-    return {
-      componentArgs,
-      storySlots: {}
-    };
-  }
-
-  return {
-    componentArgs,
-    storySlots: storySlots as Record<string, string>
   };
 }
 

--- a/packages/@storybook-astro/framework/src/testing/astro-runtime.ts
+++ b/packages/@storybook-astro/framework/src/testing/astro-runtime.ts
@@ -6,6 +6,10 @@ import { resolveTestingProjectRoot } from './project-root.ts';
 import { runWithWorkingDirectory } from './working-directory.ts';
 import { getComponentModuleId, isAstroComponentFactory, isStorybookAstroClientStub } from './component-utils.ts';
 import { ssrLoadModuleWithFsFallback } from '../lib/ssr-load-module-with-fs-fallback.ts';
+import { separateStorySlots } from '../lib/separate-story-slots.ts';
+import { reconstructProps, reconstructSlots } from '../lib/reconstruct-component-args.ts';
+import { patchCreateAstroCompat } from '../astroRenderHandler.ts';
+import { serializeAstroComponentMarkers } from '@storybook-astro/renderer/types';
 import type { ComposedStory } from './types.ts';
 import { renderViaTestingRendererDaemon } from './renderer-daemon.ts';
 
@@ -16,7 +20,13 @@ const astroSsrViteServerPromises = new Map<string, Promise<ViteDevServer>>();
 
 const astroSsrHandlerPromises = new Map<
   string,
-  Promise<(data: { component: string; args?: Record<string, unknown> }) => Promise<string>>
+  Promise<
+    (data: {
+      component: string;
+      args?: Record<string, unknown>;
+      slots?: Record<string, unknown>;
+    }) => Promise<string>
+  >
 >();
 
 const testingIntegrationsCache = new Map<string, StorybookAstroIntegration[]>();
@@ -115,6 +125,14 @@ async function resolveAstroComponent(component: unknown, resolveFrom: string) {
   return resolvedComponent;
 }
 
+function setRenderedHtml(html: string) {
+  if (typeof document !== 'undefined') {
+    document.body.innerHTML = html;
+  }
+
+  return html;
+}
+
 async function renderAstroComponentToDom(
   component: unknown,
   args: Record<string, unknown>,
@@ -122,21 +140,26 @@ async function renderAstroComponentToDom(
 ) {
   const moduleId = getComponentModuleId(component);
 
+  // Split slot content from props, then serialize any Astro component passed as
+  // a prop or slot into a moduleId marker. The handler reconstructs each marker —
+  // loading the real server component by moduleId — so a story can nest Astro
+  // components without the unrenderable client stub leaking through.
+  const { componentArgs, storySlots } = separateStorySlots(args);
+  const serializedArgs = serializeAstroComponentMarkers(componentArgs) as Record<string, unknown>;
+  const serializedSlots = serializeAstroComponentMarkers(storySlots) as Record<string, unknown>;
+
   if (moduleId) {
     try {
       // Fast path: reuse a single shared SSR daemon instead of spinning SSR in each worker.
       const html = await renderViaTestingRendererDaemon({
         resolveFrom,
         component: moduleId,
-        args
+        args: serializedArgs,
+        slots: serializedSlots
       });
 
       if (typeof html === 'string') {
-        if (typeof document !== 'undefined') {
-          document.body.innerHTML = html;
-        }
-
-        return html;
+        return setRenderedHtml(html);
       }
     } catch {
       // Fall back to in-worker rendering below when daemon render fails.
@@ -146,14 +169,11 @@ async function renderAstroComponentToDom(
       const handler = await getAstroSsrHandler(resolveFrom);
       const html = await handler({
         component: moduleId,
-        args
+        args: serializedArgs,
+        slots: serializedSlots
       });
 
-      if (typeof document !== 'undefined') {
-        document.body.innerHTML = html;
-      }
-
-      return html;
+      return setRenderedHtml(html);
     } catch {
       // Fall back to direct Container rendering below
     }
@@ -161,20 +181,31 @@ async function renderAstroComponentToDom(
 
   const resolvedComponent = await resolveAstroComponent(component, resolveFrom);
   const container = await getAstroContainer();
-  
+
   if (!container) {
     throw new Error('Failed to initialize Astro container for rendering');
   }
-  
-  const html = await container.renderToString(resolvedComponent, {
-    props: args
+
+  // The direct fallback has no handler, so reconstruct nested components here:
+  // load each marker's real server module by id and render slot markers to HTML.
+  const loadComponent = async (id: string) => {
+    const viteServer = await getAstroSsrViteServer(resolveFrom);
+    const mod = (await ssrLoadModuleWithFsFallback(viteServer, id)) as Record<string, unknown>;
+
+    return patchCreateAstroCompat(mod.default);
+  };
+  const reconstructedArgs = await reconstructProps(serializedArgs, { loadComponent });
+  const reconstructedSlots = await reconstructSlots(serializedSlots, {
+    loadComponent,
+    renderToHtml: (child) => container.renderToString(child, {})
   });
 
-  if (typeof document !== 'undefined') {
-    document.body.innerHTML = html;
-  }
+  const html = await container.renderToString(resolvedComponent, {
+    props: reconstructedArgs,
+    slots: reconstructedSlots
+  });
 
-  return html;
+  return setRenderedHtml(html);
 }
 
 async function renderComposedStory(story: ComposedStory) {

--- a/packages/@storybook-astro/framework/src/testing/astro-runtime.ts
+++ b/packages/@storybook-astro/framework/src/testing/astro-runtime.ts
@@ -8,7 +8,7 @@ import { getComponentModuleId, isAstroComponentFactory, isStorybookAstroClientSt
 import { ssrLoadModuleWithFsFallback } from '../lib/ssr-load-module-with-fs-fallback.ts';
 import { separateStorySlots } from '../lib/separate-story-slots.ts';
 import { reconstructProps, reconstructSlots } from '../lib/reconstruct-component-args.ts';
-import { patchCreateAstroCompat } from '../astroRenderHandler.ts';
+import { patchCreateAstroCompat, markRawSlots } from '../astroRenderHandler.ts';
 import { serializeAstroComponentMarkers } from '@storybook-astro/renderer/types';
 import type { ComposedStory } from './types.ts';
 import { renderViaTestingRendererDaemon } from './renderer-daemon.ts';
@@ -202,7 +202,7 @@ async function renderAstroComponentToDom(
 
   const html = await container.renderToString(resolvedComponent, {
     props: reconstructedArgs,
-    slots: reconstructedSlots
+    slots: markRawSlots(reconstructedSlots)
   });
 
   return setRenderedHtml(html);

--- a/packages/@storybook-astro/renderer/src/astroComponentMarker.ts
+++ b/packages/@storybook-astro/renderer/src/astroComponentMarker.ts
@@ -1,0 +1,90 @@
+/**
+ * Astro component references can't be JSON-serialized, so when a story passes an
+ * Astro component as a prop or as slot content, the client replaces it with this
+ * plain marker before sending the render request. The server reconstructs it: a
+ * marker used as a prop is resolved back to the real component factory (the
+ * parent template renders it via `<Comp />`); a marker used as slot content is
+ * rendered to an HTML string (the Astro Container only accepts string slots).
+ *
+ * Only the `moduleId` needs to cross the boundary — the server loads the
+ * component from it exactly like it loads the top-level story component.
+ *
+ * Scope: a marker carries a bare component reference, not per-instance props or
+ * slots. Passing a "configured" child (with its own props/slots) or a non-Astro
+ * framework component as a slot/prop is not supported yet.
+ */
+export const ASTRO_COMPONENT_MARKER = '__astroComponent';
+
+export type AstroComponentMarker = {
+  [ASTRO_COMPONENT_MARKER]: true;
+  moduleId: string;
+};
+
+/**
+ * A value is a marker only when both keys are present and well-typed, so a
+ * legitimate plain-object arg can't be mistaken for one.
+ */
+export function isAstroComponentMarker(value: unknown): value is AstroComponentMarker {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<string, unknown>)[ASTRO_COMPONENT_MARKER] === true &&
+    typeof (value as Record<string, unknown>).moduleId === 'string'
+  );
+}
+
+/**
+ * Detects an Astro component factory — the callable produced by importing a
+ * `.astro` file. On the client this is the stub from `vitePluginAstroComponentMarker`
+ * (which sets `isAstroComponentFactory` and `moduleId`); on the server (and in the
+ * Vitest/portable path) it's the real Astro factory, which also sets the flag.
+ */
+export function isAstroComponentFactory(value: unknown): boolean {
+  return (
+    typeof value === 'function' &&
+    'isAstroComponentFactory' in value &&
+    (value as { isAstroComponentFactory?: unknown }).isAstroComponentFactory === true
+  );
+}
+
+/**
+ * Recursively replaces Astro component factories in an args/slots value with
+ * serializable {@link AstroComponentMarker}s so the value can cross the JSON
+ * render boundary. Walks arrays and nested objects. A factory missing its
+ * `moduleId` can't be rendered server-side, so it's dropped with an error.
+ */
+export function serializeAstroComponentMarkers(value: unknown, depth = 0): unknown {
+  if (isAstroComponentFactory(value)) {
+    const moduleId = (value as { moduleId?: unknown }).moduleId;
+
+    if (typeof moduleId !== 'string') {
+      console.error(
+        '[storybook-astro] An Astro component passed in args has no moduleId and cannot be rendered.'
+      );
+
+      return undefined;
+    }
+
+    return { [ASTRO_COMPONENT_MARKER]: true, moduleId } satisfies AstroComponentMarker;
+  }
+
+  if (depth >= 10) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => serializeAstroComponentMarkers(item, depth + 1));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+
+    for (const [key, nested] of Object.entries(value)) {
+      out[key] = serializeAstroComponentMarkers(nested, depth + 1);
+    }
+
+    return out;
+  }
+
+  return value;
+}

--- a/packages/@storybook-astro/renderer/src/render.tsx
+++ b/packages/@storybook-astro/renderer/src/render.tsx
@@ -2,7 +2,8 @@ import { simulateDOMContentLoaded, simulatePageLoad } from 'storybook/internal/p
 import type { ArgsStoryFn, Renderer, RenderContext, StoryContext } from 'storybook/internal/types';
 import { dedent } from 'ts-dedent';
 import 'astro:scripts/page.js';
-import type { AstroComponentFactory, AstroRenderer } from './types';
+import type { AstroComponentFactory, AstroRenderer, SlotValue } from './types';
+import { serializeAstroComponentMarkers } from './astroComponentMarker';
 import * as astroRenderer from 'virtual:storybook-astro-renderer';
 import * as renderers from 'virtual:storybook-renderer-fallback';
 
@@ -178,39 +179,6 @@ function isAstroComponent(element: unknown): element is AstroComponentFactory {
   );
 }
 
-// Slot content crosses the render boundary as JSON, so it must be an HTML
-// string — an Astro component reference (a factory function) can't be
-// serialized and the Astro Container expects string slots. Passing a component
-// today renders nothing at all, so warn loudly instead of failing silently.
-// Tracked for first-class support in NESTED_COMPONENT_SUPPORT.md (issue #128).
-function warnIfComponentPassedAsSlotContent(
-  slots: Record<string, unknown>,
-  componentArgs: Record<string, unknown>
-): void {
-  Object.entries(slots).forEach(([name, value]) => {
-    if (isAstroComponent(value)) {
-      console.warn(dedent`
-        Astro slot "${name}" received a component reference, which can't be rendered yet.
-        Slot content must be an HTML string, e.g. slots: { ${name}: '<span>...</span>' }.
-        Passing Astro components as slot content is on the roadmap (issue #128).
-      `);
-    }
-  });
-
-  // A component sitting at the top level of args (React "children" style) is
-  // read as a prop the template never uses, so the slot renders empty.
-  Object.entries(componentArgs).forEach(([name, value]) => {
-    if (isAstroComponent(value)) {
-      console.warn(dedent`
-        Arg "${name}" is an Astro component reference passed as a prop, so it is ignored.
-        To place it in a slot, nest it under args.slots — and note slot content must
-        currently be an HTML string, e.g. slots: { ${name}: '<span>...</span>' }.
-        Passing Astro components as slot content is on the roadmap (issue #128).
-      `);
-    }
-  });
-}
-
 async function renderAstroToCanvas(
   element: AstroComponentFactory,
   args: Record<string, unknown>,
@@ -223,12 +191,10 @@ async function renderAstroToCanvas(
 
   const { slots = {}, ...componentArgs } = args;
 
-  warnIfComponentPassedAsSlotContent(slots, componentArgs);
-
   const response = await astroRenderer.render({
     component: element.moduleId,
-    args: componentArgs,
-    slots: slots as Record<string, string>,
+    args: serializeAstroComponentMarkers(componentArgs) as Record<string, unknown>,
+    slots: serializeAstroComponentMarkers(slots) as Record<string, SlotValue>,
     story: storyContext
       ? {
           id: storyContext.id,

--- a/packages/@storybook-astro/renderer/src/types.ts
+++ b/packages/@storybook-astro/renderer/src/types.ts
@@ -1,4 +1,16 @@
 import type { WebRenderer } from 'storybook/internal/types';
+import type { AstroComponentMarker } from './astroComponentMarker';
+
+export {
+  ASTRO_COMPONENT_MARKER,
+  isAstroComponentMarker,
+  isAstroComponentFactory,
+  serializeAstroComponentMarkers
+} from './astroComponentMarker';
+export type { AstroComponentMarker } from './astroComponentMarker';
+
+/** Slot content: an HTML string, a serialized component reference, or a list of either. */
+export type SlotValue = string | AstroComponentMarker | Array<string | AstroComponentMarker>;
 
 /**
  * Mirrors the shape that the Astro language server gives to `.astro` imports:
@@ -26,7 +38,7 @@ export interface AstroRenderer extends WebRenderer {
 export type RenderComponentInput = {
   component: string;
   args: Record<string, unknown>;
-  slots: Record<string, string>;
+  slots: Record<string, SlotValue>;
   story?: {
     id: string;
     title?: string;

--- a/packages/components/src/Nesting/Badge.astro
+++ b/packages/components/src/Nesting/Badge.astro
@@ -1,0 +1,17 @@
+---
+// Small child component used both as slot content and as a prop in the nesting stories.
+const { label = 'badge' } = Astro.props;
+
+---
+<span class="badge" data-testid="badge">{label}</span>
+
+<style>
+  .badge {
+    display: inline-block;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    background: #BF3FBF;
+    color: #fff;
+    font-size: 0.75rem;
+  }
+</style>

--- a/packages/components/src/Nesting/IconButton.astro
+++ b/packages/components/src/Nesting/IconButton.astro
@@ -1,0 +1,9 @@
+---
+// Parent that renders a component passed as a prop, via `<Icon />`.
+const { Icon, label = 'Click' } = Astro.props;
+
+---
+<button class="icon-button" data-testid="icon-button">
+  {Icon ? <Icon label="icon" /> : null}
+  <span>{label}</span>
+</button>

--- a/packages/components/src/Nesting/Nesting.test.ts
+++ b/packages/components/src/Nesting/Nesting.test.ts
@@ -1,0 +1,38 @@
+import { screen, within } from '@testing-library/dom';
+import { test, expect } from 'vitest';
+import { composeStories, renderStory } from '@storybook-astro/framework/testing';
+import * as slotStories from './SlotNesting.stories.jsx';
+import * as propStories from './PropNesting.stories.jsx';
+
+const { ComponentInSlot, StringInSlot } = composeStories(slotStories);
+const { ComponentAsProp } = composeStories(propStories);
+
+// Issue #128: an Astro component passed as slot content used to render empty.
+test('an Astro component passed as slot content renders inside the slot', async () => {
+  await renderStory(ComponentInSlot);
+
+  const panel = screen.getByTestId('panel');
+  const badge = within(panel).getByTestId('badge');
+
+  expect(badge).toBeInTheDocument();
+  expect(badge).toHaveTextContent('badge');
+});
+
+// String slot content is sanitized (it's raw user HTML), so assert on text
+// rather than a data-* attribute the allowlist strips.
+test('a string slot still renders (regression guard)', async () => {
+  await renderStory(StringInSlot);
+
+  const panel = screen.getByTestId('panel');
+
+  expect(panel).toHaveTextContent('plain string slot');
+});
+
+test('an Astro component passed as a prop renders via the parent template', async () => {
+  await renderStory(ComponentAsProp);
+
+  const button = screen.getByTestId('icon-button');
+
+  expect(within(button).getByTestId('badge')).toBeInTheDocument();
+  expect(button).toHaveTextContent('Save');
+});

--- a/packages/components/src/Nesting/Panel.astro
+++ b/packages/components/src/Nesting/Panel.astro
@@ -1,0 +1,10 @@
+---
+// Parent with a default slot — the issue #128 repro target. Slot content may be
+// an HTML string or another Astro component.
+const { title = 'Panel' } = Astro.props;
+
+---
+<section class="panel" data-testid="panel">
+  <h2>{title}</h2>
+  <div class="panel-body"><slot /></div>
+</section>

--- a/packages/components/src/Nesting/PropNesting.stories.jsx
+++ b/packages/components/src/Nesting/PropNesting.stories.jsx
@@ -1,0 +1,22 @@
+import IconButton from './IconButton.astro';
+import Badge from './Badge.astro';
+
+export default {
+  title: 'Astro/Nesting/Prop',
+  component: IconButton,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Passing an Astro component as a prop. The parent template renders it with `<Icon />`, so the Container resolves the real component factory.',
+      },
+    },
+  },
+};
+
+export const ComponentAsProp = {
+  args: {
+    label: 'Save',
+    Icon: Badge,
+  },
+};

--- a/packages/components/src/Nesting/SlotNesting.stories.jsx
+++ b/packages/components/src/Nesting/SlotNesting.stories.jsx
@@ -1,0 +1,29 @@
+import Panel from './Panel.astro';
+import Badge from './Badge.astro';
+
+export default {
+  title: 'Astro/Nesting/Slot',
+  component: Panel,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Passing an Astro component as slot content (the React `children` pattern). Slot content can be an HTML string or another Astro component — see issue #128.',
+      },
+    },
+  },
+};
+
+export const ComponentInSlot = {
+  args: {
+    title: 'Component slot',
+    slots: { default: Badge },
+  },
+};
+
+export const StringInSlot = {
+  args: {
+    title: 'String slot',
+    slots: { default: '<p data-testid="plain-slot">plain string slot</p>' },
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4920,7 +4920,7 @@ __metadata:
     "@types/react-dom": "npm:^18.3.6"
     "@vitest/ui": "npm:^4.0.18"
     alpinejs: "npm:^3.14.9"
-    astro: "npm:6.0.3"
+    astro: "npm:6.4.4"
     eslint: "npm:^9.39.2"
     happy-dom: "npm:^17.4.4"
     http-server: "npm:^14.1.1"


### PR DESCRIPTION
## Summary

A story can now pass an Astro component as a **prop** (`args: { Icon }`, rendered by the parent via `<Icon />`) or as **slot content** (`args.slots.default` — the React `children` pattern). Closes #128.

Backward compatible (string slots and existing args are unchanged) — targeted at the **1.8** release.

## How it works

Component references can't be JSON-serialized across the render boundary, so the client replaces them with `{ __astroComponent, moduleId }` markers and the server reconstructs them:

- **Props** resolve back to the real component factory and pass through — the Astro Container renders factory-valued props natively (so the parent's `<Comp />` just works; no `set:html` needed).
- **Slots** render the child to an HTML string, because the Container only accepts string slots.

Slot rendering runs **after sanitization**, so a component's own markup (classes, scoped-CSS attributes) is preserved, while plain-string slots are still sanitized. The reconstruction lives in the shared render handler, so **dev, server, and static-build** modes are all covered, and the testing/portable path splits slots + serializes markers for parity.

## Changes

- **renderer**: `astroComponentMarker.ts` (marker + guards + serializer); widened `RenderComponentInput.slots`; client serialization in `render.tsx` (replaces the old warn-and-drop).
- **framework**: `lib/reconstruct-component-args.ts` (`reconstructProps` / `reconstructSlots`), `lib/separate-story-slots.ts`; wired into `astroRenderHandler` (props before sanitize, slots after) and the testing runtime.
- **demo + tests**: an `Astro/Nesting` demo (Panel / Badge / IconButton + stories + test) in the shared `components` package, so the #128 slot repro and prop nesting render in **all** integration Storybook builds (astro5/6/7) and run in CI; plus unit tests for the marker + reconstruction walkers.
- **docs**: slots & props guides, `NESTED_COMPONENT_SUPPORT.md` (Pattern B marked done; corrected the `set:html` note), CHANGELOG.

## Verify in the Cloudflare previews

In **each** of demo-astro5 / demo-astro6 / demo-astro7:
- **Astro → Nesting → Slot** → `ComponentInSlot` (Badge inside the Panel slot — the #128 case), `StringInSlot` (string-slot regression baseline)
- **Astro → Nesting → Prop** → `ComponentAsProp` (Badge rendered by IconButton via `<Icon />`)

## Validation

- Unit (marker + reconstruction) and integration (`renderStory`) tests pass.
- Static **prerender builds** verified on astro5 (Astro 5 / Vite 6) and astro7 (Astro 7 / Vite 8): Badge renders in both slot and prop, with styling intact.
- Full gate: lint ✓, `yarn test` ✓, website build ✓.

## Out of scope (future)

- Passing a *configured* child (a component with its own props/slots) — v1 passes a bare component reference, which renders with default props.
- Cross-framework components (React/Vue/etc.) as an Astro slot/prop.