### PR TITLE
fix: keep per-story stylesheets on the Docs page

### DIFF
--- a/integration/astro7/tests/code-tabs-docs.spec.ts
+++ b/integration/astro7/tests/code-tabs-docs.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+// Regression test for the Docs page stomping per-story stylesheets.
+//
+// The CodeTabs Docs page renders every CodeTabs story (react, solid, vue, …)
+// into one shared iframe head. Each framework ships its own stylesheet, so the
+// stylesheet sync must keep them all — previously a later story removed earlier
+// stories' links, leaving most CodeTabs instances unstyled on Docs (they were
+// fine on individual Canvas story pages).
+test.describe('CodeTabs on the Docs page', () => {
+  test('react CodeTabs keeps its styling alongside the other framework stories', async ({ page }) => {
+    await page.goto('/iframe.html?viewMode=docs&id=astro-code-tabs--docs');
+
+    // The Docs page renders all stories; the react implementation appears in
+    // multiple stories (Default + React (client:load)).
+    const reactTabs = page.locator('[data-testid="react-code-tabs"]').first();
+
+    await expect(reactTabs).toBeVisible();
+
+    // `.installTabs` from the CSS module sets a 10px radius. If the stylesheet
+    // was stripped by a later story's render, this falls back to the default 0px.
+    await expect
+      .poll(async () => reactTabs.evaluate((el) => getComputedStyle(el).borderTopLeftRadius))
+      .toBe('10px');
+
+    // The tablist uses `display: flex` from the same module.
+    const tablist = page.locator('[data-testid="react-code-tabs"] [role="tablist"]').first();
+
+    await expect(tablist).toHaveCSS('display', 'flex');
+  });
+});

--- a/packages/@storybook-astro/renderer/src/render.tsx
+++ b/packages/@storybook-astro/renderer/src/render.tsx
@@ -205,25 +205,41 @@ async function renderAstroToCanvas(
   });
 
   astroRenderer.applyStyles?.();
-  canvasElement.innerHTML = prepareServerRenderedHtml(response.html, canvasElement.ownerDocument);
+  canvasElement.innerHTML = prepareServerRenderedHtml(
+    response.html,
+    canvasElement.ownerDocument,
+    storyContext?.viewMode
+  );
   invokeScriptTags(canvasElement);
 }
 
 /** Parses the server HTML response and hoists any stylesheet links into the iframe head. */
-function prepareServerRenderedHtml(html: string, document: Document) {
+function prepareServerRenderedHtml(html: string, document: Document, viewMode?: string) {
   const template = document.createElement('template');
 
   template.innerHTML = html;
 
   // Server mode returns stylesheet links in the HTML response. Keep those in
   // the iframe head so controls rerenders can reuse them instead of refetching.
-  syncServerRenderedStylesheets(template.content, document);
+  syncServerRenderedStylesheets(template.content, document, viewMode);
 
   return template.innerHTML;
 }
 
-/** Keeps server-rendered stylesheets in the iframe head across controls rerenders. */
-function syncServerRenderedStylesheets(fragment: DocumentFragment, document: Document) {
+/**
+ * Keeps server-rendered stylesheets in the iframe head across controls rerenders.
+ *
+ * In the Canvas (one story at a time) we drop links the current render no longer
+ * uses, so a previous story's stylesheets don't linger. On a Docs page every
+ * story renders into the *same* head, so dropping "stale" links would let each
+ * story strip the others' stylesheets (e.g. CodeTabs' per-framework CSS) — there
+ * we only add, letting all stories' stylesheets coexist.
+ */
+function syncServerRenderedStylesheets(
+  fragment: DocumentFragment,
+  document: Document,
+  viewMode?: string
+) {
   const nextHrefs = new Set<string>();
   const stylesheetLinks = Array.from(fragment.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'));
 
@@ -251,6 +267,12 @@ function syncServerRenderedStylesheets(fragment: DocumentFragment, document: Doc
 
     link.remove();
   });
+
+  // On a Docs page, multiple stories share one head — keep every story's
+  // stylesheets. Only the single-story Canvas prunes links it no longer needs.
+  if (viewMode === 'docs') {
+    return;
+  }
 
   Array.from(document.head.querySelectorAll<HTMLLinkElement>('link[data-storybook-astro-style]')).forEach(
     (link) => {


### PR DESCRIPTION
## Problem

On **all** Astro builds, the **CodeTabs** component lost its styling on its Storybook **Docs** page, while individual **Canvas** story pages were fine.

## Root cause

Each Astro story's server-rendered HTML carries its component CSS as a `<link rel="stylesheet">`. `syncServerRenderedStylesheets` hoists that link into the iframe `<head>`, and also **removed any link the current render didn't use**. That's correct on the Canvas (one story at a time), but the Docs page renders *every* story for a component into one shared `<head>`. CodeTabs renders a different framework implementation per story (react / solid / vue / svelte / preact / alpine), each with its **own** CSS module / stylesheet — so as the stories rendered, each one stripped the others' stylesheets. The last-rendered framework won; the rest went unstyled.

## Fix

Skip the stale-link cleanup when rendering in **Docs view** (`viewMode === 'docs'`), so all stories' stylesheets coexist in the shared head. The single-story Canvas still prunes links it no longer needs.

## Test

Adds a Playwright regression test that loads the CodeTabs Docs page and asserts the react implementation keeps its CSS-module styling (10px radius, flex tablist) alongside the other framework stories. Verified it passes with the fix.

## Verification
- `build:packages` ✓, lint ✓
- New Docs-page Playwright test passes (builds the static Storybook with the fixed renderer, serves it, drives Chromium to the CodeTabs Docs page)