### PR TITLE
fix: stop docs typography from restyling rendered stories

### DIFF
--- a/integration/astro5/.storybook/preview.css
+++ b/integration/astro5/.storybook/preview.css
@@ -1,27 +1,24 @@
 /* Import global styles */
 @import '../src/styles/global.css';
 
-/* Storybook docs panel overrides (scoped to .sbdocs) */
-/* The docs panel has a light/white background, so we need dark text */
-.sbdocs strong {
+/* Storybook docs panel overrides (scoped to .sbdocs).
+   The docs panel has a light/white background, so the docs prose needs dark
+   text. `:not(.sb-unstyled *)` keeps these overrides off rendered story content
+   — the framework tags each inline story's container `.sb-unstyled` in docs
+   view — so a component keeps its own styling in the Docs preview. */
+.sbdocs strong:not(.sb-unstyled *) {
   color: #1a1a1a;
 }
 
-.sbdocs p,
-.sbdocs li {
+.sbdocs :is(p, li):not(.sb-unstyled *) {
   color: #333;
 }
 
-.sbdocs h1,
-.sbdocs h2,
-.sbdocs h3,
-.sbdocs h4,
-.sbdocs h5,
-.sbdocs h6 {
+.sbdocs :is(h1, h2, h3, h4, h5, h6):not(.sb-unstyled *) {
   color: #1a1a1a;
 }
 
-.sbdocs code {
+.sbdocs code:not(.sb-unstyled *) {
   background: rgba(0, 0, 0, 0.06);
   color: #1a1a1a;
   padding: 0.15em 0.4em;
@@ -29,21 +26,21 @@
   font-size: 0.9em;
 }
 
-.sbdocs pre {
+.sbdocs pre:not(.sb-unstyled *) {
   background: #f6f8fa;
   border: 1px solid #d0d7de;
 }
 
-.sbdocs pre code {
+.sbdocs pre code:not(.sb-unstyled *) {
   background: none;
   padding: 0;
   color: #1f2328;
 }
 
-.sbdocs a {
+.sbdocs a:not(.sb-unstyled *) {
   color: #0969da;
 }
 
-.sbdocs a:hover {
+.sbdocs a:not(.sb-unstyled *):hover {
   color: #0550ae;
 }

--- a/integration/astro6/.storybook/preview.css
+++ b/integration/astro6/.storybook/preview.css
@@ -1,27 +1,24 @@
 /* Import global styles */
 @import '../src/styles/global.css';
 
-/* Storybook docs panel overrides (scoped to .sbdocs) */
-/* The docs panel has a light/white background, so we need dark text */
-.sbdocs strong {
+/* Storybook docs panel overrides (scoped to .sbdocs).
+   The docs panel has a light/white background, so the docs prose needs dark
+   text. `:not(.sb-unstyled *)` keeps these overrides off rendered story content
+   — the framework tags each inline story's container `.sb-unstyled` in docs
+   view — so a component keeps its own styling in the Docs preview. */
+.sbdocs strong:not(.sb-unstyled *) {
   color: #1a1a1a;
 }
 
-.sbdocs p,
-.sbdocs li {
+.sbdocs :is(p, li):not(.sb-unstyled *) {
   color: #333;
 }
 
-.sbdocs h1,
-.sbdocs h2,
-.sbdocs h3,
-.sbdocs h4,
-.sbdocs h5,
-.sbdocs h6 {
+.sbdocs :is(h1, h2, h3, h4, h5, h6):not(.sb-unstyled *) {
   color: #1a1a1a;
 }
 
-.sbdocs code {
+.sbdocs code:not(.sb-unstyled *) {
   background: rgba(0, 0, 0, 0.06);
   color: #1a1a1a;
   padding: 0.15em 0.4em;
@@ -29,21 +26,21 @@
   font-size: 0.9em;
 }
 
-.sbdocs pre {
+.sbdocs pre:not(.sb-unstyled *) {
   background: #f6f8fa;
   border: 1px solid #d0d7de;
 }
 
-.sbdocs pre code {
+.sbdocs pre code:not(.sb-unstyled *) {
   background: none;
   padding: 0;
   color: #1f2328;
 }
 
-.sbdocs a {
+.sbdocs a:not(.sb-unstyled *) {
   color: #0969da;
 }
 
-.sbdocs a:hover {
+.sbdocs a:not(.sb-unstyled *):hover {
   color: #0550ae;
 }

--- a/integration/astro7/.storybook/preview.css
+++ b/integration/astro7/.storybook/preview.css
@@ -1,27 +1,24 @@
 /* Import global styles */
 @import '../src/styles/global.css';
 
-/* Storybook docs panel overrides (scoped to .sbdocs) */
-/* The docs panel has a light/white background, so we need dark text */
-.sbdocs strong {
+/* Storybook docs panel overrides (scoped to .sbdocs).
+   The docs panel has a light/white background, so the docs prose needs dark
+   text. `:not(.sb-unstyled *)` keeps these overrides off rendered story content
+   — the framework tags each inline story's container `.sb-unstyled` in docs
+   view — so a component keeps its own styling in the Docs preview. */
+.sbdocs strong:not(.sb-unstyled *) {
   color: #1a1a1a;
 }
 
-.sbdocs p,
-.sbdocs li {
+.sbdocs :is(p, li):not(.sb-unstyled *) {
   color: #333;
 }
 
-.sbdocs h1,
-.sbdocs h2,
-.sbdocs h3,
-.sbdocs h4,
-.sbdocs h5,
-.sbdocs h6 {
+.sbdocs :is(h1, h2, h3, h4, h5, h6):not(.sb-unstyled *) {
   color: #1a1a1a;
 }
 
-.sbdocs code {
+.sbdocs code:not(.sb-unstyled *) {
   background: rgba(0, 0, 0, 0.06);
   color: #1a1a1a;
   padding: 0.15em 0.4em;
@@ -29,21 +26,21 @@
   font-size: 0.9em;
 }
 
-.sbdocs pre {
+.sbdocs pre:not(.sb-unstyled *) {
   background: #f6f8fa;
   border: 1px solid #d0d7de;
 }
 
-.sbdocs pre code {
+.sbdocs pre code:not(.sb-unstyled *) {
   background: none;
   padding: 0;
   color: #1f2328;
 }
 
-.sbdocs a {
+.sbdocs a:not(.sb-unstyled *) {
   color: #0969da;
 }
 
-.sbdocs a:hover {
+.sbdocs a:not(.sb-unstyled *):hover {
   color: #0550ae;
 }

--- a/integration/astro7/tests/imagetext-docs.spec.ts
+++ b/integration/astro7/tests/imagetext-docs.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+// Regression test for Storybook's docs typography bleeding into rendered stories.
+//
+// On the Docs page a story renders inside `.sbdocs-content`, whose typography
+// rules previously restyled native elements in the component (e.g. an <h2> in
+// slot content took Storybook's docs heading color instead of its own). The
+// canvas container is now tagged `.sb-unstyled` in docs view, which Storybook
+// exempts from that typography — so the component looks the same on Docs as on
+// the individual Canvas story page.
+test.describe('ImageText on the Docs page', () => {
+  test('slot heading keeps the same color on Docs as on Canvas', async ({ page }) => {
+    const colorOf = async (selector: string) =>
+      page.locator(selector).first().evaluate((el) => getComputedStyle(el).color);
+
+    await page.goto('/iframe.html?viewMode=story&id=astro-imagetext--default');
+    await expect(page.locator('.image-text h2').first()).toBeVisible();
+    const canvasColor = await colorOf('.image-text h2');
+
+    await page.goto('/iframe.html?viewMode=docs&id=astro-imagetext--docs');
+    await expect(page.locator('.image-text h2').first()).toBeVisible();
+    const docsColor = await colorOf('.image-text h2');
+
+    expect(docsColor).toBe(canvasColor);
+  });
+});

--- a/packages/@storybook-astro/renderer/src/render.tsx
+++ b/packages/@storybook-astro/renderer/src/render.tsx
@@ -98,6 +98,12 @@ export async function renderToCanvas(
   const renderer = ctx.storyContext.parameters?.renderer as string | undefined;
   const typedRenderers = renderers as RendererRegistry;
 
+  // On the Docs page a story renders inside `.sbdocs-content`, whose typography
+  // styles bleed into the rendered component (e.g. overriding an `<h2>`'s color).
+  // Storybook exempts `.sb-unstyled` descendants from that typography, so tag the
+  // canvas container with it in docs view to preserve each component's own look.
+  canvasElement.classList.toggle('sb-unstyled', storyContext?.viewMode === 'docs');
+
   // When the framework changes, clear the canvas so the previous framework's DOM
   // doesn't stack alongside the new one. Same-framework rerenders are unaffected.
   if (renderer !== activeRenderer) {


### PR DESCRIPTION
## Problem

On the **Docs** page, Storybook's `.sbdocs` typography overrode the native styling of elements inside rendered stories — e.g. an `<h2>` in ImageText's slot content took the docs heading color instead of its own. The individual **Canvas** story pages looked correct.

## Root cause

Inline Docs rendering places the story inside `.sbdocs-content`, so any `.sbdocs <element>` rule applies to the component's markup. The integration's own `.storybook/preview.css` styles the docs prose with broad rules like `.sbdocs h1…h6 { color: #1a1a1a }`, which also matched headings inside the embedded stories.

## Fix

Two coordinated parts, using Storybook's `sb-unstyled` convention:

- **renderer** — tag each inline story's canvas container `.sb-unstyled` in docs view (`viewMode === 'docs'`). Storybook's core docs typography already exempts `.sb-unstyled` descendants (`:where(h2:not(…, .sb-unstyled h2))`), and it gives integrations a hook to scope their own docs CSS.
- **integration preview.css (astro5/6/7)** — scope the `.sbdocs` text overrides with `:not(.sb-unstyled *)`, so the docs *prose* stays styled while rendered stories keep their own look.

## Test

Adds a Playwright regression test that asserts ImageText's slot `<h2>` computes the **same color on the Docs page as on the Canvas story page**. Verified it fails before the fix (docs `rgb(26,26,26)` vs canvas `rgb(240,246,252)`) and passes after.

## Verification
- `build:packages` ✓, lint ✓
- Full astro7 Playwright suite passes (7 tests, incl. the new docs test; existing story-view tests confirm the `sb-unstyled` toggle doesn't affect Canvas rendering)