### PR TITLE
fix: stale component when switching frameworks via Docs pages

### DIFF
--- a/integration/astro7/tests/framework-switch-docs.spec.ts
+++ b/integration/astro7/tests/framework-switch-docs.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+// Regression test for a stale component left over when switching frameworks via
+// Docs pages. The renderer used to track the "active renderer" in one module
+// global; a Docs page renders stories into their own canvases, which polluted
+// that global so the shared story canvas wasn't cleared when a different
+// framework's story reused it — leaving two components (e.g. Vue + Svelte
+// Accordion) stacked until a reload. Tracking the renderer per canvas fixes it.
+//
+// This must drive the manager (not /iframe.html) because the bug only appears
+// across SPA navigation that doesn't reload the preview iframe.
+test.describe('framework switch through Docs pages', () => {
+  test('navigating Vue→Svelte via Docs leaves only one component', async ({ page }) => {
+    const preview = page.frameLocator('#storybook-preview-iframe');
+
+    // Single full load: start on the Vue Accordion Docs page.
+    await page.goto('/?path=/docs/vue-accordion--docs');
+    await expect(preview.locator('[data-testid="vue-accordion"]').first()).toBeVisible({
+      timeout: 30_000
+    });
+
+    // SPA navigation (no iframe reload) following the reported sequence:
+    // Vue docs -> Vue story -> Svelte docs -> Svelte story.
+    await page.locator('#vue-accordion--default').click();
+    await expect(preview.locator('.accordion')).toHaveCount(1);
+
+    await page.locator('#svelte-accordion').click(); // expand the Svelte group
+    await page.locator('#svelte-accordion--docs').click();
+    await expect(preview.locator('[data-testid="svelte-accordion"]').first()).toBeVisible();
+
+    await page.locator('#svelte-accordion--default').click();
+
+    // The Svelte story canvas must contain exactly one accordion — no leftover
+    // Vue accordion from the earlier story.
+    await expect(preview.locator('.accordion')).toHaveCount(1);
+    await expect(preview.locator('[data-testid="svelte-accordion"]')).toHaveCount(1);
+    await expect(preview.locator('[data-testid="vue-accordion"]')).toHaveCount(0);
+  });
+});

--- a/packages/@storybook-astro/renderer/src/render.tsx
+++ b/packages/@storybook-astro/renderer/src/render.tsx
@@ -86,9 +86,13 @@ function cloneElementWithArgs(element: HTMLElement, args: Record<string, unknown
   return output;
 }
 
-// Tracks the renderer used in the previous renderToCanvas call so we can detect
-// framework switches and clear the canvas before the new framework mounts.
-let activeRenderer: string | undefined;
+// Tracks the renderer last used to render into a given canvas, so we can detect
+// framework switches and clear that canvas before the new framework mounts.
+// Keyed per canvas (not a single module global): the Docs page renders stories
+// into their own canvases, and a global would let a Docs render of one framework
+// suppress the cleanup when a different framework's story later reuses the shared
+// story canvas — stacking two components until a reload.
+const lastRendererByCanvas = new WeakMap<HTMLElement, string | undefined>();
 
 export async function renderToCanvas(
   ctx: RenderContext<AstroRenderer>,
@@ -98,12 +102,13 @@ export async function renderToCanvas(
   const renderer = ctx.storyContext.parameters?.renderer as string | undefined;
   const typedRenderers = renderers as RendererRegistry;
 
-  // When the framework changes, clear the canvas so the previous framework's DOM
-  // doesn't stack alongside the new one. Same-framework rerenders are unaffected.
-  if (renderer !== activeRenderer) {
+  // When this canvas's framework changes, clear it so the previous framework's
+  // DOM doesn't stack alongside the new one. Same-framework rerenders are
+  // unaffected.
+  if (renderer !== lastRendererByCanvas.get(canvasElement)) {
     canvasElement.innerHTML = '';
   }
-  activeRenderer = renderer;
+  lastRendererByCanvas.set(canvasElement, renderer);
 
   if (renderer && Object.hasOwn(typedRenderers, renderer)) {
     showMain();


### PR DESCRIPTION
## Problem

Navigating **Vue → Accordion (Docs)** → **Vue Accordion (story)** → **Svelte → Accordion (Docs)** → **Svelte Accordion (story)** left **two** Accordion components stacked in the canvas. A refresh showed only one, and navigating directly between stories never triggered it. Same for other components (e.g. Counter).

## Root cause

`renderToCanvas` clears the canvas on a framework switch so the previous framework's DOM doesn't stack. It tracked the last renderer in a **single module-global** (`activeRenderer`).

A Docs page renders its stories *inline*, into their own canvas elements. Those Docs renders updated the global. So after viewing the Svelte Accordion **Docs** page, the global was already `'svelte'` — and when the Svelte Accordion **story** then rendered into the *shared story canvas* (which still held the Vue Accordion from the earlier Vue story), the switch check saw "same renderer" and skipped the clear. Svelte mounted alongside the leftover Vue accordion → two components. A reload reset the global, hiding it.

## Fix

Track the last renderer **per canvas** (`WeakMap` keyed by the canvas element) instead of one global. The clear now fires based on what *that specific* canvas last rendered, so Docs renders into other canvases can't suppress it.

## Test

Adds a manager-driven Playwright regression test that reproduces the exact navigation sequence and asserts a single accordion in the final story canvas.

**Verified both ways:** the test **fails without the fix** (`.accordion` count = 2 — the Vue + Svelte stack) and **passes with it**.