### PR TITLE
fix(framework): unblock Storybook dev server under Astro 7 / Vite 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `optimizeDeps.esbuildOptions` is now only set on Vite ≤7, removing the deprecation warning emitted under Vite 8 (the Rolldown optimizer reads `rolldownOptions`).
+- Storybook dev server no longer hangs with a blank preview under Astro 7 / Vite 8. Two Vite 8-only issues are now handled in the dev config: `@vitejs/plugin-react`'s native Fast Refresh wrapper (a Rolldown builtin) threw ``Missing field `moduleType` `` while transforming the preview `iframe.html`, 500-ing every story; and the dependency optimizer failed on the Storybook renderer entry-previews that ship non-JS source (e.g. `@storybook/svelte`'s `.svelte` files), 504-ing every renderer. React components still render in dev; only React Fast Refresh is unavailable (component edits trigger a full reload).
 
 ## [1.6.0] - 2026-06-19
 

--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -243,6 +243,48 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
   );
   optimizeDepsMut.rolldownOptions = rolldownOpts;
 
+  // Vite 8 dev-server compatibility (Astro 7+). Vite ≤7 (Astro 5/6) is unaffected.
+  if (configType === 'DEVELOPMENT' && viteMajor >= 8) {
+    // 1. Drop @vitejs/plugin-react's Vite 8 native Fast Refresh wrapper. Under
+    //    Vite 8 the plugin delegates Fast Refresh to a Rolldown builtin
+    //    (`builtin:vite-react-refresh-wrapper`) that throws
+    //    "Missing field `moduleType`" while transforming Storybook's iframe.html
+    //    inline bootstrap script — 500-ing every preview load. There is no
+    //    config opt-out, so we remove the plugin. React components still render;
+    //    only Fast Refresh is lost (component edits full-reload instead).
+    const stripReactRefreshWrapper = (plugins: unknown[]): unknown[] =>
+      plugins
+        .map((plugin) => (Array.isArray(plugin) ? stripReactRefreshWrapper(plugin) : plugin))
+        .filter(
+          (plugin) =>
+            !(
+              plugin &&
+              typeof plugin === 'object' &&
+              (plugin as { name?: string }).name === 'vite:react:refresh-wrapper'
+            )
+        );
+
+    finalConfig.plugins = stripReactRefreshWrapper(
+      finalConfig.plugins ?? []
+    ) as typeof finalConfig.plugins;
+
+    // 2. Exclude the Storybook renderer entry-previews from dependency
+    //    optimization. Some ship non-JS source (e.g. `@storybook/svelte`'s
+    //    `.svelte` files) that the esbuild dep scanner cannot load
+    //    ("No loader is configured for .svelte"), which fails optimization and
+    //    504s every renderer entry. Serving them as source lets the framework's
+    //    own Vite plugins transform them.
+    const entryPreviews = integrations
+      .map((integration) => integration.storybookEntryPreview)
+      .filter((specifier): specifier is string => Boolean(specifier));
+
+    for (const specifier of entryPreviews) {
+      if (!finalConfig.optimizeDeps.exclude.includes(specifier)) {
+        finalConfig.optimizeDeps.exclude.push(specifier);
+      }
+    }
+  }
+
   return finalConfig;
 };
 


### PR DESCRIPTION
## Problem

Under Astro 7 (Vite 8 / Rolldown), `yarn dev` loaded the Astro 7 integration's Storybook but the preview pane hung blank — every story request returned **HTTP 500**. Astro 5/6 (Vite 6/7) were unaffected, and the Astro 7 **production build** worked fine; the failure was dev-only.

## Root cause

Two distinct Vite 8-only failures in the preview config, both surfacing as a blank/hung preview:

1. **`Missing field \`moduleType\`` (500 on every `iframe.html`)** — `@vitejs/plugin-react@5.x` delegates React Fast Refresh to a Rolldown native builtin (`builtin:vite-react-refresh-wrapper`). That builtin throws while transforming Storybook's `iframe.html` inline bootstrap script (`pluginCode: InvalidArg`), 500-ing the entire preview. `skipFastRefresh` only disables it when HMR is off — which we can't do, the render channel relies on HMR — so there is no config opt-out.
2. **`No loader is configured for .svelte` (504 on every renderer entry-preview)** — the dependency optimizer's esbuild scan chokes on Storybook renderer entry-previews that ship non-JS source (e.g. `@storybook/svelte`'s `.svelte` files). This aborts optimization, so every `@storybook/*_entry-preview` 504s and no renderer initializes.

## Fix

In `preset.ts` `viteFinal`, gated to **`DEVELOPMENT` on Vite 8+** (Astro 5/6 code path is unchanged):

1. Remove the `vite:react:refresh-wrapper` plugin. React components still render; only React Fast Refresh is lost (component edits trigger a full reload instead of HMR — the same DX as Astro 5/6, which never had this native wrapper).
2. Add each integration's `storybookEntryPreview` to `optimizeDeps.exclude`, so Vite serves them as source and the framework's own plugins transform them.

Also bumps the `integration/astro7` dev dependency to `vite ^8.1.0` (latest 8.x; the fix itself is version-independent within Vite 8).

## Verification

- Dev server: **astro, react, vue, svelte, preact, solid** stories all render with no console errors (previously all 500'd).
- Production build of `integration/astro7` still succeeds.
- 128 framework unit tests pass; framework lint clean.

> Note: the existing Playwright suite runs against the **built** static output, so this dev-only regression isn't covered by it. A dev-server test project would be a separate infra addition.