### PR TITLE
fix(framework): mark @vitejs/plugin-react as an optional peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `optimizeDeps.esbuildOptions` is now only set on Vite ≤7, removing the deprecation warning emitted under Vite 8 (the Rolldown optimizer reads `rolldownOptions`).
 - Storybook dev server no longer hangs with a blank preview under Astro 7 / Vite 8. Two Vite 8-only issues are now handled in the dev config: `@vitejs/plugin-react`'s native Fast Refresh wrapper (a Rolldown builtin) threw ``Missing field `moduleType` `` while transforming the preview `iframe.html`, 500-ing every story; and the dependency optimizer failed on the Storybook renderer entry-previews that ship non-JS source (e.g. `@storybook/svelte`'s `.svelte` files), 504-ing every renderer. React components still render in dev; only React Fast Refresh is unavailable (component edits trigger a full reload).
+- `@vitejs/plugin-react` is now an **optional** peer dependency, matching the other framework integrations. It was the only integration peer not marked optional, so `npm install` in a project without React (e.g. an Astro 6 / Vite 7 content site) tried to satisfy it, picked `@vitejs/plugin-react@6` (which requires Vite 8), and failed with `ERESOLVE` against the project's Vite 7.
 
 ## [1.6.0] - 2026-06-19
 

--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -135,6 +135,9 @@
     "@storybook/vue3": {
       "optional": true
     },
+    "@vitejs/plugin-react": {
+      "optional": true
+    },
     "@vitejs/plugin-vue": {
       "optional": true
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4816,6 +4816,8 @@ __metadata:
       optional: true
     "@storybook/vue3":
       optional: true
+    "@vitejs/plugin-react":
+      optional: true
     "@vitejs/plugin-vue":
       optional: true
     "@vitejs/plugin-vue-jsx":


### PR DESCRIPTION
## Problem

`npm install @storybook-astro/framework@canary` failed with `ERESOLVE` in a project on Vite 7 (an Astro 6 content site with no React):

```
Could not resolve dependency:
peer vite@"^8.0.0" from @vitejs/plugin-react@6.0.3
  peer @vitejs/plugin-react@"^5.0.0 || ^6.0.0" from @storybook-astro/framework
```

## Root cause

`@vitejs/plugin-react` was listed in `peerDependencies` but — unlike **every other** framework-integration peer (`@astrojs/*`, `@vitejs/plugin-vue`, `@vitejs/plugin-vue-jsx`, `storybook-solidjs`, …) — it was **missing from `peerDependenciesMeta` as `optional`**. npm therefore treated it as required, resolved the `^5.0.0 || ^6.0.0` range greedily to `@vitejs/plugin-react@6`, and that version peer-requires Vite 8 — conflicting with the project's Vite 7.

The project doesn't even use React, so the plugin should never have entered the resolution.

## Fix

Add `@vitejs/plugin-react` to `peerDependenciesMeta` as `optional`. npm now skips it for non-React projects; React projects still get a compatible `@vitejs/plugin-react` transitively through `@astrojs/react` (which pins `^5.2.0`, compatible with both Vite 7 and 8).

## Verification

Packed the framework with `yarn pack` and `npm install`ed it into a minimal **Astro 6 / Vite 7** project:

- **Before:** reproduces the exact `ERESOLVE` (`peer vite@"^8.0.0" from @vitejs/plugin-react@6.0.3`).
- **After:** clean install — `added 127 packages`, no error.