### PR TITLE
fix(framework): stub @storybook/preview in SSR prerender to fix "document is not defined"

### DIFF
--- a/packages/@storybook-astro/framework/src/storySsrVite.test.ts
+++ b/packages/@storybook-astro/framework/src/storySsrVite.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest';
+import { createStorybookBrowserStubPlugin } from './storySsrVite.ts';
+
+type HookFn = (id: string) => unknown;
+
+/** Calls a Vite resolveId/load hook regardless of whether it's a function or an object hook. */
+function callHook(hook: unknown, id: string) {
+  const handler = (typeof hook === 'function' ? hook : (hook as { handler: HookFn }).handler) as HookFn;
+
+  return handler.call({}, id);
+}
+
+describe('createStorybookBrowserStubPlugin', () => {
+  test('stubs @storybook/preview with a working CSF4 factory', async () => {
+    const plugin = createStorybookBrowserStubPlugin();
+
+    const resolved = callHook(plugin.resolveId, '@storybook/preview');
+    const source = callHook(plugin.load, resolved) as string;
+
+    // The stub must run as a real module: prerendering loads it to read each
+    // story's component and args, so evaluate the emitted source and exercise it.
+    const previewModule = await import(`data:text/javascript,${encodeURIComponent(source)}`);
+    const component = () => '';
+    const meta = previewModule.default.meta({ component, args: { size: 'lg' } });
+    const story = meta.story({ args: { label: 'Primary' } });
+
+    expect(story._tag).toBe('Story');
+    expect(story.input).toEqual({ args: { label: 'Primary' } });
+    expect(story.meta.input.component).toBe(component);
+    expect(story.meta.input.args).toEqual({ size: 'lg' });
+  });
+
+  test('stubs the browser-only docs packages', () => {
+    const plugin = createStorybookBrowserStubPlugin();
+
+    for (const specifier of [
+      '@storybook/addon-docs',
+      '@storybook/addon-docs/blocks',
+      '@storybook/blocks'
+    ]) {
+      const resolved = callHook(plugin.resolveId, specifier);
+
+      expect(resolved).toBeTruthy();
+      expect(callHook(plugin.load, resolved)).toContain('export default');
+    }
+  });
+
+  test('leaves unrelated specifiers untouched', () => {
+    const plugin = createStorybookBrowserStubPlugin();
+
+    expect(callHook(plugin.resolveId, '@storybook/addon-a11y')).toBeNull();
+    expect(callHook(plugin.resolveId, 'astro/runtime/server/index.js')).toBeNull();
+  });
+});

--- a/packages/@storybook-astro/framework/src/storySsrVite.ts
+++ b/packages/@storybook-astro/framework/src/storySsrVite.ts
@@ -253,26 +253,47 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-// Stubs Storybook's browser-only docs packages so a project's preview config
-// doesn't crash the SSR prerender. Stories import `@storybook/preview`, which
-// loads `.storybook/preview.ts`, which commonly registers the docs addon
-// (`import addonDocs from '@storybook/addon-docs'`). The docs addon pulls in
-// Storybook's UI kit, which reads `document.documentElement` at module load and
-// throws `document is not defined` under Node. The docs UI never runs during
-// prerendering — we only need each story's component and args — so replacing it
-// with a no-op is safe.
+// Stubs Storybook's browser-only modules so a project's preview config doesn't
+// crash the SSR prerender.
 //
-// `@storybook/addon-docs`'s default export is called as a function in preview
-// config (`addonDocs()`), so the stub exports a callable no-op. `blocks` are the
-// docs block components (used only inside MDX, which is not prerendered), and
-// `@storybook/blocks` is the pre-Storybook-10 path for those same blocks.
-function createStorybookBrowserStubPlugin(): Plugin {
+// CSF4 stories import `@storybook/preview` and build their meta with
+// `preview.meta(...).story(...)`. The real `@storybook/preview` re-exports the
+// project's `.storybook/preview.ts`, which registers addons (docs, a11y, themes,
+// …) whose UI kit reads `document` at module load and throws
+// `document is not defined` under Node. Those addons pull `storybook/internal/...`
+// in as externalized native imports, so a per-package stub can't reliably catch
+// every DOM-touching module they reach.
+//
+// Prerendering only needs each story's component and args, never preview-level
+// decorators/parameters or any addon. So we replace `@storybook/preview` with a
+// minimal CSF4 factory: `meta(input)` returns `{ input }` and `meta.story(input)`
+// returns the `{ _tag: 'Story', input, meta }` shape `resolveStoryAnnotations`
+// reads. This sidesteps the project preview and its entire addon graph.
+//
+// The docs-package stubs remain as defense in depth for any path that still loads
+// `.storybook/preview.ts` directly. `@storybook/addon-docs`'s default export is
+// called as a function in preview config, so it stubs to a callable no-op;
+// `blocks` are the docs block components (used only inside MDX, never prerendered)
+// and `@storybook/blocks` is the pre-Storybook-10 path for those same blocks.
+export function createStorybookBrowserStubPlugin(): Plugin {
   const STUBBED_SPECIFIERS = new Set([
     '@storybook/addon-docs',
     '@storybook/addon-docs/blocks',
     '@storybook/blocks'
   ]);
   const STUB_ID = '\0storybook-astro-browser-stub';
+  const PREVIEW_SPECIFIER = '@storybook/preview';
+  const PREVIEW_STUB_ID = '\0storybook-astro-preview-stub';
+  const PREVIEW_STUB_SOURCE = [
+    'const preview = {',
+    '  meta(input = {}) {',
+    '    const meta = { input };',
+    "    meta.story = (storyInput = {}) => ({ _tag: 'Story', input: storyInput, meta });",
+    '    return meta;',
+    '  }',
+    '};',
+    'export default preview;'
+  ].join('\n');
 
   return {
     name: 'storybook-astro:storybook-browser-stubs',
@@ -280,6 +301,10 @@ function createStorybookBrowserStubPlugin(): Plugin {
     // bare specifiers to their real (browser-only) files before we can stub them.
     enforce: 'pre',
     resolveId(id: string) {
+      if (id === PREVIEW_SPECIFIER) {
+        return PREVIEW_STUB_ID;
+      }
+
       if (STUBBED_SPECIFIERS.has(id)) {
         return STUB_ID;
       }
@@ -287,6 +312,10 @@ function createStorybookBrowserStubPlugin(): Plugin {
       return null;
     },
     load(id: string) {
+      if (id === PREVIEW_STUB_ID) {
+        return PREVIEW_STUB_SOURCE;
+      }
+
       if (id === STUB_ID) {
         return 'export default () => ({});';
       }


### PR DESCRIPTION
## Problem

`storybook build` (`build:storybook`) fails during the static **prerender** step with:

```
[plugin storybook-astro:build-prerender]
ReferenceError: document is not defined
  at storybook/dist/components/index.js
```

This reproduces on an Astro 7 / Vite 8 project using **CSF4** stories with `@storybook/addon-a11y` and `@storybook/addon-themes`.

## Root cause

The prerender runs an SSR Vite server under Node to render each Astro story to static HTML. CSF4 stories `import preview from "@storybook/preview"`, which re-exports the project's `.storybook/preview.ts` and registers addons. Those addons pull in `storybook/internal/components` (Storybook's browser UI kit), which reads `document` at module load → crash under Node.

The previous fix (#130) only stubbed the **docs** packages (`@storybook/addon-docs`, `@storybook/blocks`). `addon-a11y`/`addon-themes` reach the DOM-touching module through a *different*, externalized native-import path that a per-addon stub can't reliably intercept — so the crash returns through a new door whenever a project adds another addon whose UI kit touches the DOM.

## Fix

Stub **`@storybook/preview`** itself in the SSR prerender with a minimal CSF4 factory:

```js
const preview = {
  meta(input = {}) {
    const meta = { input };
    meta.story = (storyInput = {}) => ({ _tag: 'Story', input: storyInput, meta });
    return meta;
  }
};
export default preview;
```

Prerendering only needs each story's component and args (never preview-level decorators/parameters or any addon), so this sidesteps the project preview and its **entire** addon graph in one move — robust against *any* DOM-touching addon, not just docs. The existing docs-package stubs remain as defense in depth.

## Verification

- `build:storybook` now completes for a CSF4 + addon-a11y/addon-themes project on Astro 7 / Vite 8: **86 stories prerendered, 0 blank**, components render full HTML with their classes.
- Adds `storySsrVite.test.ts` (3 tests) covering the CSF4 stub shape, the docs stubs, and that unrelated specifiers pass through.
- Full suite green: **140 framework unit tests + all integration tests (astro5/6/7)**. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)