### PR TITLE
fix(framework): sanitize array slot entries as one document so split wrapper tags nest correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- An array slot's string entries are now sanitized together as one HTML document instead of each entry in isolation, so a wrapper tag's opening and closing halves can live in separate array entries around a component (#146). Previously, sanitization auto-closed an entry like `'<div>'` on its own and discarded a lone `'</div>'` in a later entry, so the component ended up rendered as a sibling after a self-closed wrapper instead of nested inside it.
+
 ## [1.8.0] - 2026-07-02
 
 ### Added

--- a/apps/website/src/content/docs/writing-stories/slots.md
+++ b/apps/website/src/content/docs/writing-stories/slots.md
@@ -189,6 +189,24 @@ Astro component **tags written inside a string** (e.g. `default: '<Badge>hi</Bad
 
 A configured component's `props` are passed to the child untouched — they are **not** HTML-sanitized (so values like `"A & B"` survive verbatim). Its `slots` are sanitized like any other string slot content.
 
+An array entry's HTML string doesn't need to be a self-contained fragment — a wrapper tag's opening and closing halves can live in separate entries, with a component sandwiched between them:
+
+```jsx
+export const WrappedChild = {
+  args: {
+    slots: {
+      default: [
+        '<div class="Panel">',
+        { component: Badge, slots: { default: 'Shipped' } },
+        '</div>',
+      ],
+    },
+  },
+};
+```
+
+The array's string entries are sanitized together as one HTML document (not each entry on its own), so the `<div>` opened in the first entry stays open until the matching `</div>` in the last entry — the component renders nested inside it, not as a sibling after a self-closed wrapper.
+
 ## Combining props and slots
 
 Props and slots are passed together in the same `args` object. Regular properties become `Astro.props`, and the `slots` property is handled separately by the renderer:

--- a/integration/astro7/src/components/SlotBox/SlotBox.stories.jsx
+++ b/integration/astro7/src/components/SlotBox/SlotBox.stories.jsx
@@ -36,3 +36,19 @@ export const MixedContent = {
     },
   },
 };
+
+// A wrapper tag's opening and closing halves live in separate array entries,
+// with the configured child sandwiched between them — issue #146's follow-up
+// report. Sanitization must parse the whole array as one document so the
+// child ends up nested inside the wrapper instead of the tag self-closing.
+export const WrappedChild = {
+  args: {
+    slots: {
+      default: [
+        '<div class="Wrapper">',
+        { component: BoxChild, slots: { default: '<p>Inside the wrapper</p>' } },
+        '</div>',
+      ],
+    },
+  },
+};

--- a/integration/astro7/src/components/SlotBox/SlotBox.test.ts
+++ b/integration/astro7/src/components/SlotBox/SlotBox.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from 'vitest';
 import { composeStories, renderStory } from '@storybook-astro/framework/testing';
 import * as stories from './SlotBox.stories.jsx';
 
-const { ConfiguredChild, MixedContent } = composeStories(stories);
+const { ConfiguredChild, MixedContent, WrappedChild } = composeStories(stories);
 
 test('renders a configured child component with its own props and slot content', async () => {
   await renderStory(ConfiguredChild);
@@ -24,4 +24,18 @@ test('renders plain HTML and a configured child mixed in one slot', async () => 
   expect(screen.getByTestId('box-child')).toBeInTheDocument();
   expect(screen.getByText('Inside the child')).toBeInTheDocument();
   expect(screen.getByText('After the child')).toBeInTheDocument();
+});
+
+test('renders a configured child nested inside a wrapper tag split across array entries', async () => {
+  await renderStory(WrappedChild);
+
+  // The wrapper's opening and closing tags are separate array entries with the
+  // child sandwiched between them — the child must end up nested inside the
+  // wrapper, not rendered as its sibling after a self-closed wrapper div.
+  const wrapper = document.querySelector('.Wrapper');
+  const child = screen.getByTestId('box-child');
+
+  expect(wrapper).toBeInTheDocument();
+  expect(wrapper).toContainElement(child);
+  expect(screen.getByText('Inside the wrapper')).toBeInTheDocument();
 });

--- a/packages/@storybook-astro/framework/src/lib/sanitization.test.ts
+++ b/packages/@storybook-astro/framework/src/lib/sanitization.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { resolveSanitizationOptions, sanitizeRenderPayload } from './sanitization.ts';
+import { reconstructSlots } from './reconstruct-component-args.ts';
 
 describe('sanitization', () => {
   test('enables sanitization and sanitizes all slots by default', () => {
@@ -257,5 +258,82 @@ describe('sanitization', () => {
     );
 
     expect((payload.args.meta as Record<string, unknown>).html).toBe('<p>Safe</p>');
+  });
+
+  test('keeps a tag balanced when its open and close are split across array entries around a component', () => {
+    const options = resolveSanitizationOptions();
+
+    const payload = sanitizeRenderPayload(
+      {
+        args: {},
+        slots: {
+          default: [
+            '<div class="wrapper">',
+            {
+              component: { __astroComponent: true, moduleId: '/Child.astro' },
+              slots: { default: 'inside' }
+            },
+            '</div>'
+          ]
+        }
+      },
+      options
+    );
+
+    // A per-entry sanitize pass would auto-close '<div class="wrapper">' on its
+    // own and discard the orphan '</div>' — this proves the entries are parsed
+    // as one balanced document instead.
+    expect(payload.slots.default).toEqual([
+      '<div class="wrapper">',
+      { component: { __astroComponent: true, moduleId: '/Child.astro' }, slots: { default: 'inside' } },
+      '</div>'
+    ]);
+  });
+
+  test('renders a component wrapped by a tag split across array entries end-to-end', async () => {
+    const options = resolveSanitizationOptions();
+
+    const payload = sanitizeRenderPayload(
+      {
+        args: {},
+        slots: {
+          default: [
+            '<div class="wrapper">',
+            { component: { __astroComponent: true, moduleId: '/Child.astro' } },
+            '</div>'
+          ]
+        }
+      },
+      options
+    );
+
+    const rendered = await reconstructSlots(payload.slots, {
+      loadComponent: async () =>
+        Object.assign(() => undefined, { isAstroComponentFactory: true as const, moduleId: '/Child.astro' }),
+      renderToHtml: async () => '<b>child</b>'
+    });
+
+    expect(rendered.default).toBe('<div class="wrapper"><b>child</b></div>');
+  });
+
+  test('drops a component entry whose surrounding tag is fully discarded by sanitization', () => {
+    const options = resolveSanitizationOptions();
+
+    const payload = sanitizeRenderPayload(
+      {
+        args: {},
+        slots: {
+          default: [
+            '<script>',
+            { component: { __astroComponent: true, moduleId: '/Child.astro' } },
+            '</script>',
+            '<p>after</p>'
+          ]
+        }
+      },
+      options
+    );
+
+    expect(payload.slots.default).toEqual(['<p>after</p>']);
   });
 });

--- a/packages/@storybook-astro/framework/src/lib/sanitization.ts
+++ b/packages/@storybook-astro/framework/src/lib/sanitization.ts
@@ -269,11 +269,7 @@ function sanitizeValue(
   }
 
   if (Array.isArray(value)) {
-    return value.map((item, index) => {
-      const nextPath = `${currentPath}.${index}`;
-
-      return sanitizeValue(item, nextPath, patterns, options);
-    });
+    return sanitizeArrayValue(value, currentPath, patterns, options);
   }
 
   // A configured component slot ({ component, props, slots }): only its `slots`
@@ -303,6 +299,71 @@ function sanitizeValue(
   }
 
   return value;
+}
+
+/**
+ * Sanitizes an array slot's string entries as **one** HTML document instead
+ * of each entry in isolation. A per-entry pass would auto-close a tag opened
+ * in one entry (e.g. `'<div>'`) and discard an orphan closing tag in a later
+ * entry (e.g. `'</div>'`) before the array is ever joined — breaking the
+ * common pattern of wrapping a component entry in a container element.
+ * Every entry that isn't a sanitizable string (components, nested
+ * descriptors, excluded paths) is swapped for a unique placeholder so the
+ * parser sees one balanced tree, then the sanitized document is split back
+ * apart on those placeholders.
+ */
+function sanitizeArrayValue(
+  items: unknown[],
+  currentPath: string,
+  patterns: string[],
+  options: IOptions
+): unknown[] {
+  const sanitizableIndexes = new Set<number>();
+
+  items.forEach((item, index) => {
+    if (typeof item === 'string' && shouldSanitizePath(`${currentPath}.${index}`, patterns)) {
+      sanitizableIndexes.add(index);
+    }
+  });
+
+  if (sanitizableIndexes.size === 0) {
+    return items.map((item, index) => sanitizeValue(item, `${currentPath}.${index}`, patterns, options));
+  }
+
+  const nonce = Math.random().toString(36).slice(2);
+  const placeholderFor = (index: number) => `astro-slot-array-item-${nonce}-${index}`;
+
+  const document = items
+    .map((item, index) => (sanitizableIndexes.has(index) ? (item as string) : placeholderFor(index)))
+    .join('');
+
+  let remaining = sanitizeHtml(document, options);
+  const result: unknown[] = [];
+
+  items.forEach((item, index) => {
+    if (sanitizableIndexes.has(index)) {
+      return;
+    }
+
+    const placeholder = placeholderFor(index);
+    const placeholderIndex = remaining.indexOf(placeholder);
+
+    // A missing placeholder means its surrounding tag was disallowed and
+    // discarded along with its contents — there is nothing to splice in.
+    if (placeholderIndex === -1) {
+      return;
+    }
+
+    result.push(remaining.slice(0, placeholderIndex));
+    result.push(
+      typeof item === 'string' ? item : sanitizeValue(item, `${currentPath}.${index}`, patterns, options)
+    );
+    remaining = remaining.slice(placeholderIndex + placeholder.length);
+  });
+
+  result.push(remaining);
+
+  return result;
 }
 
 function shouldSanitizePath(path: string, patterns: string[]): boolean {


### PR DESCRIPTION
Closes #146 (follow-up from the final comment after the 1.8.0 release).

## Problem

After 1.8.0 shipped configured-component slots (#147), a follow-up report on #146 found that wrapping a component in a container tag split across array entries didn't nest correctly:

```jsx
slots: {
  default: [
    '<div class="container">',
    { component: BoxChild, slots: { default: '...' } },
    '</div>',
  ],
}
```

`BoxChild` rendered as a sibling after the wrapper instead of inside it.

## Root cause

`sanitization.ts` sanitized each array entry independently, before the array was joined. `sanitize-html` parses each string as its own document, so `'<div class="container">'` alone gets auto-closed to `'<div class="container"></div>'`, and the orphan `'</div>'` entry is discarded as an unmatched closing tag — both happen before `reconstruct-component-args.ts` ever concatenates the array.

## Fix

Array string entries are now sanitized together as **one** HTML document instead of each in isolation. Non-string entries (components, configured-component descriptors, or strings excluded by a sanitization path pattern) are swapped for a unique placeholder so the parser sees a single balanced tree; the sanitized result is then split back apart on those placeholders. This preserves existing behavior for self-contained fragments and only changes behavior for tags that span array entries.

## Tests

- Unit tests in `sanitization.test.ts`: balanced split-tag sanitization, end-to-end render via `reconstructSlots`, and a graceful-degrade case where a placeholder's surrounding disallowed tag (e.g. `<script>`) is discarded entirely.
- New `WrappedChild` story + test in `integration/astro7`'s `SlotBox` fixture, exercising the fix through the real Astro Container SSR pipeline.
- Full suite green: framework, renderer, astro5/6/7 integrations (191 tests). Lint clean.

## Docs

- `writing-stories/slots.md`: documents that array entries are sanitized as one document, with an example of wrapping a component in a split tag.
- `CHANGELOG.md`: added under `[Unreleased]`.