### PR TITLE
ci: add Chromatic visual regression workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,59 @@
+name: Chromatic
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+# Cancel superseded runs on the same ref to save snapshots
+concurrency:
+  group: chromatic-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  visual-regression:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - astro: '5'
+            workingDir: integration/astro5
+            token: CHROMATIC_PROJECT_TOKEN_ASTRO5
+          - astro: '6'
+            workingDir: integration/astro6
+            token: CHROMATIC_PROJECT_TOKEN_ASTRO6
+          - astro: '7'
+            workingDir: integration/astro7
+            token: CHROMATIC_PROJECT_TOKEN_ASTRO7
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Chromatic needs full history for baselines/TurboSnap
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build packages
+        run: yarn build:packages
+
+      - name: Run Chromatic (Astro ${{ matrix.astro }})
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets[matrix.token] }}
+          workingDir: ${{ matrix.workingDir }}
+          buildScriptName: build
+          exitZeroOnChanges: true
+          onlyChanged: false
+        env:
+          STORYBOOK_DISABLE_TELEMETRY: 1

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
     "astro-eslint-parser": "^1.2.2",
+    "chromatic": "^11.0.0",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-astro": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7739,6 +7739,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chromatic@npm:^11.0.0":
+  version: 11.29.0
+  resolution: "chromatic@npm:11.29.0"
+  peerDependencies:
+    "@chromatic-com/cypress": ^0.*.* || ^1.0.0
+    "@chromatic-com/playwright": ^0.*.* || ^1.0.0
+  peerDependenciesMeta:
+    "@chromatic-com/cypress":
+      optional: true
+    "@chromatic-com/playwright":
+      optional: true
+  bin:
+    chroma: dist/bin.js
+    chromatic: dist/bin.js
+    chromatic-cli: dist/bin.js
+  checksum: 10c0/4c26e00a170cb40b38f837358fbcab51ab0bdf3644a396b166074cd167696be6a34eeb5583e65425f4392845c8a3052f6d538ea9fb0d09a903100c52d858b4f9
+  languageName: node
+  linkType: hard
+
 "chromatic@npm:^13.3.4":
   version: 13.3.5
   resolution: "chromatic@npm:13.3.5"
@@ -14607,6 +14626,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.18.2"
     "@typescript-eslint/parser": "npm:^8.18.2"
     astro-eslint-parser: "npm:^1.2.2"
+    chromatic: "npm:^11.0.0"
     eslint: "npm:^9.39.2"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-astro: "npm:^1.3.2"


### PR DESCRIPTION
## Summary
- Activates the already-installed but dormant `@chromatic-com/storybook` Visual Tests addon by adding a `chromatic` CLI dependency and a new `.github/workflows/chromatic.yml` CI workflow.
- Runs Chromatic as a 3-way matrix across the Astro 5/6/7 integration apps, each treated as its own Chromatic project, catching visual regressions (scoped CSS, slot rendering, hydration) that the existing Playwright DOM assertions can't see.
- `exitZeroOnChanges: true` so visual diffs surface for review in the Chromatic UI without hard-failing PRs while baselines are still being established.

## Manual setup required before this workflow can run green
- Create three Chromatic projects (one per Astro integration app) linked to this repo.
- Add repo secrets: `CHROMATIC_PROJECT_TOKEN_ASTRO5`, `CHROMATIC_PROJECT_TOKEN_ASTRO6`, `CHROMATIC_PROJECT_TOKEN_ASTRO7`.

## Test plan
- [x] `yarn install` resolves `chromatic@^11.0.0` cleanly
- [x] `yarn lint` passes
- [ ] Chromatic secrets added, then confirm the workflow runs and establishes baselines for all three projects
- [ ] Introduce a deliberate visual change and confirm Chromatic flags it across projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)