### PR TITLE
fix(framework): collect islands from nested .astro imports in the static build

### DIFF
--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.test.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.test.ts
@@ -85,6 +85,50 @@ describe('collectHydratedComponentPaths', () => {
     expect(result).not.toContain(missingTsx.replace(/\\/g, '/'));
   });
 
+  test('collects an island declared inside a nested .astro component', async () => {
+    // A story's .astro component can compose other .astro components that own
+    // the actual islands. Without recursing into nested .astro imports, those
+    // islands never become build inputs and their `component-url` stays a raw
+    // filesystem path in the prerendered static output (404, no hydration).
+    const storyAstro = join(tmpDir, 'Page.astro');
+    const nestedAstro = join(tmpDir, 'Section.astro');
+    const vueFile = join(tmpDir, 'Counter.vue');
+
+    await writeFile(storyAstro, `---\nimport Section from './Section.astro';\n---\n<Section />`);
+    await writeFile(
+      nestedAstro,
+      `---\nimport Counter from './Counter.vue';\n---\n<Counter client:visible />`
+    );
+    await writeFile(
+      vueFile,
+      `<script setup>\nconst count = ref(0);\n</script>\n<template><button>{{ count }}</button></template>`
+    );
+
+    const result = await collectHydratedComponentPaths(storyAstro, tmpDir);
+
+    expect(result).toContain(vueFile.replace(/\\/g, '/'));
+  });
+
+  test('does not loop on circular .astro imports', async () => {
+    const firstAstro = join(tmpDir, 'First.astro');
+    const secondAstro = join(tmpDir, 'Second.astro');
+    const vueFile = join(tmpDir, 'Counter.vue');
+
+    await writeFile(
+      firstAstro,
+      `---\nimport Second from './Second.astro';\n---\n<Second />`
+    );
+    await writeFile(
+      secondAstro,
+      `---\nimport First from './First.astro';\nimport Counter from './Counter.vue';\n---\n<Counter client:visible />`
+    );
+    await writeFile(vueFile, `<template><button>hi</button></template>`);
+
+    const result = await collectHydratedComponentPaths(firstAstro, tmpDir);
+
+    expect(result).toContain(vueFile.replace(/\\/g, '/'));
+  });
+
   test('includes a tsconfig-aliased island (the static build fix)', async () => {
     // Islands imported via path aliases never matched the staticModuleMap because
     // readLocalImportSpecifiers filtered them out before they could become Rollup

--- a/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroBuildShared.ts
@@ -100,7 +100,17 @@ export async function emitHydratedComponentEntriesFromAstroFile(options: {
 }
 
 /** Collects the framework component files one Astro component hydrates in the browser. */
-export async function collectHydratedComponentPaths(astroFilePath: string, resolveFrom: string) {
+export async function collectHydratedComponentPaths(
+  astroFilePath: string,
+  resolveFrom: string,
+  visited = new Set<string>()
+): Promise<string[]> {
+  if (visited.has(astroFilePath)) {
+    return [];
+  }
+
+  visited.add(astroFilePath);
+
   // Only Astro components create islands, so only their framework imports
   // need standalone client chunks in built Storybook output.
   const allImportSpecifiers = await readAllImportSpecifiers(astroFilePath);
@@ -114,6 +124,16 @@ export async function collectHydratedComponentPaths(astroFilePath: string, resol
       : await resolveAliasedIsland(specifier, resolveFrom);
 
     if (!resolvedImportPath) {
+      continue;
+    }
+
+    // Nested .astro components render on the server but can declare their own
+    // islands (`client:*`), so their framework imports need client chunks too.
+    if (resolvedImportPath.endsWith('.astro')) {
+      hydratedComponentPaths.push(
+        ...(await collectHydratedComponentPaths(resolvedImportPath, resolveFrom, visited))
+      );
+
       continue;
     }
 


### PR DESCRIPTION
Fixes #167

### What

`collectHydratedComponentPaths()` only inspected the top-level `.astro` file's imports, so islands (`client:*`) declared inside nested `.astro` components never became build inputs for the static pipeline. Their `<astro-island component-url>` stayed a raw filesystem path in `astro-prerendered-stories.json` — a 404 and no hydration on a published static Storybook.

### How

- Recurse into imports that resolve to `.astro` files, reusing the same resolution rules (relative imports via `resolveLocalImportPath`, aliased via `resolveAliasedIsland`), so nested islands feed `buildHydratedComponentAssets()`/`emitHydratedComponentEntriesFromAstroFile()` exactly like top-level ones and get rewritten to built `./_astro/*.js` assets with their extracted CSS.
- Guard with a `visited` set so circular `.astro` imports terminate.

### Tests

Two new cases in `vitePluginAstroBuildShared.test.ts`, following the file's existing fixture pattern:

- a story `.astro` importing a nested `.astro` that hydrates a `.vue` island (`client:visible`) — the island path is collected (fails without the fix);
- circular `.astro` imports still terminate and collect the island.

`yarn test` (full monorepo suite) and `yarn lint` pass.
