### PR TITLE
fix(framework): inject user astro.config vite plugins into all render pipelines

### DIFF
--- a/packages/@storybook-astro/framework/src/lib/hydratedComponentBuild.test.ts
+++ b/packages/@storybook-astro/framework/src/lib/hydratedComponentBuild.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+import { buildHydratedComponentAssets } from './hydratedComponentBuild.ts';
+
+describe('buildHydratedComponentAssets', () => {
+  test('receives vite plugins declared in the project astro.config', async () => {
+    // The fixture must live inside the package (not the OS tmpdir) so that
+    // `importAstroConfig` can resolve `astro/config` by walking up from it.
+    const packageDir = fileURLToPath(new URL('../..', import.meta.url));
+    const fixtureDir = await mkdtemp(join(packageDir, '.vitest-island-fixture-'));
+    const outDir = join(fixtureDir, 'out');
+
+    try {
+      await writeFile(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({ name: 'island-fixture', type: 'module', private: true })
+      );
+      // The island imports a virtual module that only the user's vite plugin
+      // can resolve — the build fails unless the plugin is injected.
+      await writeFile(
+        join(fixtureDir, 'astro.config.mjs'),
+        [
+          'const userPlugin = {',
+          "  name: 'user-test-plugin',",
+          '  resolveId(id) {',
+          "    if (id === 'virtual:user-plugin-probe') return '\\0user-plugin-probe';",
+          '  },',
+          '  load(id) {',
+          "    if (id === '\\0user-plugin-probe') return 'export default \"USER_PLUGIN_APPLIED\";';",
+          '  }',
+          '};',
+          'export default { vite: { plugins: [userPlugin] } };'
+        ].join('\n')
+      );
+      await writeFile(
+        join(fixtureDir, 'Island.jsx'),
+        [
+          "import probe from 'virtual:user-plugin-probe';",
+          'export default function Island() {',
+          '  return probe;',
+          '}'
+        ].join('\n')
+      );
+      await writeFile(
+        join(fixtureDir, 'Wrapper.astro'),
+        ['---', "import Island from './Island.jsx';", '---', '<Island client:load />'].join('\n')
+      );
+
+      const assets = await buildHydratedComponentAssets({
+        componentPaths: [join(fixtureDir, 'Wrapper.astro')],
+        integrations: [],
+        resolveFrom: fixtureDir,
+        outDir
+      });
+
+      const islandPath = join(fixtureDir, 'Island.jsx').replace(/\\/g, '/');
+      const chunkRelPath = assets.staticModuleMap[islandPath];
+
+      expect(chunkRelPath).toBeTruthy();
+
+      const chunkCode = await readFile(join(outDir, chunkRelPath), 'utf-8');
+
+      expect(chunkCode).toContain('USER_PLUGIN_APPLIED');
+    } finally {
+      await rm(fixtureDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/packages/@storybook-astro/framework/src/lib/hydratedComponentBuild.ts
+++ b/packages/@storybook-astro/framework/src/lib/hydratedComponentBuild.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { build, type Rollup } from 'vite';
 import type { Integration } from '../integrations/index.ts';
+import { appendUserVitePlugins, loadUserAstroVitePlugins } from '../loadUserAstroConfig.ts';
 import { mergeWithAstroConfig } from '../vitePluginAstro.ts';
 import { collectHydratedComponentPaths } from '../vitePluginAstroBuildShared.ts';
 import type { StaticCssMap, StaticModuleMap } from './staticHtmlRewriting.ts';
@@ -97,6 +98,13 @@ export async function buildHydratedComponentAssets(
     'production',
     'build'
   );
+
+  // The main Storybook build auto-loads `vite.plugins` from the user's
+  // astro.config (see preset.ts). The island asset build must receive the same
+  // plugins, or hydrated components relying on one of them (e.g.
+  // vite-svg-loader's `.svg?component` imports) fail to bundle correctly.
+  appendUserVitePlugins(finalConfig, await loadUserAstroVitePlugins(options.resolveFrom));
+
   const buildResult = (await build(finalConfig)) as BuiltOutput | BuiltOutput[];
   const output = Array.isArray(buildResult)
     ? buildResult.flatMap((result) => result.output)

--- a/packages/@storybook-astro/framework/src/loadUserAstroConfig.test.ts
+++ b/packages/@storybook-astro/framework/src/loadUserAstroConfig.test.ts
@@ -2,7 +2,9 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import type { Plugin, PluginOption } from 'vite';
 import {
+  appendUserVitePlugins,
   loadUserAstroFonts,
   loadUserAstroIntegrations,
   loadUserAstroVitePlugins
@@ -128,6 +130,62 @@ describe('loadUserAstroVitePlugins', () => {
     const plugins = await loadUserAstroVitePlugins(tmpDir);
 
     expect(plugins.map((p) => p.name)).toEqual(['real']);
+  });
+});
+
+describe('appendUserVitePlugins', () => {
+  function pluginNames(plugins: PluginOption[] | undefined): string[] {
+    return (((plugins ?? []) as unknown[]).flat(Infinity) as Plugin[]).map((p) => p.name);
+  }
+
+  test('appends plugins loaded from astro.config to a pipeline Vite config', async () => {
+    await writeConfig(`
+      export default {
+        vite: {
+          plugins: [{ name: 'vite-svg-loader' }]
+        }
+      };
+    `);
+
+    const config: { plugins?: PluginOption[] } = { plugins: [{ name: 'astro:build' }] };
+    const appended = appendUserVitePlugins(config, await loadUserAstroVitePlugins(tmpDir));
+
+    expect(appended.map((p) => p.name)).toEqual(['vite-svg-loader']);
+    expect(pluginNames(config.plugins)).toEqual(['astro:build', 'vite-svg-loader']);
+  });
+
+  test('skips plugins already registered under the same name, even in nested arrays', () => {
+    const config: { plugins?: PluginOption[] } = {
+      plugins: [[{ name: 'vite-svg-loader' }], { name: 'astro:build' }]
+    };
+
+    const appended = appendUserVitePlugins(config, [
+      { name: 'vite-svg-loader' },
+      { name: 'my-i18n-plugin' }
+    ]);
+
+    expect(appended.map((p) => p.name)).toEqual(['my-i18n-plugin']);
+    expect(pluginNames(config.plugins)).toEqual([
+      'vite-svg-loader',
+      'astro:build',
+      'my-i18n-plugin'
+    ]);
+  });
+
+  test('initializes plugins when the config has none', () => {
+    const config: { plugins?: PluginOption[] } = {};
+
+    appendUserVitePlugins(config, [{ name: 'vite-svg-loader' }]);
+
+    expect(pluginNames(config.plugins)).toEqual(['vite-svg-loader']);
+  });
+
+  test('leaves the config untouched when there are no user plugins', () => {
+    const plugins: PluginOption[] = [{ name: 'astro:build' }];
+    const config = { plugins };
+
+    expect(appendUserVitePlugins(config, [])).toEqual([]);
+    expect(config.plugins).toBe(plugins);
   });
 });
 

--- a/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
+++ b/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
@@ -1,4 +1,4 @@
-import { loadConfigFromFile, type Plugin } from 'vite';
+import { loadConfigFromFile, type Plugin, type PluginOption } from 'vite';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { AstroIntegration } from 'astro';
@@ -157,4 +157,41 @@ export async function loadUserAstroFonts(resolveFrom: string): Promise<Storybook
  */
 export async function loadUserAstroVitePlugins(resolveFrom: string): Promise<Plugin[]> {
   return (await loadUserAstroConfigData(resolveFrom)).vitePlugins;
+}
+
+/**
+ * Appends user Vite plugins (from `loadUserAstroVitePlugins`) to a Vite
+ * config, skipping any plugin whose name is already registered.  Every render
+ * pipeline — the main Storybook build, the static prerender's SSR server, the
+ * hydrated-island asset build and the dev-mode internal SSR server — must
+ * receive these plugins, otherwise components that rely on one of them (e.g.
+ * `vite-svg-loader`'s `.svg?component` imports) resolve differently between
+ * pipelines.  Returns the plugins that were actually appended so callers can
+ * log them.
+ */
+export function appendUserVitePlugins(
+  config: { plugins?: PluginOption[] },
+  userVitePlugins: Plugin[]
+): Plugin[] {
+  if (userVitePlugins.length === 0) {
+    return [];
+  }
+
+  const existingNames = new Set<string>();
+
+  for (const plugin of ((config.plugins ?? []) as unknown[]).flat(Infinity) as Array<{
+    name?: string;
+  }>) {
+    if (plugin && typeof plugin === 'object' && typeof plugin.name === 'string') {
+      existingNames.add(plugin.name);
+    }
+  }
+
+  const newPlugins = userVitePlugins.filter((plugin) => !existingNames.has(plugin.name));
+
+  if (newPlugins.length > 0) {
+    config.plugins = [...(config.plugins ?? []), ...newPlugins];
+  }
+
+  return newPlugins;
 }

--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -13,7 +13,11 @@ import { vitePluginAstroVueFallback } from './vitePluginAstroVueFallback.ts';
 import { vitePluginAstroToolbarFallback } from './vitePluginAstroToolbarFallback.ts';
 import { resolveSanitizationOptions } from './lib/sanitization.ts';
 import { mergeWithAstroConfig } from './vitePluginAstro.ts';
-import { loadUserAstroFonts, loadUserAstroVitePlugins } from './loadUserAstroConfig.ts';
+import {
+  appendUserVitePlugins,
+  loadUserAstroFonts,
+  loadUserAstroVitePlugins
+} from './loadUserAstroConfig.ts';
 
 export const core = {
   builder: '@storybook/builder-vite',
@@ -147,24 +151,12 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
   // than Astro integrations (e.g. `@tailwindcss/vite`, `unocss/vite`) which
   // the integration auto-loader does not pick up.
   const userVitePlugins = await loadUserAstroVitePlugins(options.resolveFrom);
+  const newPlugins = appendUserVitePlugins(finalConfig, userVitePlugins);
 
-  if (userVitePlugins.length > 0) {
-    const existingNames = new Set<string>();
-
-    for (const plugin of (finalConfig.plugins ?? []).flat(Infinity) as Array<{ name?: string }>) {
-      if (plugin && typeof plugin === 'object' && typeof plugin.name === 'string') {
-        existingNames.add(plugin.name);
-      }
-    }
-
-    const newPlugins = userVitePlugins.filter((plugin) => !existingNames.has(plugin.name));
-
-    if (newPlugins.length > 0) {
-      console.warn(
-        `[storybook-astro] Auto-loaded ${newPlugins.length} vite plugin${newPlugins.length === 1 ? '' : 's'} from astro.config: ${newPlugins.map((p) => p.name).join(', ')}`
-      );
-      finalConfig.plugins = [...(finalConfig.plugins ?? []), ...newPlugins];
-    }
+  if (newPlugins.length > 0) {
+    console.warn(
+      `[storybook-astro] Auto-loaded ${newPlugins.length} vite plugin${newPlugins.length === 1 ? '' : 's'} from astro.config: ${newPlugins.map((p) => p.name).join(', ')}`
+    );
   }
 
   // Exclude Astro integration packages from dependency optimization because

--- a/packages/@storybook-astro/framework/src/storySsrVite.test.ts
+++ b/packages/@storybook-astro/framework/src/storySsrVite.test.ts
@@ -1,5 +1,8 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
-import { createStorybookBrowserStubPlugin } from './storySsrVite.ts';
+import { createStorybookBrowserStubPlugin, createStorySsrViteServer } from './storySsrVite.ts';
 
 type HookFn = (id: string) => unknown;
 
@@ -9,6 +12,42 @@ function callHook(hook: unknown, id: string) {
 
   return handler.call({}, id);
 }
+
+describe('createStorySsrViteServer', () => {
+  test('receives vite plugins declared in the project astro.config', async () => {
+    // The fixture must live inside the package (not the OS tmpdir) so that
+    // `importAstroConfig` can resolve `astro/config` by walking up from it.
+    const packageDir = fileURLToPath(new URL('..', import.meta.url));
+    const fixtureDir = await mkdtemp(join(packageDir, '.vitest-ssr-fixture-'));
+
+    try {
+      await writeFile(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({ name: 'ssr-fixture', type: 'module', private: true })
+      );
+      await writeFile(
+        join(fixtureDir, 'astro.config.mjs'),
+        `export default { vite: { plugins: [{ name: 'user-test-plugin' }] } };`
+      );
+
+      const viteServer = await createStorySsrViteServer({
+        integrations: [],
+        trackedSpecifiers: new Set(),
+        resolveFrom: fixtureDir
+      });
+
+      try {
+        const pluginNames = viteServer.config.plugins.map((plugin) => plugin.name);
+
+        expect(pluginNames).toContain('user-test-plugin');
+      } finally {
+        await viteServer.close();
+      }
+    } finally {
+      await rm(fixtureDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});
 
 describe('createStorybookBrowserStubPlugin', () => {
   test('stubs @storybook/preview with a working CSF4 factory', async () => {

--- a/packages/@storybook-astro/framework/src/storySsrVite.ts
+++ b/packages/@storybook-astro/framework/src/storySsrVite.ts
@@ -6,6 +6,7 @@ import { importAstroConfig } from './importAstroConfig.ts';
 import type { Integration } from './integrations/index.ts';
 import { resolveAliasedIsland } from './lib/resolve-aliased-island.ts';
 import { ssrLoadModuleWithFsFallback } from './lib/ssr-load-module-with-fs-fallback.ts';
+import { appendUserVitePlugins, loadUserAstroVitePlugins } from './loadUserAstroConfig.ts';
 import { resolveStoryModuleMock } from './module-mocks.ts';
 import type { FrameworkOptions } from './types.ts';
 import { vitePluginAstroFonts } from './vitePluginAstroFonts.ts';
@@ -56,6 +57,12 @@ export async function createStorySsrViteServer(options: {
       createStorybookBrowserStubPlugin()
     ]
   });
+
+  // The main Storybook build auto-loads `vite.plugins` from the user's
+  // astro.config (see preset.ts). The prerender SSR server must receive the
+  // same plugins, or components relying on one of them (e.g. vite-svg-loader's
+  // `.svg?component` imports) resolve differently in the static output.
+  appendUserVitePlugins(config, await loadUserAstroVitePlugins(options.resolveFrom));
 
   const viteServer = await createServer(config);
 

--- a/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
+++ b/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
@@ -1,7 +1,14 @@
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import type { ServerResponse } from 'node:http';
-import { createServer, createLogger, type Connect, type PluginOption, type ViteDevServer } from 'vite';
+import {
+  createServer,
+  createLogger,
+  type Connect,
+  type InlineConfig,
+  type PluginOption,
+  type ViteDevServer
+} from 'vite';
 import type { RenderRequestMessage, RenderResponseMessage } from '@storybook-astro/renderer/types';
 import type { FrameworkOptions } from './types.ts';
 import type { Integration } from './integrations/index.ts';
@@ -14,7 +21,11 @@ import { vitePluginAstroRoutesFallback } from './vitePluginAstroRoutesFallback.t
 import { vitePluginStoryModuleMocks } from './vitePluginStoryModuleMocks.ts';
 import { ssrLoadModuleWithFsFallback } from './lib/ssr-load-module-with-fs-fallback.ts';
 import { resolveRulesConfigFilePath } from './rules-options.ts';
-import { loadUserAstroIntegrations } from './loadUserAstroConfig.ts';
+import {
+  appendUserVitePlugins,
+  loadUserAstroIntegrations,
+  loadUserAstroVitePlugins
+} from './loadUserAstroConfig.ts';
 
 export async function vitePluginStorybookAstroMiddleware(options: FrameworkOptions) {
   // The internal Vite server is created lazily inside configureServer (dev-only).
@@ -195,7 +206,7 @@ export async function createViteServer(
     }
   )({ mode: 'development', command: 'serve' });
 
-  const viteServer = await createServer({
+  const serverConfig: InlineConfig = {
     configFile: false,
     ...config,
     // Astro's own runtime (e.g. `astro/assets/runtime`'s `createSvgComponent`,
@@ -224,7 +235,15 @@ export async function createViteServer(
       ...(config.plugins?.filter(Boolean) ?? []),
       viteAstroContainerRenderersPlugin(safeIntegrations)
     ]
-  });
+  };
+
+  // The main Storybook build auto-loads `vite.plugins` from the user's
+  // astro.config (see preset.ts). The internal SSR server must receive the
+  // same plugins, or components relying on one of them (e.g. vite-svg-loader's
+  // `.svg?component` imports) fail to render in dev mode.
+  appendUserVitePlugins(serverConfig, await loadUserAstroVitePlugins(resolveFrom));
+
+  const viteServer = await createServer(serverConfig);
 
   // Initialize the server's plugin container to ensure all plugins are ready.
   // Without this, some plugins (like vite:css) may have uninitialized state


### PR DESCRIPTION
Fixes #169

Vite plugins auto-loaded from the project's `astro.config.*` (`loadUserAstroVitePlugins`) were only appended to the main Storybook build in `viteFinal`. The static prerender's SSR server (`createStorySsrViteServer`), the hydrated-island asset build (`buildHydratedComponentAssets`) and the dev-mode internal SSR server (`createViteServer`) never received them, so components depending on a project Vite plugin (e.g. `vite-svg-loader`'s `.svg?component` imports) rendered broken markup in the static output — data-URI element tags in prerendered HTML and `InvalidCharacterError` on hydration.

### Changes

- Extracted the existing dedupe-and-append block from `viteFinal` into a shared `appendUserVitePlugins(config, userVitePlugins)` helper in `loadUserAstroConfig.ts` (skips plugins whose name is already registered; returns what was appended). `viteFinal` behavior and its "Auto-loaded N vite plugins" warning are unchanged.
- Applied the helper, after the config is composed and before the server/build starts, in the three missing pipelines: `storySsrVite.ts`, `lib/hydratedComponentBuild.ts`, `viteStorybookAstroMiddlewarePlugin.ts`.

### Tests

- Unit tests for `appendUserVitePlugins` (append, dedupe incl. nested plugin arrays, no-op cases, loading from a real `astro.config.mjs`).
- Integration test: `createStorySsrViteServer` on a fixture project asserts the user plugin ends up in the resolved server config.
- Integration test: `buildHydratedComponentAssets` on a fixture where the island imports a virtual module only the user plugin can resolve — the build fails without the fix and the emitted chunk contains the plugin's output with it.

Both integration tests fail on `develop` without the source change. Full suite: 183 tests passing, lint and `tsup` build green.
