### PR TITLE
fix(framework): per-pipeline user vite plugin instances, vitest config coverage, and CI coverage for #169

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ coverage/
 test-results/
 playwright-report/
 
+# temporary fixture projects written by framework tests; they live inside the
+# package so `importAstroConfig` can resolve `astro/config` by walking up
+**/.vitest-*-fixture-*/
+
 # generated types
 .astro/
 

--- a/integration/astro6/astro.config.mjs
+++ b/integration/astro6/astro.config.mjs
@@ -6,10 +6,14 @@ import vue from '@astrojs/vue';
 import preact from '@astrojs/preact';
 import svelte from '@astrojs/svelte';
 import alpinejs from '@astrojs/alpinejs';
+import { projectBanner } from './vite-plugin-project-banner.mjs';
 
 // https://astro.build/config
 export default defineConfig({
   output: 'static',
+  vite: {
+    plugins: [projectBanner()],
+  },
   fonts: [
     {
       provider: fontProviders.google(),

--- a/integration/astro6/src/components/VitePluginDemo/VitePluginCounter.vue
+++ b/integration/astro6/src/components/VitePluginDemo/VitePluginCounter.vue
@@ -1,0 +1,16 @@
+<template>
+  <button
+    data-testid="vite-plugin-island"
+    @click="clicks++"
+  >
+    {{ banner }} — clicks: {{ clicks }}
+  </button>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import banner from 'virtual:project-banner';
+
+const clicks = ref(0);
+
+</script>

--- a/integration/astro6/src/components/VitePluginDemo/VitePluginDemo.astro
+++ b/integration/astro6/src/components/VitePluginDemo/VitePluginDemo.astro
@@ -1,0 +1,7 @@
+---
+import banner from 'virtual:project-banner';
+import VitePluginCounter from './VitePluginCounter.vue';
+---
+
+<div data-testid="vite-plugin-astro">{banner}</div>
+<VitePluginCounter client:load />

--- a/integration/astro6/src/components/VitePluginDemo/VitePluginDemo.stories.jsx
+++ b/integration/astro6/src/components/VitePluginDemo/VitePluginDemo.stories.jsx
@@ -1,0 +1,16 @@
+import VitePluginDemo from './VitePluginDemo.astro';
+
+export default {
+  title: 'Astro/Vite Plugin Demo',
+  component: VitePluginDemo,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Both the Astro component and its hydrated Vue island import a virtual module that only a project-level `vite.plugins` entry in `astro.config.mjs` can resolve. If any render pipeline is missing those plugins the story fails to build or render (issue #169).',
+      },
+    },
+  },
+};
+
+export const Default = {};

--- a/integration/astro6/src/components/VitePluginDemo/VitePluginDemo.test.ts
+++ b/integration/astro6/src/components/VitePluginDemo/VitePluginDemo.test.ts
@@ -1,0 +1,17 @@
+import { screen } from '@testing-library/dom';
+import { test, expect } from 'vitest';
+import { composeStories, renderStory } from '@storybook-astro/framework/testing';
+import * as stories from './VitePluginDemo.stories.jsx';
+
+const { Default } = composeStories(stories);
+
+// The SSR render server is one of the pipelines that used to miss the
+// project's astro.config vite plugins (issue #169) — without them the
+// virtual module the component imports never resolves.
+test('a project vite plugin resolves in the SSR render server', async () => {
+  await renderStory(Default);
+
+  expect(screen.getByTestId('vite-plugin-astro')).toHaveTextContent(
+    'Served by the project Vite plugin'
+  );
+});

--- a/integration/astro6/src/env.d.ts
+++ b/integration/astro6/src/env.d.ts
@@ -6,3 +6,11 @@ declare module '*.astro' {
 
   export default component;
 }
+
+// Provided by the project-level Vite plugin in astro.config.mjs
+// (see ../vite-plugin-project-banner.mjs).
+declare module 'virtual:project-banner' {
+  const banner: string;
+
+  export default banner;
+}

--- a/integration/astro6/tests/vite-plugin-demo.spec.ts
+++ b/integration/astro6/tests/vite-plugin-demo.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+// Islands are bundled by a separate asset build, which used to run without
+// the project's astro.config vite plugins (issue #169). In the static output
+// that produced an island chunk that never resolved the plugin's virtual
+// module, so the component rendered but could not hydrate.
+test.describe('VitePluginDemo', () => {
+  test('a project vite plugin resolves in the prerendered HTML', async ({ page }) => {
+    await page.goto('/iframe.html?id=astro-vite-plugin-demo--default&viewMode=story');
+
+    await expect(page.getByTestId('vite-plugin-astro')).toHaveText(
+      'Served by the project Vite plugin'
+    );
+  });
+
+  test('a project vite plugin resolves in the island bundle, and the island hydrates', async ({
+    page,
+  }) => {
+    await page.goto('/iframe.html?id=astro-vite-plugin-demo--default&viewMode=story');
+
+    const island = page.getByTestId('vite-plugin-island');
+
+    await expect(island).toContainText('Served by the project Vite plugin');
+
+    await island.click();
+
+    await expect(island).toContainText('clicks: 1');
+  });
+});

--- a/integration/astro6/vite-plugin-project-banner.mjs
+++ b/integration/astro6/vite-plugin-project-banner.mjs
@@ -1,0 +1,31 @@
+/**
+ * A project-level Vite plugin, declared under `vite.plugins` in astro.config
+ * rather than as an Astro integration — the same shape as `vite-svg-loader`
+ * or `@tailwindcss/vite` in a real project.
+ *
+ * It exists so CI exercises issue #169: plugins declared here have to reach
+ * every render pipeline (the Storybook build, the prerender SSR server, the
+ * island asset build and the dev SSR server), not just the main build. A
+ * component importing `virtual:project-banner` fails to resolve in whichever
+ * pipeline is missing the plugin.
+ */
+const VIRTUAL_ID = 'virtual:project-banner';
+const RESOLVED_ID = '\0virtual:project-banner';
+
+export function projectBanner() {
+  return {
+    name: 'project-banner',
+
+    resolveId(id) {
+      if (id === VIRTUAL_ID) {
+        return RESOLVED_ID;
+      }
+    },
+
+    load(id) {
+      if (id === RESOLVED_ID) {
+        return `export default 'Served by the project Vite plugin';`;
+      }
+    }
+  };
+}

--- a/packages/@storybook-astro/framework/src/loadUserAstroConfig.test.ts
+++ b/packages/@storybook-astro/framework/src/loadUserAstroConfig.test.ts
@@ -189,6 +189,31 @@ describe('appendUserVitePlugins', () => {
   });
 });
 
+describe('loadUserAstroVitePlugins', () => {
+  test('hands every render pipeline its own plugin instances', async () => {
+    // Each pipeline registers these plugins with a different Vite instance,
+    // and in dev two of those servers are live at once. Sharing one stateful
+    // plugin object between them lets whichever server resolved last win.
+    await writeConfig(`
+      export default {
+        vite: {
+          plugins: [{ name: 'vite-svg-loader', cache: new Map() }]
+        }
+      };
+    `);
+
+    const [forDevServer] = await loadUserAstroVitePlugins(tmpDir);
+    const [forIslandBuild] = await loadUserAstroVitePlugins(tmpDir);
+
+    expect(forDevServer.name).toBe('vite-svg-loader');
+    expect(forIslandBuild.name).toBe('vite-svg-loader');
+    expect(forIslandBuild).not.toBe(forDevServer);
+    expect(
+      (forIslandBuild as unknown as { cache: Map<string, string> }).cache
+    ).not.toBe((forDevServer as unknown as { cache: Map<string, string> }).cache);
+  });
+});
+
 describe('loadUserAstroIntegrations (regression)', () => {
   test('still picks up integrations after the refactor', async () => {
     await writeConfig(`

--- a/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
+++ b/packages/@storybook-astro/framework/src/loadUserAstroConfig.ts
@@ -28,6 +28,9 @@ const EMPTY: UserAstroConfigData = {
 // promise so concurrent callers share the same load.
 const configCache = new Map<string, Promise<UserAstroConfigData>>();
 
+// Config files that already produced a load failure warning.
+const warnedConfigFiles = new Set<string>();
+
 async function loadUserAstroConfigData(resolveFrom: string): Promise<UserAstroConfigData> {
   let cached = configCache.get(resolveFrom);
 
@@ -75,10 +78,16 @@ async function readUserAstroConfig(resolveFrom: string): Promise<UserAstroConfig
       vitePlugins: extractVitePlugins(config.vite?.plugins)
     };
   } catch (err) {
-    console.warn(
-      '[storybook-astro] Could not load astro.config to discover integrations / fonts / vite plugins:',
-      err instanceof Error ? err.message : String(err)
-    );
+    // Vite plugins are read once per render pipeline (see
+    // loadUserAstroVitePlugins), so a broken config would otherwise repeat
+    // the same warning several times per session.
+    if (!warnedConfigFiles.has(configFile)) {
+      warnedConfigFiles.add(configFile);
+      console.warn(
+        '[storybook-astro] Could not load astro.config to discover integrations / fonts / vite plugins:',
+        err instanceof Error ? err.message : String(err)
+      );
+    }
 
     return EMPTY;
   }
@@ -154,9 +163,17 @@ export async function loadUserAstroFonts(resolveFrom: string): Promise<Storybook
  * registered through Astro's integration API so `loadUserAstroIntegrations`
  * does not pick them up; this loader fills the gap so CSS frameworks added
  * as raw Vite plugins work in Storybook without `viteFinal`.
+ *
+ * Deliberately skips the config cache: a Vite plugin is a stateful object
+ * (it captures the resolved config in `configResolved`, caches in
+ * `buildStart`) and every caller registers the result with a different Vite
+ * instance — in dev the Storybook server and the internal SSR server are even
+ * live at the same time.  Re-reading the config runs the config module again
+ * and hands each pipeline its own instances.  Integrations and fonts are
+ * plain data and keep using the cache.
  */
 export async function loadUserAstroVitePlugins(resolveFrom: string): Promise<Plugin[]> {
-  return (await loadUserAstroConfigData(resolveFrom)).vitePlugins;
+  return (await readUserAstroConfig(resolveFrom)).vitePlugins;
 }
 
 /**

--- a/packages/@storybook-astro/framework/src/vitest/config.ts
+++ b/packages/@storybook-astro/framework/src/vitest/config.ts
@@ -8,6 +8,7 @@ import { importAstroConfig } from '../importAstroConfig.ts';
 import { vitePluginAstroComponentMarker } from '../vitePluginAstroComponentMarker.ts';
 import { vitePluginAstroSvgComponentMarker } from '../vitePluginAstroSvgComponentMarker.ts';
 import { registerTestingIntegrationsForRoot } from '../testing/integration-config.ts';
+import { appendUserVitePlugins, loadUserAstroVitePlugins } from '../loadUserAstroConfig.ts';
 import { cjsInteropPlugin, vitestPatchForSolidJs } from './vite-plugins.ts';
 
 /**
@@ -135,6 +136,12 @@ export function defineConfig(options: TestingDefineConfig) {
     // Inject the logger — this overrides any logger Astro may have set,
     // which is intentional since we only filter benign test-context noise.
     config.customLogger = testLogger;
+
+    // Component tests compile the same sources Storybook does, so plugins the
+    // project declares under `vite.plugins` have to be here too. `getViteConfig`
+    // runs with `configFile: false` by default and would otherwise drop them,
+    // leaving tests unable to resolve what the browser resolves fine.
+    appendUserVitePlugins(config, await loadUserAstroVitePlugins(root));
 
     return config;
   };


### PR DESCRIPTION
Follow-ups from the review of #170 (merged). Three issues raised there, plus a fourth the new coverage surfaced.

### 1. Each pipeline gets its own plugin instances

`loadUserAstroVitePlugins` served every caller from the astro.config cache, so the *same* plugin objects were registered with several Vite instances. After #170 that's up to four pipelines, and in dev the Storybook server and the internal SSR server are live simultaneously. A plugin that captures the resolved config in `configResolved` or caches in `buildStart` — `@tailwindcss/vite` is the obvious candidate, and it's the plugin named in `preset.ts`'s own comment — would have whichever server resolved last win.

Plugins are now read fresh. Verified that Vite's `loadConfigFromFile` re-evaluates the config module, so the factories run again and produce distinct objects with distinct state; cost is ~79ms cold, ~11ms warm, once per pipeline. Integrations and fonts are plain data and keep using the cache. Config load failures are now warned about once per config file instead of once per pipeline.

### 2. The vitest config had the same gap

Adding the integration coverage below immediately surfaced a fourth instance of #169 that wasn't in the original report: `vitest/config.ts` builds its Vite config through `getViteConfig` with `configFile: false`, so `vite.plugins` never reached it. A component importing something only a project plugin can resolve renders fine in Storybook but fails to even *collect* under `yarn test`:

```
Error: Cannot find package 'virtual:project-banner' imported from .../VitePluginDemo.astro
```

Same one-line `appendUserVitePlugins` treatment as the pipelines #170 fixed.

### 3. CI coverage

No integration app declared `vite.plugins`, so #169 couldn't have been caught here and a regression still wouldn't be. `integration/astro6` now registers a small project plugin serving a virtual module, with a story whose Astro component *and* hydrated Vue island both import it. That puts every pipeline under test at once:

| Pipeline | How it fails without the fix |
|---|---|
| Dev/testing SSR server | `VitePluginDemo.test.ts` fails to collect |
| Island asset build | `storybook build` fails: `Rolldown failed to resolve import "virtual:project-banner"` |
| Prerender SSR server | Playwright: prerendered HTML assertion fails |
| Hydration from built chunk | Playwright: island never becomes interactive |

I confirmed this empirically — reverting #170's `storySsrVite.ts` and `hydratedComponentBuild.ts` on this branch makes the astro6 static build fail hard, so the Playwright web server can't even start.

Scoped to astro6 (the app I originally reproduced #169 against; it runs both `storybook build` and `test:browser` in CI). Extending it to astro7 for Vite 8 / Rolldown coverage is a copy of four small files if that's wanted.

### 4. Test fixture dirs

`.vitest-*-fixture-*/` is gitignored. Those `mkdtemp` fixtures live inside the framework package so `importAstroConfig` can resolve `astro/config` by walking up; an interrupted run left them in `git status` and in eslint's path.

### Verification

- `yarn test` — all 6 projects green (186 framework tests, up from 183).
- `yarn workspace @storybook-astro/integration-astro6 test:browser` — 8/8, including the 2 new specs.
- `yarn lint` and `yarn lint:links` clean.
- `storybook build` green for astro6 and astro7.
- The new `loadUserAstroVitePlugins` unit test fails on `develop` without the source change (asserts distinct instances); both new integration tests fail with #170 reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)