### PR TITLE
feat: extract component docs and props tables from .astro frontmatter JSDoc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ This document provides guidance for AI assistants working on the `@storybook-ast
 - `src/vitePluginAstroComponentMarker.ts` - Patches Astro's client-side `.astro` stubs (Astro 6+ and Astro 7's Rust compiler) to set `isAstroComponentFactory` and preserve scoped CSS imports
 - `src/vitePluginAstroFonts.ts` - Resolves Astro's Font Provider API in Storybook's SSR context and auto-loads fonts declared in `astro.config.*`
 - `src/portable-stories.ts` - `composeStories`/`composeStory` for testing outside Storybook
+- `src/docgen/` - Extracts component descriptions and prop tables from `.astro` frontmatter JSDoc. `index.ts` owns the runtime (guarded `typescript` import, tsconfig discovery, caching), `tsProject.ts` the one shared TypeScript language service, `extract.ts` the extraction itself. Design record: `docs/specs/docgen.md`
 - `src/integrations/` - Integration adapters for each supported framework
 
 #### 2. `packages/@storybook-astro/renderer` (Client)
@@ -50,6 +51,7 @@ This document provides guidance for AI assistants working on the `@storybook-ast
 **Important Files**:
 - `src/render.tsx` - Exports `render()` and `renderToCanvas()` functions
 - `src/preset.ts` - Defines preview annotations
+- `src/extractArgTypes.ts` - Maps the `__docgenInfo` the framework attaches to a component stub into Storybook's props table. Registered through `preview-defaults.ts` so both CSF3 and CSF-factory stories pick it up
 - `src/decorators.ts` - `applyDecorators`, the renderer's `applyDecorators` project annotation. Composes a story's `decorators` array into a `SlotValue` tree for Astro stories (Decision 2 in `docs/specs/decorators.md#design-decisions`), or defers to Storybook's `defaultDecorateStory` for framework-delegated stories (`parameters.renderer` set)
 
 ### Data Flow

--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -115,28 +115,23 @@ The render time and HTML string are already available when `renderAstroComponent
 
 ### Automatic Documentation Extraction from JSDoc
 
-📋 **To Do**
+✅ **Done**
 
-Enable automatic extraction of component descriptions and prop documentation from JSDoc comments in Astro components, similar to how React/Vue frameworks extract documentation via docgen tools.
+Component descriptions and prop documentation are extracted from JSDoc in a
+component's `.astro` frontmatter, so autodocs pages populate without any
+`argTypes` boilerplate in story files.
 
-**Complexity**: Medium-High
-**Tracking**: [Issue #110 — Storybook Astro is unable to parse documentation from the component's JSDocs](https://github.com/storybook-astro/storybook-astro/issues/110)
+**Tracking**: [Issue #163](https://github.com/storybook-astro/storybook-astro/issues/163), [Issue #110](https://github.com/storybook-astro/storybook-astro/issues/110)
 
-**Current behavior**: Users must manually duplicate all documentation in story files via `argTypes` and `parameters.docs.description.component`.
+**What you get**:
+- Component description from a JSDoc block in the frontmatter
+- Per-prop descriptions, types and defaults in the properties table
+- Select controls for literal union props
+- Inherited DOM attributes filtered out, while props you destructure are kept
+- Types imported from other files, including through tsconfig `paths` aliases
 
-**What this requires**:
-- Parser for Astro component frontmatter to extract TypeScript `Props` interface and JSDoc comments
-- Implementation of `docs.extractArgTypes` and `docs.extractComponentDescription` functions in the framework preset
-- Integration with TypeScript Compiler API (similar to `react-docgen-typescript`) to read type information and JSDoc tags from `.astro` files
-- Handling Astro-specific syntax where the `Props` interface is embedded in frontmatter rather than standalone `.ts` files
-
-**What this enables**:
-- Automatic component descriptions from top-level JSDoc comments
-- Automatic prop documentation in the properties table from interface JSDoc
-- Reduced boilerplate in story files
-- Consistency with how other Storybook frameworks handle documentation
-
-**Workaround**: Manually define `argTypes` and descriptions in story files as shown in the integration examples.
+See [Controls & ArgTypes](/writing-stories/controls/) for the conventions and the
+`docgen` framework option.
 
 ## Future Enhancements
 
@@ -308,7 +303,7 @@ This table tracks compatibility of Storybook's built-in features when used with 
 | Stories (CSF) | ✅ Supported | Component Story Format for defining stories |
 | Args & Controls | ✅ Supported | Interactive controls for component props (dev only for Astro components; pre-rendered in static builds) |
 | Actions | ✅ Supported | Log user interactions and events |
-| Docs (Autodocs) | ✅ Supported | Automatic documentation pages for components |
+| Docs (Autodocs) | ✅ Supported | Automatic documentation pages, with props tables generated from frontmatter JSDoc |
 | Docs (MDX) | ✅ Supported | Custom documentation pages with MDX |
 | Docs Blocks | ✅ Supported | Pre-built documentation components (Description, Primary, Controls, Stories, etc.) |
 | Viewports | ✅ Supported | Responsive design testing with different viewport sizes |

--- a/apps/website/src/content/docs/writing-stories/controls.md
+++ b/apps/website/src/content/docs/writing-stories/controls.md
@@ -1,63 +1,167 @@
 ---
 title: Controls & ArgTypes
-description: Customize Storybook's Controls panel for Astro component stories.
+description: How Astro component props reach Storybook's Controls panel and props table.
 ---
 
-Use `argTypes` to customize how Storybook's Controls panel renders each arg.
+Your component's props table and description are generated from the JSDoc in its
+`.astro` frontmatter. Story files don't need to restate any of it.
 
-## Defining argTypes
+## Documenting a component
+
+Write a JSDoc block above the `Props` declaration, and one above each prop:
+
+```astro
+---
+/**
+ * A simple content card with optional highlight styling.
+ */
+interface Props {
+  /** Card heading text. */
+  title?: string;
+  /** Card body text. */
+  content?: string;
+  /** Applies a highlighted visual style. */
+  highlight?: boolean;
+}
+
+const { title = 'Default title', content = 'Default content', highlight = false } = Astro.props;
+---
+```
+
+The story file only names the component:
 
 ```jsx
+import Card from './Card.astro';
+
 export default {
-  title: 'Components/Header',
-  component: Header,
-  argTypes: {
-    logoText: { control: 'text' },
-    currentPath: { control: 'text' },
-    navItems: { control: 'object' },
+  title: 'Components/Card',
+  component: Card,
+};
+```
+
+That produces the component description, a row per prop with its description and
+type, and the defaults read from the `Astro.props` destructuring.
+
+### What gets extracted
+
+| From the component | Becomes |
+|---|---|
+| JSDoc above `Props` (or a block at the top of the frontmatter) | The component description |
+| JSDoc above a prop | That prop's description |
+| The prop's TypeScript type | The **Type** column |
+| A default in the `Astro.props` destructuring | The **Default** column |
+| A union of string literals | A select control with those options |
+| A prop that is neither optional nor defaulted | Marked **Required** |
+| `@default` on a prop | The **Default** column, when the destructuring has none |
+
+Types imported from another file work too, including via tsconfig `paths`
+aliases — the extractor uses your project's `tsconfig.json`.
+
+### Inherited props
+
+Components that extend Astro's DOM types pick up a lot:
+
+```astro
+---
+import type { HTMLTag, Polymorphic } from 'astro/types';
+
+interface Props<Tag extends HTMLTag = 'button' | 'a'> extends Polymorphic<{ as: Tag }> {
+  /** Disables interaction. */
+  disabled?: boolean;
+}
+
+const { as: Tag = 'button', href, class: className } = Astro.props as Props;
+---
+```
+
+`Polymorphic` alone contributes around 200 attributes, so props declared only in
+a dependency are filtered out by default. Two things keep the useful ones:
+
+- A prop you **destructure from `Astro.props`** is always kept, wherever its type
+  came from. That's what puts `href` and `class` in the table above.
+- A prop you **redeclare in your own `Props`** is always kept, even when the same
+  name also exists on the DOM type.
+
+To keep more, pass your own filter:
+
+```js
+// .storybook/main.js
+export default {
+  framework: {
+    name: '@storybook-astro/framework',
+    options: {
+      docgen: {
+        // Keep everything, including inherited DOM attributes.
+        propFilter: () => true,
+      },
+    },
   },
 };
 ```
 
-You can specify control types (`text`, `boolean`, `number`, `object`, `select`, etc.), descriptions, default values, and table metadata:
+## Overriding what's extracted
+
+`argTypes` still works, and wins over anything extracted. Use it to change how a
+prop is *presented* rather than to restate it:
 
 ```jsx
 export default {
-  title: 'Components/ImageText',
-  component: ImageText,
+  title: 'Components/Card',
+  component: Card,
   argTypes: {
-    imageSrc: {
-      description: 'Image source — an imported asset (ImageMetadata) or a URL string.',
-      table: {
-        type: { summary: 'ImageMetadata | string' },
-      },
-    },
-    imageAlt: {
-      description: 'Alt text for the image.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Image'" },
-      },
-    },
-    reversed: {
-      description: 'Places the image on the right side instead of the left.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
+    // Force a colour picker for a prop typed as a plain string.
+    accent: { control: 'color' },
+    // Hide an inherited prop that isn't interesting for this story.
+    class: { table: { disable: true } },
   },
 };
 ```
+
+If you find yourself writing `description`, `table.type` or `table.defaultValue`
+by hand, that belongs in the component's JSDoc instead — otherwise the two drift
+apart and the story file quietly wins.
+
+## Slots
+
+Slots have no TypeScript representation, so they never appear in the props table.
+Describe them in the component's JSDoc block, and pass them through `args.slots`:
+
+```jsx
+export const WithMain = {
+  args: {
+    title: 'Hello',
+    slots: { main: '<p>Slot content</p>' },
+  },
+};
+```
+
+## Turning extraction off
+
+```js
+// .storybook/main.js
+options: {
+  docgen: false,
+}
+```
+
+Extraction is also skipped automatically when `@storybook/addon-docs` isn't
+installed, and during test builds.
+
+It needs TypeScript 5.0 or newer, which Astro projects already have. Without it,
+docgen is skipped with a warning and everything else keeps working.
 
 ## Static build limitation
 
-In static builds (`storybook build`), Astro components are pre-rendered at build time with their default args. The Controls panel cannot re-render them with different values.
+In static builds (`storybook build`), Astro components are pre-rendered at build
+time with their default args. The Controls panel cannot re-render them with
+different values.
 
-The package handles this automatically: in a static build, all control inputs for Astro component stories are disabled and an **ℹ️ Astro** info row appears in the Controls table explaining that the component is pre-rendered. No configuration is needed.
+The package handles this automatically: in a static build, all control inputs for
+Astro component stories are disabled and an **ℹ️ Astro** info row appears in the
+Controls table explaining that the component is pre-rendered. The props table
+itself still shows everything extracted from the component.
 
-Controls work fully in dev mode (`storybook dev`) and for framework component stories (React, Vue, etc.) in all modes.
+Controls work fully in dev mode (`storybook dev`) and for framework component
+stories (React, Vue, etc.) in all modes.
 
 See [Static Builds](/how-it-works/static-builds/) for more details.

--- a/docs/specs/code-panel-source.md
+++ b/docs/specs/code-panel-source.md
@@ -30,7 +30,7 @@ The decorator is delivered as a **docs-only preview annotation**: `@storybook/vu
 ### What we have
 
 - `packages/@storybook-astro/renderer/src/preset.ts` appends only `entry-preview` to `previewAnnotations`. No docs annotation exists.
-- For Astro stories, `ctx.component` is the client stub produced by `vitePluginAstroComponentMarker` — a function carrying `moduleId` (the absolute path of the `.astro` file). There is no docgen info yet (JSDoc extraction is tracked separately as issue #110).
+- For Astro stories, `ctx.component` is the client stub produced by `vitePluginAstroComponentMarker` — a function carrying `moduleId` (the absolute path of the `.astro` file). Since the docgen work landed, the stub also carries `__docgenInfo` with the component's extracted description and props (`docs/specs/docgen.md`).
 - Story args follow one convention worth preserving in snippets: `args.slots` is a map of slot name → HTML string (`default` plus named slots), and everything else is a prop.
 - Storybook sets `parameters.fileName` to the story file's path, which lets us compute a realistic relative import path for the frontmatter.
 - CSF1–3 and CSF4 (`definePreview`) both load preview annotations the same way, so one annotation file covers both.
@@ -50,7 +50,7 @@ Stories delegated via `parameters.renderer` render through the framework's `rend
 
 **Decision 4 — Generate from context, not from output.** Source comes from `ctx.component` + `ctx.args`. This makes the decorator order-independent and immune to the decorator-support feature (`docs/specs/decorators.md`): when `storyFn()` starts returning renderable trees, the source decorator still passes the value through untouched and the snippet still shows the undecorated component usage — which is the desired behavior (parity with `excludeDecorators` defaults elsewhere).
 
-**Decision 5 — Component name resolution order.** `component.__docgenInfo.displayName` (future-proofing for issue #110) → basename of `component.moduleId` without `.astro` → last segment of `ctx.title`. Import path: `moduleId` relative to `dirname(parameters.fileName)` when both are available, else `./<Name>.astro`.
+**Decision 5 — Component name resolution order.** `component.__docgenInfo.displayName` (populated by the docgen extractor, `docs/specs/docgen.md`) → basename of `component.moduleId` without `.astro` → last segment of `ctx.title`. Import path: `moduleId` relative to `dirname(parameters.fileName)` when both are available, else `./<Name>.astro`.
 
 ## Source Generation Spec
 
@@ -125,6 +125,6 @@ const author = { name: "Ada", role: "Engineer" };
 
 - **Decorators are not reflected** in the snippet — it intentionally shows the undecorated component usage.
 - **Framework component stories** (`parameters.renderer`) keep the raw-source fallback; per-framework dynamic source is a possible follow-up.
-- **Complex objects** render as hoisted `const` literals; values that aren't plausibly literal (class instances, `ImageMetadata` from imported images) serialize as plain object literals rather than recovering the original `import img from '…'` form. Revisit alongside JSDoc/docgen work (issue #110).
+- **Complex objects** render as hoisted `const` literals; values that aren't plausibly literal (class instances, `ImageMetadata` from imported images) serialize as plain object literals rather than recovering the original `import img from '…'` form. Revisit alongside `docs/specs/docgen.md` — the extractor already records each prop's declaring file, which is a starting point for recovering an original `import` form.
 - **Slot HTML is echoed verbatim** from `args.slots` — it is not reformatted or validated.
 - Stories whose `render` returns template strings or DOM nodes are skipped (no component to attribute the source to), matching `__isArgsStory` semantics in other renderers.

--- a/docs/specs/docgen.md
+++ b/docs/specs/docgen.md
@@ -1,0 +1,251 @@
+# JSDoc and Props Extraction for Astro Components
+
+## Problem Statement
+
+Storybook autodocs renders an empty description and an empty props table for every `.astro` story. Authors have to restate the entire component API in the story file — every prop's description, type summary and default — and repeat the component description in `parameters.docs.description.component`. React, Vue, Preact, Svelte and Angular all derive this from source; Astro is the only framework in our matrix that does not.
+
+The goal is that this component:
+
+```astro
+---
+/**
+ * A simple content card with optional highlight styling.
+ */
+interface Props {
+  /** Card heading text. */
+  title?: string;
+  /** Applies a highlighted visual style. */
+  highlight?: boolean;
+}
+
+const { title = 'Default title', highlight = false } = Astro.props;
+---
+```
+
+produces a populated description and props table — with defaults, types and per-prop descriptions — from a story file that declares nothing but `component`.
+
+**Reference**: [Issue #163 — Automatic Documentation Extraction from JSDoc](https://github.com/storybook-astro/storybook-astro/issues/163), reported downstream as [#110](https://github.com/storybook-astro/storybook-astro/issues/110).
+
+## Current State
+
+### How docgen reaches Storybook's UI
+
+Storybook 10 has two mechanisms, and they are not alternatives so much as successive generations.
+
+The **legacy path** is stable since Storybook 6 and works on every 10.x release. A build-time tool attaches `__docgenInfo` to the component object; the renderer registers `parameters.docs.extractArgTypes` and `parameters.docs.extractComponentDescription`, plus `enhanceArgTypes` in `argTypesEnhancers`. `enhanceArgTypes` calls `extractArgTypes(component)` during story preparation and merges the result under the author's own `argTypes`.
+
+The **Docgen Server** ([RFC](https://github.com/storybookjs/storybook/discussions/35333)) arrived in 10.5 behind `features.experimentalDocgenServer`. Extraction moves into a long-lived Node worker thread owned by core. A framework contributes a serializable `DocgenProviderDescriptor` — a module specifier, not a closure, since it has to cross a worker boundary — through the `experimental_docgenProvider` preset. The worker imports that module, calls its `createDocgenProvider()`, and folds the returned middleware into a provider chain. Results reach the manager and preview over the Open Service channel, and static builds get per-component JSON snapshots under `services/core/docgen/<id>.json`.
+
+| | Legacy | Docgen Server |
+|---|---|---|
+| Storybook floor | all of `^10.0.0` | 10.5+, and opt-in per project |
+| Runs on | dev-server main thread, in a Vite `transform` | Node worker thread, off the critical path |
+| Static builds | inlined in the bundle | JSON snapshots written by core |
+| Stability | stable since SB 6 | experimental; payload may change before SB 11 |
+
+Only React ships a provider in 10.5; Vue 3 and Angular added theirs during 10.6-alpha.
+
+### What we have
+
+- `vitePluginAstroComponentMarker.ts` already owns the client-side `.astro` stub. It detects Astro's browser stub, replaces it with a factory carrying `isAstroComponentFactory` and `moduleId`, and reads the `.astro` source to inline styles and re-emit child imports. It is `enforce: 'post'`.
+- `packages/@storybook-astro/renderer/src/preview-defaults.ts` is the single place default `docs.*` parameters live. It is deliberately free of virtual-module imports so the framework's CSF4 `definePreview` can merge it synchronously — CSF-factory stories never see the renderer's `entry-preview` annotation, so anything that must reach both authoring styles goes here.
+- `renderer/src/entry-preview.ts` already registers an `argTypesEnhancer` that disables every control in static mode.
+- `get-tsconfig` is a dependency, used in `src/lib/resolve-aliased-island.ts`.
+- `typescript` is **not** a dependency of the framework package.
+- `docs/specs/code-panel-source.md` already anticipates this work: its component-name resolution order starts with `component.__docgenInfo.displayName`.
+
+### Prior art
+
+[`astro-docgen-typescript`](https://github.com/SalahAdDin/astro-docgen-typescript) by @SalahAdDin — MIT, roughly 660 lines, unpublished — established the core technique and the output shape this spec adopts: lift the `.astro` frontmatter into a virtual TypeScript source file, serve it from a compiler host that delegates every other file to disk, and read the `Props` declaration off the type checker. Its `Astro.props` destructuring walker is the part worth porting closely.
+
+We reimplement rather than depend on it. An unpublished single-maintainer package is not something to put on the critical path of the docs pipeline, and four of its behaviors need to change — each documented as a decision below.
+
+## Design Decisions
+
+**Decision 1 — Both delivery paths, sharing one extractor.** The legacy path is the default because it covers the whole `storybook: ^10.0.0` peer range; the Docgen Server is contributed only when `features.experimentalDocgenServer` is set. Shipping the server path alone would leave most users with no change at all. This mirrors `@storybook/vue3-vite`, which selects between `vue-docgen-api` and `vue-component-meta` on the same flag. Extraction logic lives in one place and neither path duplicates it.
+
+The two are **mutually exclusive**. A worker thread has its own module registry, so enabling both would pay the full TypeScript warm-up cost twice for identical output. When the server path is active, the Vite plugin does not inject `__docgenInfo`.
+
+**Decision 2 — Emit the `react-docgen-typescript` shape.** The extractor produces `{ displayName, description, props: { <name>: { name, required, type, description, defaultValue } } }` rather than Storybook's `StrictArgTypes`. `extractComponentProps` in `storybook/internal/docs-tools` consumes that shape directly, routing it through `javaScriptFactory` → `convert()` → `sbType`. That gives JSDoc tag parsing, `@ignore` handling, enum and union control inference, default-value formatting, and the existing string-quoting workaround for free. Converting to `StrictArgTypes` afterwards is a small mapping over `PropDef[]`, matching `@storybook/react`'s own `extractArgTypes`.
+
+**Decision 3 — One long-lived `LanguageService`, never a program per file.** Measured against `astro/types` in this repo, where a single `createProgram` pulls in 243 source files:
+
+| Strategy | first component | each subsequent |
+|---|---|---|
+| Fresh `ts.createProgram` per file | 358 ms | 190–711 ms |
+| Shared `LanguageService` + `DocumentRegistry` | ~0.9 s once | 0–1.4 ms |
+
+The legacy path runs inside a Vite `transform` on the dev server's critical path, so per-file program creation would cost roughly ten seconds of blocked transform time on a fifty-component Storybook. Steady-state heap for the shared service measured ~170 MB and stayed flat across edit cycles.
+
+Beyond the obvious host members, three are load-bearing. `getProjectVersion()` lets TypeScript skip `synchronizeHostData` when nothing changed — without it every `getProgram()` walks all roots. `resolveModuleNameLiterals()` over a shared module-resolution cache is also where `./Child.astro` maps to that component's own virtual file; `astro/client.d.ts` declares no `*.astro` module, so without this every `.astro` import in frontmatter silently degrades to `any`. And ambient roots must be listed explicitly in `getScriptFileNames()` because nothing imports them: the project's `.astro/types.d.ts` and `src/env.d.ts`, plus a shim of our own declaring `*.astro` and `const Astro: any` — `Astro.props as Props` is otherwise a "cannot use namespace as a value" error.
+
+Invalidation is driven by Vite's watcher into an explicit version map, not by `stat()` polling. Changes under `node_modules` need a dev-server restart, since Vite's watcher ignores it. The service must be `dispose()`d before it is ever replaced or the `DocumentRegistry` retains every acquired source file.
+
+### The virtual TypeScript file
+
+**Decision 4 — The virtual file is `<component dir>/<Name>.astro.ts`, and preserves byte offsets.** The prior art names it `virtual-frontmatter.ts` with no directory, so `./types` resolves against the process working directory instead of the component folder. The failure is invisible: TypeScript's error type still stringifies to the written type name, so the table looks plausible while `getApparentProperties()` returns nothing. This is very likely a contributing cause of #110.
+
+Placing the file beside the component makes relative imports, tsconfig `paths`, package `exports` conditions and nearest-`package.json` resolution all behave exactly as they do for a real file in that folder. The `.astro.ts` suffix matches `@astrojs/language-server`, `svelte2tsx` and `vue-tsc`.
+
+The virtual text is the **whole `.astro` file with everything outside the frontmatter blanked** — the opening `---` becomes `// `, and the template is replaced by spaces with every newline preserved. Every TypeScript position is then the exact offset in the real file, so diagnostics and declaration positions need no translation, and no prelude shifts line numbers. Compiler options come from the project `tsconfig.json` via `get-tsconfig`; `rootDir` is left alone, and virtual files enter through `getScriptFileNames()` because a user's `include` never covers `.astro`.
+
+### Heritage rewrite
+
+**Decision 5 — Rewrite `interface Props extends …` to a type alias when TypeScript rejects the heritage clause.** The component in #110 is written as:
+
+```ts
+interface Props<Tag extends HTMLTag = "button" | "a"> extends Polymorphic<{ as: Tag } & ButtonVariants> { … }
+```
+
+That is not valid TypeScript. `Polymorphic<…>` bottoms out in a deferred indexed access on a type parameter, and an interface may only extend types with statically known members (TS2312). TypeScript drops the entire base type: **three props are extracted instead of roughly two hundred**, with `as`, `variant`, `size`, `color` and `href` all missing. Astro's documented polymorphic idiom is the type alias, which has no such restriction.
+
+Rewriting the declaration in the virtual file to `type Props<T…> = A & B & { members }` yields zero diagnostics and 199 apparent properties. The rewrite is conditional — applied only when the declaration is an interface, has heritage clauses, and `getSemanticDiagnostics` (measured at 4 ms) reports TS2312 within its range — because rewriting unconditionally would change declaration-merging semantics for the common case. It is applied as a TypeScript text edit rather than a regex; real `extends` clauses span lines and nest angle brackets.
+
+**Decision 6 — Instantiate generics with their defaults, and merge across union constituents.** `getDeclaredTypeOfSymbol` on a generic `Props` returns `Props<Tag>` with the parameter unapplied. Appending `declare const __SB_PROPS__: Props;` to the virtual file and reading `getTypeAtLocation` on it applies the defaults; a parameter with no default falls back to its constraint, then `unknown`.
+
+One subtlety justifies extra work. `keyof (A | B)` is the *intersection* of keys, so a union-defaulted tag collapses the surface:
+
+| Instantiation | props | notable |
+|---|---|---|
+| `Props<"a" \| "button">` | 198 | `href` **absent** |
+| `Props<"a">` | 206 | `href` present |
+| `Props<"button">` | 210 | `type` present |
+| merged | 218 | both |
+
+When the resolved default is a union of eight or fewer string literals, instantiate once per constituent and union the property sets — sub-millisecond on a warm checker. The cap keeps `Tag extends HTMLTag = HTMLTag` from expanding to every HTML element.
+
+### Prop filtering
+
+**Decision 7 — Drop props declared *exclusively* under `node_modules`, and always keep destructured names.** A `Props` extending `HTMLAttributes` or `Polymorphic` measured at 199 properties, of which 191 come from `astro/astro-jsx.d.ts`. Unfiltered, every Astro props table is unusable. Three corrections to the conventional `react-docgen-typescript` recipe:
+
+- **Filter on declaration source files, not `prop.parent`.** Props derived from `VariantProps<typeof x>` are `PropertyAssignment` nodes inside an object literal, so the prior art's parent lookup returns `undefined` for exactly the variant props authors care most about.
+- **Keep a prop when *any* declaration sits outside `node_modules`.** A locally redeclared `disabled` also has a declaration in `astro/types`; an any-declaration-matches filter silently deletes it. Verified: the loose form keeps only `variant`, the correct form keeps `disabled` and `variant`.
+- **Always keep names bound in the `Astro.props` destructuring pattern**, whatever their declaring file. We already walk that pattern for defaults, and it is the author's own statement of the public surface. On the #110 button this recovers `as`, `href` and `class` with no hardcoded allowlist.
+
+Net effect on that component: roughly nine meaningful rows instead of three or two hundred. `docgen.propFilter` overrides the default using the `react-docgen-typescript` signature.
+
+### Description precedence
+
+**Decision 8 — Resolve descriptions through the AST, and strip non-standard tags.** A "floating" JSDoc block is not floating — TypeScript attaches it to the following statement, so `ts.getJSDocCommentsAndTags` finds it reliably. Precedence, first non-empty winning:
+
+1. The first frontmatter statement whose JSDoc carries `@component` or `@description` — using the tag's text if present, otherwise the block's free text.
+2. `propsSymbol.getDocumentationComment(checker)`, which survives declaration merging and re-exports in a way text scraping does not.
+3. The file's leading `/** */` block, but only when it is the first trivia **and** is not attached to an import declaration.
+4. Empty.
+
+The prior art takes the first `/** */` in the file by regex, which happily picks up a license header or a JSDoc on an import.
+
+Separately, `description` carries only the free text before the first tag; everything else goes to `__docgenInfo.tags` / `DocgenPayload.jsDocTags`. Storybook's `parseJsDoc` understands `@param`, `@returns`, `@deprecated` and `@ignore` only, and the #110 component's `@preview`, `@usage` and `@examples` blocks contain markdown and JSX that would otherwise render as noise. `@ignore` is preserved so docs-tools' existing prop-dropping still fires.
+
+### Failure modes
+
+**Decision 9 — Docgen is a side channel and never breaks rendering.** `transform` returns `null` on any failure and never throws. A wrong props table is cosmetic; a thrown error in a Vite `transform` is a blank preview iframe.
+
+- **No TypeScript.** `typescript` is an optional peer dependency, loaded through a guarded dynamic import, with a version floor of 5.0 (`resolveModuleNameLiterals` and `getJSDocCommentsAndTags` behavior varies below it). One deduplicated warning, then docgen is skipped.
+- **Type errors.** Diagnostics are *signal, not gate*. A file with an unresolved import, a missing default export and an `Astro`-as-value error still yielded correct types for every resolvable prop; refusing to extract unless diagnostics are empty would disable docgen for most real projects. TS2312 triggers the heritage rewrite; an unresolved-module diagnostic triggers a one-time warning naming the specifier, because that is the failure users cannot otherwise see.
+- **No `Props` declaration.** Common for slot-only components. Return `{ displayName, description, props: {} }` rather than nothing, so the description still reaches autodocs. Bail before touching TypeScript when there is no frontmatter at all.
+
+Failures are cached by content hash so a component that legitimately yields nothing does not re-run a type check on every HMR tick. In the worker path, failures are reported on `DocgenPayload.error`. Default values are narrowed to `string | number | boolean | null` before code generation so nothing can throw at serialization time.
+
+**Decision 10 — Scan frontmatter with the existing house pattern.** `vitePluginAstroComponentMarker.ts` already extracts frontmatter with a line-anchored regex in `extractAstroImportSpecifiers` and `extractStyleBlocksWithLang`. Do the same rather than adopting `@astrojs/compiler`'s asynchronous WASM `parse()` — it keeps extraction synchronous, avoids a WASM load inside a worker thread, and matches the file it sits beside.
+
+## Extraction Spec
+
+Given a `.astro` file, the extractor produces:
+
+| Field | Source |
+|---|---|
+| `displayName` | file basename without `.astro` |
+| `description` | per [Description precedence](#description-precedence), free text only |
+| `tags` | JSDoc block tags other than the description |
+| `props[name].type.name` | `checker.typeToString`, with `\| undefined` stripped for optional props |
+| `props[name].type.value` | literal union constituents, when the type is a union of literals |
+| `props[name].required` | not optional **and** no destructuring default |
+| `props[name].description` | `symbol.getDocumentationComment(checker)` |
+| `props[name].defaultValue` | destructuring default, else the `@default` tag, else absent |
+| `props[name].parent` | declaring interface or type alias; falls back to the declaring source file and nearest named ancestor |
+
+Default values are read from the top-level `Astro.props` destructuring, including the `as Props` and `satisfies Props` forms:
+
+| Frontmatter | `defaultValue.value` |
+|---|---|
+| `const { a = 'x' } = Astro.props` | `"x"` |
+| `const { a = 42 } = Astro.props` | `42` |
+| `const { a = true } = Astro.props` | `true` |
+| `const { a = defaultLinks } = Astro.props` | `"defaultLinks"` (source text) |
+| `const { a } = Astro.props` + `/** @default 'x' */` | `"x"` |
+| `const { a } = Astro.props` | absent → prop is required |
+
+## Implementation Plan
+
+### Step 1 — The extractor
+
+`packages/@storybook-astro/framework/src/docgen/`, with no Storybook or Vite imports so it unit-tests in isolation:
+
+- `types.ts` — the output shape from Decision 2, and `AstroDocgenOptions`.
+- `tsProject.ts` — the shared `LanguageService`, `DocumentRegistry` and host from Decision 3.
+- `virtualFile.ts` — offset-preserving blanking, the conditional heritage rewrite, the `__SB_PROPS__` probe.
+- `extract.ts` — pure `(checker, sourceFile, astroFilePath)`: instantiation, union merge, description precedence, filtering.
+- `defaultValues.ts` — the `Astro.props` destructuring walker, ported closely from the prior art.
+- `propFilter.ts` — the Decision 7 default plus overrides.
+- `cache.ts` — content-hash memory cache plus `createFileSystemCache` from `storybook/internal/common`.
+
+Add `typescript` as an optional peer dependency and to `tsup.config.ts` `external`.
+
+**Exit criteria**: `src/docgen/*.test.ts` green, covering every measured failure above — the TS2312 heritage case (3 props before the rewrite, 199 after), a relative frontmatter import and a `Props` imported from a sibling module (both silently empty if the virtual path is wrong), `VariantProps` props with no `prop.parent`, a locally redeclared `disabled`, `href` reachable only through the union merge, literal unions, `Astro.props as Props`, a component with no `Props`, and one with no frontmatter.
+
+### Step 2 — Legacy path
+
+- Extend `vitePluginAstroComponentMarker.ts` to attach `__docgenInfo` to the stub it already generates. Its `transform` becomes async. Warm the service in `buildStart` without awaiting, so the one-time cost overlaps Storybook's boot.
+- Add `docgen?: false | AstroDocgenOptions` to `BaseFrameworkOptions` in `src/types.ts`, threaded through the existing `options` object in `viteFinal`. Skip when the docs addon is absent, when `build.test.disableDocgen` is set, and for `.astro` files reached only as children.
+- New `renderer/src/entry-preview-argtypes.ts` exporting `parameters.docs.{extractArgTypes, extractComponentDescription}` and `argTypesEnhancers: [enhanceArgTypes]`.
+- Register the `docs.*` extractors in `preview-defaults.ts` so both the CSF3 annotation and the framework's CSF4 `definePreview` pick them up.
+
+`enhanceArgTypes` must run **before** the static-mode enhancer in `entry-preview.ts`. Reversed, newly extracted props appear with live controls in a static build, where they do nothing.
+
+**Exit criteria**: an autodocs page in `integration/astro6` shows a populated description and props table with no `argTypes` in the story file.
+
+### Step 3 — Docgen Server provider
+
+- `src/docgen/docgen-worker.ts` exporting `createDocgenProvider()`, satisfying `DocgenWorkerModule`. Resolve `meta.component` from the index entry's story file back to a `.astro` path, run the extractor, return a `DocgenPayload`. Merge with downstream by spread and `??`, per the contract in Storybook's own `docgen/types.ts`.
+- Component resolution uses `storybook/internal/csf-tools`. `createMetaComponentResolver` is a 10.6 addition and absent in 10.5.2, so feature-detect it.
+- `src/preset.ts` exports `experimental_docgenProvider`, returning a descriptor only when the feature flag is set.
+- Add `./docgen-worker` to the package exports and `tsup.config.ts` — core imports the descriptor's module specifier by absolute path, so it must be separately emitted.
+
+**Exit criteria**: with `features.experimentalDocgenServer` enabled in one integration app, the props table matches the legacy path's output, and the Vite plugin no longer injects.
+
+### Step 4 — Integration components and stories
+
+The integration environments would currently hide the feature rather than demonstrate it. Around twenty Astro story files hand-write `argTypes` — though only nine distinct blocks, since the astro5/6/7 copies are byte-identical — and `enhanceArgTypes` merges extracted types *under* the author's, so those pages would render unchanged. Two of those blocks have already drifted from their components: `Footer`'s documented `links` default and `Header`'s documented `navItems` default both describe values the components no longer have.
+
+Meanwhile no first-party component exercises the hard paths. There are no uses of `Polymorphic`, `HTMLAttributes`, `VariantProps`, `cva()`, generic `Props<T>` or intersection `Props` anywhere, every `Props` is declared inline in its own file, and while one component carries a real JSDoc block, **no `Props` member in the repository has one at all**.
+
+Order matters: **author JSDoc before removing any `argTypes`**, or the pages go blank in between.
+
+1. Add component and per-prop JSDoc to the nine components carrying workarounds, fixing the two stale defaults in passing.
+2. Convert the eleven `//` header comments that already hold real prose into `/** */` blocks — the cheapest description coverage available.
+3. Remove the duplicated `argTypes` and `docs.description.component`. Keep `docs.description.story`, which documents story intent rather than component API. Anything surviving should be a deliberate override.
+4. Tighten loose prop types encountered along the way — `ImageText` declares `imageSrc: any` while its story's table claims `ImageMetadata | string`.
+5. Add the missing fixtures: a polymorphic `Button` modeled on the #110 component, and one component importing its `Props` from a sibling module.
+6. Collapse `Astro.mdx`, a byte-identical third copy of the prop catalogue that is already incomplete.
+
+Two components make good first tests. `PageCard.astro` is the only one with both an existing JSDoc block and an overlapping story description, so it proves end to end that a real block reaches the page and displaces the story's copy. `ProjectStats.astro` has the widest surface — eight props, seven defaulted — and no stories at all, so nothing conflicts.
+
+**Exit criteria**: every page whose `argTypes` block was deleted renders equivalent content. One should gain a row: `GithubStars.fallbackStars` is declared in `Props` but missing from its story's `argTypes`.
+
+### Step 5 — Documentation and release
+
+- Rewrite `apps/website/src/content/docs/writing-stories/controls.md`. It currently teaches the workaround as the primary pattern, hand-writing every description and type summary for `ImageText`. Reframe it: JSDoc on the component is the source of truth, `argTypes` overrides it. The static-build section stays.
+- Add a page covering the `docgen` framework option, the prop-filter default, and the JSDoc conventions honored.
+- Flip the roadmap entry and the feature-table row to ✅ and drop the workaround note.
+- Remove the "no docgen info yet" note in `code-panel-source.md` and land the `__docgenInfo.displayName` branch its name resolution already anticipates.
+- Note the new files in `AGENTS.md`.
+
+## Known Limitations
+
+- **Slots are not documented.** Named `<slot name="…">` elements are part of an Astro component's API but have no TypeScript representation, so they do not appear in the props table. Authors continue to describe them in prose.
+- **Static builds keep controls disabled.** Extracted props render in the table with their types and defaults, but the existing static-mode enhancer still disables every control, because pre-rendered components cannot re-render with new args.
+- **`node_modules` changes need a restart.** Vite's watcher ignores `node_modules`, so installing or upgrading a package that contributes types will not invalidate the language service.
+- **Untyped components get no props.** A component that destructures `Astro.props` without declaring `Props` yields a description and an empty table; inferring props from the destructuring pattern alone would type every one of them `any`.
+- **One extraction engine at a time.** Enabling `experimentalDocgenServer` disables the Vite-plugin path rather than merging the two.
+- **Framework component stories** (`parameters.renderer`) are untouched — their docgen belongs to the delegated renderer, which our framework does not load.

--- a/docs/specs/docgen.md
+++ b/docs/specs/docgen.md
@@ -53,6 +53,7 @@ Only React ships a provider in 10.5; Vue 3 and Angular added theirs during 10.6-
 - `get-tsconfig` is a dependency, used in `src/lib/resolve-aliased-island.ts`.
 - `typescript` is **not** a dependency of the framework package.
 - `docs/specs/code-panel-source.md` already anticipates this work: its component-name resolution order starts with `component.__docgenInfo.displayName`.
+- The extraction cache is in-memory only. A filesystem cache (`createFileSystemCache` from `storybook/internal/common`) would make cold restarts free and is the obvious next optimisation.
 
 ### Prior art
 
@@ -186,11 +187,14 @@ Default values are read from the top-level `Astro.props` destructuring, includin
 
 - `types.ts` — the output shape from Decision 2, and `AstroDocgenOptions`.
 - `tsProject.ts` — the shared `LanguageService`, `DocumentRegistry` and host from Decision 3.
-- `virtualFile.ts` — offset-preserving blanking, the conditional heritage rewrite, the `__SB_PROPS__` probe.
-- `extract.ts` — pure `(checker, sourceFile, astroFilePath)`: instantiation, union merge, description precedence, filtering.
+- `virtualFile.ts` — frontmatter scanning, offset-preserving blanking, and the `Props` probes.
+- `propsDeclaration.ts` — the conditional heritage rewrite and the union-constituent split.
+- `description.ts` — the precedence order, and splitting block tags out of the description.
 - `defaultValues.ts` — the `Astro.props` destructuring walker, ported closely from the prior art.
 - `propFilter.ts` — the Decision 7 default plus overrides.
-- `cache.ts` — content-hash memory cache plus `createFileSystemCache` from `storybook/internal/common`.
+- `extract.ts` — orchestration: instantiation, union merge, prop building, filtering.
+- `index.ts` — the runtime: the guarded TypeScript import, tsconfig discovery, the
+  extraction cache, and trimming absolute paths out of anything bound for the bundle.
 
 Add `typescript` as an optional peer dependency and to `tsup.config.ts` `external`.
 

--- a/docs/specs/docgen.md
+++ b/docs/specs/docgen.md
@@ -129,9 +129,11 @@ Net effect on that component: roughly nine meaningful rows instead of three or t
 **Decision 8 — Resolve descriptions through the AST, and strip non-standard tags.** A "floating" JSDoc block is not floating — TypeScript attaches it to the following statement, so `ts.getJSDocCommentsAndTags` finds it reliably. Precedence, first non-empty winning:
 
 1. The first frontmatter statement whose JSDoc carries `@component` or `@description` — using the tag's text if present, otherwise the block's free text.
-2. `propsSymbol.getDocumentationComment(checker)`, which survives declaration merging and re-exports in a way text scraping does not.
-3. The file's leading `/** */` block, but only when it is the first trivia **and** is not attached to an import declaration.
+2. JSDoc on the `Props` declaration.
+3. The frontmatter's leading `/** */` block, whatever statement it attaches to.
 4. Empty.
+
+Rule 3 deliberately does not exclude blocks attached to an import. Astro frontmatter puts imports first, so a description written at the top of a file usually lands on one — `PageCard.astro` in this repo is shaped exactly that way, and excluding imports silently dropped its description. What keeps the rule honest is that the block must be the *first* thing in the frontmatter; a JSDoc on the third import or on some mid-file constant is not a component description.
 
 The prior art takes the first `/** */` in the file by regex, which happily picks up a license header or a JSDoc on an import.
 

--- a/integration/astro5/src/components/Accordion/Accordion.stories.jsx
+++ b/integration/astro5/src/components/Accordion/Accordion.stories.jsx
@@ -4,31 +4,6 @@ import Accordion from '@storybook-astro/components/Accordion/astro/Accordion.ast
 export default {
   title: 'Astro/Accordion',
   component: Accordion,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A collapsible section list with vanilla JS toggle behavior. Renders server-side with no framework runtime — interactivity uses an inline `<script>` tag.',
-      },
-    },
-  },
-  argTypes: {
-    items: {
-      description: 'Sections to render. Each item has a `title` (header text) and `content` (body text).',
-      control: 'object',
-      table: {
-        type: { summary: '{ title: string, content: string }[]' },
-        defaultValue: { summary: '[]' },
-      },
-    },
-    allowMultiple: {
-      description: 'When true, multiple sections can be open at the same time. When false, opening one section closes the others.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro5/src/components/Astro.mdx
+++ b/integration/astro5/src/components/Astro.mdx
@@ -34,11 +34,25 @@ export const Example = {
 
 In `storybook build`, Astro components are **pre-rendered at build time** — changing args via the Controls panel has no effect. Framework components (React, Vue, etc.) remain fully interactive.
 
-## Components
+## Documentation
 
-- **Accordion** — Collapsible sections with vanilla JS toggle (`items`, `allowMultiple`)
-- **Card** — Content card with optional highlight (`title`, `content`, `highlight`, slot: `main`)
-- **Counter** — Increment counter with vanilla JS (no props)
-- **Footer** — Site footer with configurable links (`links`, `licenseText`)
-- **Header** — Responsive nav header with hamburger menu (`logoText`, `navItems`, `currentPath`)
-- **ImageText** — Two-column image + text layout (`imageSrc`, `imageAlt`, `reversed`, slot: `default`)
+Each component's description and props table is generated from the JSDoc in its
+`.astro` frontmatter — pick a component in the sidebar and open its Docs tab.
+Story files declare no `argTypes`, so the table always matches the component:
+
+```astro
+---
+/** A simple content card with optional highlight styling. */
+interface Props {
+  /** Card heading text. */
+  title?: string;
+  /** Applies a highlighted visual style. */
+  highlight?: boolean;
+}
+
+const { title = 'Default title', highlight = false } = Astro.props;
+---
+```
+
+Slots are the exception: they have no TypeScript representation, so describe
+them in the component's own JSDoc block.

--- a/integration/astro5/src/components/Button/Button.stories.jsx
+++ b/integration/astro5/src/components/Button/Button.stories.jsx
@@ -1,0 +1,59 @@
+import Button from '@storybook-astro/components/Button/astro/Button.astro';
+
+// Everything in the props table below is extracted from Button.astro's
+// frontmatter — this file deliberately declares no argTypes and no component
+// description (docs/specs/docgen.md).
+export default {
+  title: 'Astro/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export const Default = {
+  parameters: {
+    docs: { description: { story: 'Default solid button at medium size.' } },
+  },
+  args: {
+    slots: { default: 'Click me' },
+  },
+};
+
+export const Outline = {
+  parameters: {
+    docs: { description: { story: 'Outline variant at large size.' } },
+  },
+  args: {
+    variant: 'outline',
+    size: 'lg',
+    slots: { default: 'Read the docs' },
+  },
+};
+
+export const AsLink = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rendered as an anchor. `href` only exists on the anchor constituent of the polymorphic union, so it appears in the table only because docgen merges both.',
+      },
+    },
+  },
+  args: {
+    as: 'a',
+    href: 'https://storybook-astro.org',
+    variant: 'soft',
+    slots: { default: 'Visit the site' },
+  },
+};
+
+export const Disabled = {
+  parameters: {
+    docs: { description: { story: 'Disabled state, dimmed and non-interactive.' } },
+  },
+  args: {
+    disabled: true,
+    slots: { default: 'Unavailable' },
+  },
+};

--- a/integration/astro5/src/components/Card/Card.stories.jsx
+++ b/integration/astro5/src/components/Card/Card.stories.jsx
@@ -3,39 +3,6 @@ import Card from '@storybook-astro/components/Card/astro/Card.astro';
 export default {
   title: 'Astro/Card',
   component: Card,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A simple content card with optional highlight styling. Supports a `main` named slot for additional content below the body text.',
-      },
-    },
-  },
-  argTypes: {
-    title: {
-      description: 'Card heading text.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Default title'" },
-      },
-    },
-    content: {
-      description: 'Card body text.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Default content'" },
-      },
-    },
-    highlight: {
-      description: 'Applies a highlighted visual style with a yellow background and border.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro5/src/components/CodeTabs/CodeTabs.stories.jsx
+++ b/integration/astro5/src/components/CodeTabs/CodeTabs.stories.jsx
@@ -6,24 +6,6 @@ export default {
   args: {
     framework: 'react',
   },
-  parameters: {
-    docs: {
-      description: {
-        component: 'Code snippet tabs rendered by Astro, implemented by framework components. React/Solid/Preact/Svelte/Vue are hydrated with `client:load`; Alpine uses runtime directives.',
-      },
-    },
-  },
-  argTypes: {
-    framework: {
-      description: 'Client framework implementation mounted under Astro.',
-      control: { type: 'select' },
-      options: ['react', 'solid', 'preact', 'svelte', 'vue', 'alpine'],
-      table: {
-        type: { summary: "'react' | 'solid' | 'preact' | 'svelte' | 'vue' | 'alpine'" },
-        defaultValue: { summary: 'react' },
-      },
-    },
-  },
 };
 
 export const Default = {};

--- a/integration/astro5/src/components/Footer/Footer.stories.jsx
+++ b/integration/astro5/src/components/Footer/Footer.stories.jsx
@@ -5,29 +5,6 @@ export default {
   component: Footer,
   parameters: {
     layout: 'fullscreen',
-    docs: {
-      description: {
-        component: 'A site footer with configurable links and license text. Responsive layout — links stack vertically on mobile and align horizontally with dot separators on desktop.',
-      },
-    },
-  },
-  argTypes: {
-    links: {
-      description: 'Footer links. Each item has a `label` and `href`.',
-      control: 'object',
-      table: {
-        type: { summary: '{ label: string, href: string }[]' },
-        defaultValue: { summary: 'Storybook feature request, framework docs, Container API' },
-      },
-    },
-    licenseText: {
-      description: 'License notice displayed below the links.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Licensed under MIT'" },
-      },
-    },
   },
 };
 

--- a/integration/astro5/src/components/Header/Header.stories.jsx
+++ b/integration/astro5/src/components/Header/Header.stories.jsx
@@ -5,37 +5,6 @@ export default {
   component: Header,
   parameters: {
     layout: 'fullscreen',
-    docs: {
-      description: {
-        component: 'A responsive site header with logo, navigation links, and a mobile hamburger menu. The active link is highlighted based on `currentPath`.',
-      },
-    },
-  },
-  argTypes: {
-    logoText: {
-      description: 'Logo text displayed in the top-left.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Storybook Astro'" },
-      },
-    },
-    navItems: {
-      description: 'Navigation links. Each item has a `label` and `href`.',
-      control: 'object',
-      table: {
-        type: { summary: '{ label: string, href: string }[]' },
-        defaultValue: { summary: 'About, Contribute, Sample Components, Storybook Demo' },
-      },
-    },
-    currentPath: {
-      description: 'Current URL path used to highlight the active nav link.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: 'Astro.url.pathname' },
-      },
-    },
   },
 };
 

--- a/integration/astro5/src/components/ImageText/ImageText.stories.jsx
+++ b/integration/astro5/src/components/ImageText/ImageText.stories.jsx
@@ -4,37 +4,6 @@ import storybookAstro from '../../assets/storybook-astro.png';
 export default {
   title: 'Astro/ImageText',
   component: ImageText,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A two-column layout with an image and text content side by side. Supports reversing the order and accepts a `default` slot for the text column. Responsive — stacks vertically on mobile.',
-      },
-    },
-  },
-  argTypes: {
-    imageSrc: {
-      description: 'Image source — an imported asset (ImageMetadata) or a URL string.',
-      table: {
-        type: { summary: 'ImageMetadata | string' },
-      },
-    },
-    imageAlt: {
-      description: 'Alt text for the image.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Image'" },
-      },
-    },
-    reversed: {
-      description: 'Places the image on the right side instead of the left.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro5/src/components/PageCard/PageCard.stories.jsx
+++ b/integration/astro5/src/components/PageCard/PageCard.stories.jsx
@@ -4,15 +4,6 @@ import storybookAstro from '../../assets/storybook-astro.png';
 export default {
   title: 'Astro/PageCard',
   component: PageCard,
-  parameters: {
-    docs: {
-      description: {
-        component:
-          'A composite card component that nests Card.astro and uses astro:assets <Image>. ' +
-          'Tests that template nesting and image rendering both work via the Container API.',
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro6/src/components/Accordion/Accordion.stories.jsx
+++ b/integration/astro6/src/components/Accordion/Accordion.stories.jsx
@@ -4,31 +4,6 @@ import Accordion from '@storybook-astro/components/Accordion/astro/Accordion.ast
 export default {
   title: 'Astro/Accordion',
   component: Accordion,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A collapsible section list with vanilla JS toggle behavior. Renders server-side with no framework runtime — interactivity uses an inline `<script>` tag.',
-      },
-    },
-  },
-  argTypes: {
-    items: {
-      description: 'Sections to render. Each item has a `title` (header text) and `content` (body text).',
-      control: 'object',
-      table: {
-        type: { summary: '{ title: string, content: string }[]' },
-        defaultValue: { summary: '[]' },
-      },
-    },
-    allowMultiple: {
-      description: 'When true, multiple sections can be open at the same time. When false, opening one section closes the others.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro6/src/components/Astro.mdx
+++ b/integration/astro6/src/components/Astro.mdx
@@ -34,11 +34,25 @@ export const Example = {
 
 In `storybook build`, Astro components are **pre-rendered at build time** — changing args via the Controls panel has no effect. Framework components (React, Vue, etc.) remain fully interactive.
 
-## Components
+## Documentation
 
-- **Accordion** — Collapsible sections with vanilla JS toggle (`items`, `allowMultiple`)
-- **Card** — Content card with optional highlight (`title`, `content`, `highlight`, slot: `main`)
-- **Counter** — Increment counter with vanilla JS (no props)
-- **Footer** — Site footer with configurable links (`links`, `licenseText`)
-- **Header** — Responsive nav header with hamburger menu (`logoText`, `navItems`, `currentPath`)
-- **ImageText** — Two-column image + text layout (`imageSrc`, `imageAlt`, `reversed`, slot: `default`)
+Each component's description and props table is generated from the JSDoc in its
+`.astro` frontmatter — pick a component in the sidebar and open its Docs tab.
+Story files declare no `argTypes`, so the table always matches the component:
+
+```astro
+---
+/** A simple content card with optional highlight styling. */
+interface Props {
+  /** Card heading text. */
+  title?: string;
+  /** Applies a highlighted visual style. */
+  highlight?: boolean;
+}
+
+const { title = 'Default title', highlight = false } = Astro.props;
+---
+```
+
+Slots are the exception: they have no TypeScript representation, so describe
+them in the component's own JSDoc block.

--- a/integration/astro6/src/components/Button/Button.stories.jsx
+++ b/integration/astro6/src/components/Button/Button.stories.jsx
@@ -1,0 +1,59 @@
+import Button from '@storybook-astro/components/Button/astro/Button.astro';
+
+// Everything in the props table below is extracted from Button.astro's
+// frontmatter — this file deliberately declares no argTypes and no component
+// description (docs/specs/docgen.md).
+export default {
+  title: 'Astro/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export const Default = {
+  parameters: {
+    docs: { description: { story: 'Default solid button at medium size.' } },
+  },
+  args: {
+    slots: { default: 'Click me' },
+  },
+};
+
+export const Outline = {
+  parameters: {
+    docs: { description: { story: 'Outline variant at large size.' } },
+  },
+  args: {
+    variant: 'outline',
+    size: 'lg',
+    slots: { default: 'Read the docs' },
+  },
+};
+
+export const AsLink = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rendered as an anchor. `href` only exists on the anchor constituent of the polymorphic union, so it appears in the table only because docgen merges both.',
+      },
+    },
+  },
+  args: {
+    as: 'a',
+    href: 'https://storybook-astro.org',
+    variant: 'soft',
+    slots: { default: 'Visit the site' },
+  },
+};
+
+export const Disabled = {
+  parameters: {
+    docs: { description: { story: 'Disabled state, dimmed and non-interactive.' } },
+  },
+  args: {
+    disabled: true,
+    slots: { default: 'Unavailable' },
+  },
+};

--- a/integration/astro6/src/components/Card/Card.stories.jsx
+++ b/integration/astro6/src/components/Card/Card.stories.jsx
@@ -3,39 +3,6 @@ import Card from '@storybook-astro/components/Card/astro/Card.astro';
 export default {
   title: 'Astro/Card',
   component: Card,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A simple content card with optional highlight styling. Supports a `main` named slot for additional content below the body text.',
-      },
-    },
-  },
-  argTypes: {
-    title: {
-      description: 'Card heading text.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Default title'" },
-      },
-    },
-    content: {
-      description: 'Card body text.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Default content'" },
-      },
-    },
-    highlight: {
-      description: 'Applies a highlighted visual style with a yellow background and border.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro6/src/components/CodeTabs/CodeTabs.stories.jsx
+++ b/integration/astro6/src/components/CodeTabs/CodeTabs.stories.jsx
@@ -6,24 +6,6 @@ export default {
   args: {
     framework: 'react',
   },
-  parameters: {
-    docs: {
-      description: {
-        component: 'Code snippet tabs rendered by Astro, implemented by framework components. React/Solid/Preact/Svelte/Vue are hydrated with `client:load`; Alpine uses runtime directives.',
-      },
-    },
-  },
-  argTypes: {
-    framework: {
-      description: 'Client framework implementation mounted under Astro.',
-      control: { type: 'select' },
-      options: ['react', 'solid', 'preact', 'svelte', 'vue', 'alpine'],
-      table: {
-        type: { summary: "'react' | 'solid' | 'preact' | 'svelte' | 'vue' | 'alpine'" },
-        defaultValue: { summary: 'react' },
-      },
-    },
-  },
 };
 
 export const Default = {};

--- a/integration/astro6/src/components/Footer/Footer.stories.jsx
+++ b/integration/astro6/src/components/Footer/Footer.stories.jsx
@@ -5,29 +5,6 @@ export default {
   component: Footer,
   parameters: {
     layout: 'fullscreen',
-    docs: {
-      description: {
-        component: 'A site footer with configurable links and license text. Responsive layout — links stack vertically on mobile and align horizontally with dot separators on desktop.',
-      },
-    },
-  },
-  argTypes: {
-    links: {
-      description: 'Footer links. Each item has a `label` and `href`.',
-      control: 'object',
-      table: {
-        type: { summary: '{ label: string, href: string }[]' },
-        defaultValue: { summary: 'Storybook feature request, framework docs, Container API' },
-      },
-    },
-    licenseText: {
-      description: 'License notice displayed below the links.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Licensed under MIT'" },
-      },
-    },
   },
 };
 

--- a/integration/astro6/src/components/Header/Header.stories.jsx
+++ b/integration/astro6/src/components/Header/Header.stories.jsx
@@ -5,37 +5,6 @@ export default {
   component: Header,
   parameters: {
     layout: 'fullscreen',
-    docs: {
-      description: {
-        component: 'A responsive site header with logo, navigation links, and a mobile hamburger menu. The active link is highlighted based on `currentPath`.',
-      },
-    },
-  },
-  argTypes: {
-    logoText: {
-      description: 'Logo text displayed in the top-left.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Storybook Astro'" },
-      },
-    },
-    navItems: {
-      description: 'Navigation links. Each item has a `label` and `href`.',
-      control: 'object',
-      table: {
-        type: { summary: '{ label: string, href: string }[]' },
-        defaultValue: { summary: 'About, Contribute, Sample Components, Storybook Demo' },
-      },
-    },
-    currentPath: {
-      description: 'Current URL path used to highlight the active nav link.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: 'Astro.url.pathname' },
-      },
-    },
   },
 };
 

--- a/integration/astro6/src/components/ImageText/ImageText.stories.jsx
+++ b/integration/astro6/src/components/ImageText/ImageText.stories.jsx
@@ -4,37 +4,6 @@ import storybookAstro from '../../assets/storybook-astro.png';
 export default {
   title: 'Astro/ImageText',
   component: ImageText,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A two-column layout with an image and text content side by side. Supports reversing the order and accepts a `default` slot for the text column. Responsive — stacks vertically on mobile.',
-      },
-    },
-  },
-  argTypes: {
-    imageSrc: {
-      description: 'Image source — an imported asset (ImageMetadata) or a URL string.',
-      table: {
-        type: { summary: 'ImageMetadata | string' },
-      },
-    },
-    imageAlt: {
-      description: 'Alt text for the image.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Image'" },
-      },
-    },
-    reversed: {
-      description: 'Places the image on the right side instead of the left.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro6/src/components/PageCard/PageCard.stories.jsx
+++ b/integration/astro6/src/components/PageCard/PageCard.stories.jsx
@@ -4,16 +4,6 @@ import storybookAstro from '../../assets/storybook-astro.png';
 export default {
   title: 'Astro/PageCard',
   component: PageCard,
-  parameters: {
-    docs: {
-      description: {
-        component:
-          'A composite card component that nests Card.astro and uses astro:assets <Image>. ' +
-          'Tests that template nesting and image rendering both work via the Container API, ' +
-          "and that the nested Card's scoped styles load in the browser (issue #114).",
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro7/src/components/Accordion/Accordion.stories.jsx
+++ b/integration/astro7/src/components/Accordion/Accordion.stories.jsx
@@ -4,31 +4,6 @@ import Accordion from '@storybook-astro/components/Accordion/astro/Accordion.ast
 export default {
   title: 'Astro/Accordion',
   component: Accordion,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A collapsible section list with vanilla JS toggle behavior. Renders server-side with no framework runtime — interactivity uses an inline `<script>` tag.',
-      },
-    },
-  },
-  argTypes: {
-    items: {
-      description: 'Sections to render. Each item has a `title` (header text) and `content` (body text).',
-      control: 'object',
-      table: {
-        type: { summary: '{ title: string, content: string }[]' },
-        defaultValue: { summary: '[]' },
-      },
-    },
-    allowMultiple: {
-      description: 'When true, multiple sections can be open at the same time. When false, opening one section closes the others.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro7/src/components/Astro.mdx
+++ b/integration/astro7/src/components/Astro.mdx
@@ -34,11 +34,25 @@ export const Example = {
 
 In `storybook build`, Astro components are **pre-rendered at build time** — changing args via the Controls panel has no effect. Framework components (React, Vue, etc.) remain fully interactive.
 
-## Components
+## Documentation
 
-- **Accordion** — Collapsible sections with vanilla JS toggle (`items`, `allowMultiple`)
-- **Card** — Content card with optional highlight (`title`, `content`, `highlight`, slot: `main`)
-- **Counter** — Increment counter with vanilla JS (no props)
-- **Footer** — Site footer with configurable links (`links`, `licenseText`)
-- **Header** — Responsive nav header with hamburger menu (`logoText`, `navItems`, `currentPath`)
-- **ImageText** — Two-column image + text layout (`imageSrc`, `imageAlt`, `reversed`, slot: `default`)
+Each component's description and props table is generated from the JSDoc in its
+`.astro` frontmatter — pick a component in the sidebar and open its Docs tab.
+Story files declare no `argTypes`, so the table always matches the component:
+
+```astro
+---
+/** A simple content card with optional highlight styling. */
+interface Props {
+  /** Card heading text. */
+  title?: string;
+  /** Applies a highlighted visual style. */
+  highlight?: boolean;
+}
+
+const { title = 'Default title', highlight = false } = Astro.props;
+---
+```
+
+Slots are the exception: they have no TypeScript representation, so describe
+them in the component's own JSDoc block.

--- a/integration/astro7/src/components/Button/Button.stories.jsx
+++ b/integration/astro7/src/components/Button/Button.stories.jsx
@@ -1,0 +1,59 @@
+import Button from '@storybook-astro/components/Button/astro/Button.astro';
+
+// Everything in the props table below is extracted from Button.astro's
+// frontmatter — this file deliberately declares no argTypes and no component
+// description (docs/specs/docgen.md).
+export default {
+  title: 'Astro/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export const Default = {
+  parameters: {
+    docs: { description: { story: 'Default solid button at medium size.' } },
+  },
+  args: {
+    slots: { default: 'Click me' },
+  },
+};
+
+export const Outline = {
+  parameters: {
+    docs: { description: { story: 'Outline variant at large size.' } },
+  },
+  args: {
+    variant: 'outline',
+    size: 'lg',
+    slots: { default: 'Read the docs' },
+  },
+};
+
+export const AsLink = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rendered as an anchor. `href` only exists on the anchor constituent of the polymorphic union, so it appears in the table only because docgen merges both.',
+      },
+    },
+  },
+  args: {
+    as: 'a',
+    href: 'https://storybook-astro.org',
+    variant: 'soft',
+    slots: { default: 'Visit the site' },
+  },
+};
+
+export const Disabled = {
+  parameters: {
+    docs: { description: { story: 'Disabled state, dimmed and non-interactive.' } },
+  },
+  args: {
+    disabled: true,
+    slots: { default: 'Unavailable' },
+  },
+};

--- a/integration/astro7/src/components/Card/Card.stories.jsx
+++ b/integration/astro7/src/components/Card/Card.stories.jsx
@@ -3,39 +3,6 @@ import Card from '@storybook-astro/components/Card/astro/Card.astro';
 export default {
   title: 'Astro/Card',
   component: Card,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A simple content card with optional highlight styling. Supports a `main` named slot for additional content below the body text.',
-      },
-    },
-  },
-  argTypes: {
-    title: {
-      description: 'Card heading text.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Default title'" },
-      },
-    },
-    content: {
-      description: 'Card body text.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Default content'" },
-      },
-    },
-    highlight: {
-      description: 'Applies a highlighted visual style with a yellow background and border.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro7/src/components/CodeTabs/CodeTabs.stories.jsx
+++ b/integration/astro7/src/components/CodeTabs/CodeTabs.stories.jsx
@@ -6,24 +6,6 @@ export default {
   args: {
     framework: 'react',
   },
-  parameters: {
-    docs: {
-      description: {
-        component: 'Code snippet tabs rendered by Astro, implemented by framework components. React/Solid/Preact/Svelte/Vue are hydrated with `client:load`; Alpine uses runtime directives.',
-      },
-    },
-  },
-  argTypes: {
-    framework: {
-      description: 'Client framework implementation mounted under Astro.',
-      control: { type: 'select' },
-      options: ['react', 'solid', 'preact', 'svelte', 'vue', 'alpine'],
-      table: {
-        type: { summary: "'react' | 'solid' | 'preact' | 'svelte' | 'vue' | 'alpine'" },
-        defaultValue: { summary: 'react' },
-      },
-    },
-  },
 };
 
 export const Default = {};

--- a/integration/astro7/src/components/DateStamp/DateStamp.astro
+++ b/integration/astro7/src/components/DateStamp/DateStamp.astro
@@ -1,8 +1,10 @@
 ---
+/** Renders a publication date as a machine-readable `<time>` element. */
 // Regression coverage: a Date passed as a story arg must reach the component as
 // a real Date through the static-build prerender path. Calling toISOString() on
 // a clobbered value ({}) throws, which is exactly the bug this guards against.
 interface Props {
+  /** Date to display. Must arrive as a real Date, not a serialised stand-in. */
   publishedAt: Date;
 }
 

--- a/integration/astro7/src/components/Footer/Footer.stories.jsx
+++ b/integration/astro7/src/components/Footer/Footer.stories.jsx
@@ -5,29 +5,6 @@ export default {
   component: Footer,
   parameters: {
     layout: 'fullscreen',
-    docs: {
-      description: {
-        component: 'A site footer with configurable links and license text. Responsive layout — links stack vertically on mobile and align horizontally with dot separators on desktop.',
-      },
-    },
-  },
-  argTypes: {
-    links: {
-      description: 'Footer links. Each item has a `label` and `href`.',
-      control: 'object',
-      table: {
-        type: { summary: '{ label: string, href: string }[]' },
-        defaultValue: { summary: 'Storybook feature request, framework docs, Container API' },
-      },
-    },
-    licenseText: {
-      description: 'License notice displayed below the links.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Licensed under MIT'" },
-      },
-    },
   },
 };
 

--- a/integration/astro7/src/components/Header/Header.stories.jsx
+++ b/integration/astro7/src/components/Header/Header.stories.jsx
@@ -5,37 +5,6 @@ export default {
   component: Header,
   parameters: {
     layout: 'fullscreen',
-    docs: {
-      description: {
-        component: 'A responsive site header with logo, navigation links, and a mobile hamburger menu. The active link is highlighted based on `currentPath`.',
-      },
-    },
-  },
-  argTypes: {
-    logoText: {
-      description: 'Logo text displayed in the top-left.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Storybook Astro'" },
-      },
-    },
-    navItems: {
-      description: 'Navigation links. Each item has a `label` and `href`.',
-      control: 'object',
-      table: {
-        type: { summary: '{ label: string, href: string }[]' },
-        defaultValue: { summary: 'About, Contribute, Sample Components, Storybook Demo' },
-      },
-    },
-    currentPath: {
-      description: 'Current URL path used to highlight the active nav link.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: 'Astro.url.pathname' },
-      },
-    },
   },
 };
 

--- a/integration/astro7/src/components/ImageText/ImageText.stories.jsx
+++ b/integration/astro7/src/components/ImageText/ImageText.stories.jsx
@@ -4,37 +4,6 @@ import storybookAstro from '../../assets/storybook-astro.png';
 export default {
   title: 'Astro/ImageText',
   component: ImageText,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A two-column layout with an image and text content side by side. Supports reversing the order and accepts a `default` slot for the text column. Responsive — stacks vertically on mobile.',
-      },
-    },
-  },
-  argTypes: {
-    imageSrc: {
-      description: 'Image source — an imported asset (ImageMetadata) or a URL string.',
-      table: {
-        type: { summary: 'ImageMetadata | string' },
-      },
-    },
-    imageAlt: {
-      description: 'Alt text for the image.',
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: "'Image'" },
-      },
-    },
-    reversed: {
-      description: 'Places the image on the right side instead of the left.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro7/src/components/PageCard/PageCard.stories.jsx
+++ b/integration/astro7/src/components/PageCard/PageCard.stories.jsx
@@ -4,16 +4,6 @@ import storybookAstro from '../../assets/storybook-astro.png';
 export default {
   title: 'Astro/PageCard',
   component: PageCard,
-  parameters: {
-    docs: {
-      description: {
-        component:
-          'A composite card component that nests Card.astro and uses astro:assets <Image>. ' +
-          'Tests that template nesting and image rendering both work via the Container API, ' +
-          "and that the nested Card's scoped styles load in the browser (issue #114).",
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/integration/astro7/src/components/PublicImage/PublicImage.astro
+++ b/integration/astro7/src/components/PublicImage/PublicImage.astro
@@ -2,13 +2,16 @@
 import type { ImageMetadata } from "astro";
 import { Image } from "astro:assets";
 
+/** Renders an image that lives in the project's `public/` directory. */
 // Regression coverage for public-directory images rendered through Astro's
 // <Image>. In the static build these resolve to dev-only `/@fs/.../public/...`
 // URLs during prerender; the framework must rewrite them to their served root
 // path (e.g. `/images/sample.png`) or the image 404s. Mirrors a common
 // theme pattern (glob `public/images`, pass the imported asset to <Image>).
 interface Props {
+  /** Path to the image under `public/`. */
   src: string;
+  /** Alt text for the image. */
   alt: string;
 }
 

--- a/integration/astro7/src/components/SlotBox/BoxChild.astro
+++ b/integration/astro7/src/components/SlotBox/BoxChild.astro
@@ -1,8 +1,9 @@
 ---
-// A child component with its own slot. Used to prove a configured-component slot
-// (a child placed in a parent's slot *with its own props and slot content*)
-// renders as a real Astro component — issue #146.
+/** A labelled box with its own default slot, for nesting inside another box. */
+// Proves a configured-component slot (a child placed in a parent's slot *with its
+// own props and slot content*) renders as a real Astro component — issue #146.
 interface Props {
+  /** Caption shown above the slot content. */
   label?: string;
 }
 

--- a/integration/astro7/src/components/SlotBox/BoxParent.astro
+++ b/integration/astro7/src/components/SlotBox/BoxParent.astro
@@ -1,5 +1,5 @@
 ---
-// A plain wrapper that renders whatever is placed in its default slot.
+/** A plain wrapper that renders whatever is placed in its default slot. */
 ---
 
 <div class="BoxParent" data-testid="box-parent">

--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -78,6 +78,7 @@
     "eslint": "^9.39.2",
     "storybook-solidjs": "^1.0.0-beta.7",
     "tsup": "^8.5.1",
+    "typescript": "^5.8.3",
     "vite-plugin-solid": "^2.11.10",
     "vitest": "^4.1.9"
   },
@@ -99,6 +100,7 @@
     "astro": "^5.5.3 || ^6.0.0 || ^7.0.0",
     "storybook": "^10.0.0",
     "storybook-solidjs": "^1.0.0-beta.7",
+    "typescript": "^5.0.0 || ^6.0.0",
     "vite": "^6.4.1 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
@@ -145,6 +147,9 @@
       "optional": true
     },
     "storybook-solidjs": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },

--- a/packages/@storybook-astro/framework/src/docgen/defaultValues.test.ts
+++ b/packages/@storybook-astro/framework/src/docgen/defaultValues.test.ts
@@ -1,0 +1,97 @@
+import typescript from 'typescript';
+import { describe, expect, test } from 'vitest';
+import { readAstroPropsBinding } from './defaultValues.ts';
+import { buildVirtualSource } from './virtualFile.ts';
+
+/** Reads the binding out of real `.astro` frontmatter, the way the extractor does. */
+function bindingFor(frontmatter: string) {
+  const source = buildVirtualSource(`---\n${frontmatter}\n---\n<div />`) as string;
+  const sourceFile = typescript.createSourceFile(
+    '/src/Component.astro.ts',
+    source,
+    typescript.ScriptTarget.Latest,
+    true
+  );
+
+  return readAstroPropsBinding(typescript, sourceFile);
+}
+
+describe('defaults are read from the destructuring pattern', () => {
+  test.each([
+    ["const { a = 'x' } = Astro.props;", 'x'],
+    ['const { a = 42 } = Astro.props;', 42],
+    ['const { a = -1 } = Astro.props;', -1],
+    ['const { a = true } = Astro.props;', true],
+    ['const { a = false } = Astro.props;', false],
+    ['const { a = null } = Astro.props;', null],
+    ['const { a = `x` } = Astro.props;', 'x']
+  ])('%s', (frontmatter, expected) => {
+    expect(bindingFor(frontmatter).defaults.get('a')).toBe(expected);
+  });
+
+  test('a non-literal default keeps its source text, which is what readers want to see', () => {
+    const binding = bindingFor('const { navItems = defaultNavItems } = Astro.props;');
+
+    expect(binding.defaults.get('navItems')).toBe('defaultNavItems');
+  });
+
+  test('a prop destructured without a default has none', () => {
+    const binding = bindingFor('const { a } = Astro.props;');
+
+    expect(binding.defaults.has('a')).toBe(false);
+    expect(binding.destructured.has('a')).toBe(true);
+  });
+});
+
+describe('the annotated forms of Astro.props are all recognised', () => {
+  test.each([
+    'const { a = 1 } = Astro.props;',
+    'const { a = 1 } = Astro.props as Props;',
+    'const { a = 1 } = Astro.props satisfies Props;',
+    'const { a = 1 } = (Astro.props as Props);'
+  ])('%s', (frontmatter) => {
+    expect(bindingFor(frontmatter).defaults.get('a')).toBe(1);
+  });
+});
+
+describe('the destructured set is the component author’s public surface', () => {
+  test('a renamed binding records the prop name, not the local alias', () => {
+    const binding = bindingFor("const { class: className = 'card' } = Astro.props;");
+
+    expect(binding.destructured.has('class')).toBe(true);
+    expect(binding.destructured.has('className')).toBe(false);
+    expect(binding.defaults.get('class')).toBe('card');
+  });
+
+  test('a rest element is not a prop', () => {
+    const binding = bindingFor('const { as = "button", ...rest } = Astro.props;');
+
+    expect([...binding.destructured]).toEqual(['as']);
+  });
+
+  test('every destructured name is captured, defaulted or not', () => {
+    const binding = bindingFor(
+      "const { as = 'button', href, disabled = false } = Astro.props as Props;"
+    );
+
+    expect([...binding.destructured].sort()).toEqual(['as', 'disabled', 'href']);
+  });
+});
+
+describe('unrelated code is left alone', () => {
+  test('a destructure of something other than Astro.props', () => {
+    expect(bindingFor("const { a = 1 } = someOtherObject;").destructured.size).toBe(0);
+  });
+
+  test('Astro.props read without destructuring', () => {
+    expect(bindingFor('const props = Astro.props;').destructured.size).toBe(0);
+  });
+
+  test('a destructure nested in a function is not the component surface', () => {
+    const binding = bindingFor(
+      ['function helper() {', '  const { a = 1 } = Astro.props;', '}'].join('\n')
+    );
+
+    expect(binding.destructured.size).toBe(0);
+  });
+});

--- a/packages/@storybook-astro/framework/src/docgen/defaultValues.ts
+++ b/packages/@storybook-astro/framework/src/docgen/defaultValues.ts
@@ -1,0 +1,128 @@
+import type ts from 'typescript';
+
+export interface AstroPropsBinding {
+  /** Prop name → default, for props destructured with one. */
+  defaults: Map<string, string | number | boolean | null>;
+  /**
+   * Every prop name the component destructures, with or without a default.
+   *
+   * This is the author's own statement of the public surface, so the prop
+   * filter keeps these regardless of where they were declared — it is what
+   * recovers `as`, `href` and `class` on a polymorphic component whose types
+   * all come from `node_modules` (docs/specs/docgen.md#prop-filtering).
+   */
+  destructured: Set<string>;
+}
+
+/**
+ * Reads `const { … } = Astro.props` from a component's frontmatter.
+ *
+ * Only top-level statements are considered: a destructure nested inside a
+ * function isn't the component's prop surface. The `as Props` and
+ * `satisfies Props` forms are both recognised, since neither changes what is
+ * being destructured.
+ */
+export function readAstroPropsBinding(
+  typescript: typeof ts,
+  sourceFile: ts.SourceFile
+): AstroPropsBinding {
+  const defaults = new Map<string, string | number | boolean | null>();
+  const destructured = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (!typescript.isVariableStatement(statement)) {
+      continue;
+    }
+
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        !declaration.initializer ||
+        !isAstroProps(typescript, declaration.initializer) ||
+        !typescript.isObjectBindingPattern(declaration.name)
+      ) {
+        continue;
+      }
+
+      for (const element of declaration.name.elements) {
+        // `...rest` collects whatever is left over; it isn't a prop itself.
+        if (element.dotDotDotToken) {
+          continue;
+        }
+
+        // `{ class: className }` documents `class`, not `className`. The prior
+        // art read the binding name here and so recorded the local alias.
+        const propName = (element.propertyName ?? element.name).getText(sourceFile);
+
+        destructured.add(propName);
+
+        if (element.initializer) {
+          defaults.set(propName, literalValueOf(typescript, element.initializer, sourceFile));
+        }
+      }
+    }
+  }
+
+  return { defaults, destructured };
+}
+
+/** Matches `Astro.props`, `Astro.props as Props` and `Astro.props satisfies Props`. */
+function isAstroProps(typescript: typeof ts, node: ts.Expression): boolean {
+  let expression = node;
+
+  while (
+    typescript.isAsExpression(expression) ||
+    typescript.isSatisfiesExpression(expression) ||
+    typescript.isTypeAssertionExpression(expression) ||
+    typescript.isParenthesizedExpression(expression)
+  ) {
+    expression = expression.expression;
+  }
+
+  return (
+    typescript.isPropertyAccessExpression(expression) &&
+    typescript.isIdentifier(expression.expression) &&
+    expression.expression.text === 'Astro' &&
+    expression.name.text === 'props'
+  );
+}
+
+/**
+ * Narrows an initializer to something safe to serialise into the bundle.
+ * Anything that isn't a plain literal keeps its source text, which is what
+ * readers want to see for `navItems = defaultNavItems`.
+ */
+function literalValueOf(
+  typescript: typeof ts,
+  node: ts.Expression,
+  sourceFile: ts.SourceFile
+): string | number | boolean | null {
+  if (typescript.isStringLiteral(node) || typescript.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+
+  if (node.kind === typescript.SyntaxKind.TrueKeyword) {
+    return true;
+  }
+
+  if (node.kind === typescript.SyntaxKind.FalseKeyword) {
+    return false;
+  }
+
+  if (node.kind === typescript.SyntaxKind.NullKeyword) {
+    return null;
+  }
+
+  if (typescript.isNumericLiteral(node)) {
+    return Number(node.text);
+  }
+
+  if (
+    typescript.isPrefixUnaryExpression(node) &&
+    node.operator === typescript.SyntaxKind.MinusToken &&
+    typescript.isNumericLiteral(node.operand)
+  ) {
+    return -Number(node.operand.text);
+  }
+
+  return node.getText(sourceFile);
+}

--- a/packages/@storybook-astro/framework/src/docgen/description.ts
+++ b/packages/@storybook-astro/framework/src/docgen/description.ts
@@ -16,10 +16,14 @@ export interface ComponentDescription {
  *
  * 1. the first statement whose JSDoc carries `@component` or `@description`
  * 2. JSDoc on the `Props` declaration
- * 3. the file's leading block, if it isn't attached to an import
+ * 3. the frontmatter's leading block, whatever statement it attaches to
  *
- * The prior art takes the first `/** *\/` in the file by regex, which happily
- * picks up a license header or a JSDoc written above an import.
+ * Rule 3 deliberately does not care that the leading block usually attaches to
+ * an import: Astro frontmatter puts imports first, so a component description
+ * written at the top of the file almost always lands on one. What keeps this
+ * honest is that the block must be the *first* thing in the frontmatter — the
+ * prior art takes the first block found anywhere by regex, so a JSDoc on the
+ * third import or on some mid-file constant becomes the component description.
  */
 export function readComponentDescription(
   typescript: typeof ts,
@@ -56,8 +60,7 @@ export function readComponentDescription(
 
   const [leading] = blocks;
 
-  // A JSDoc above an import documents the import, not the component.
-  if (leading?.text && !typescript.isImportDeclaration(leading.statement)) {
+  if (leading?.text) {
     return { text: leading.text, tags: tagsOrUndefined(leading.tags) };
   }
 

--- a/packages/@storybook-astro/framework/src/docgen/description.ts
+++ b/packages/@storybook-astro/framework/src/docgen/description.ts
@@ -1,0 +1,100 @@
+import type ts from 'typescript';
+
+export interface ComponentDescription {
+  /** Free text only — block tags are split out so they don't render as noise. */
+  text: string;
+  tags?: Record<string, string>;
+}
+
+/**
+ * Finds the component's description in its frontmatter.
+ *
+ * A "floating" JSDoc block isn't floating: TypeScript attaches it to whatever
+ * statement follows, so the block above `const buttonVariants = cva(…)` is
+ * reachable from that statement. Precedence, first non-empty winning
+ * (docs/specs/docgen.md#description-precedence):
+ *
+ * 1. the first statement whose JSDoc carries `@component` or `@description`
+ * 2. JSDoc on the `Props` declaration
+ * 3. the file's leading block, if it isn't attached to an import
+ *
+ * The prior art takes the first `/** *\/` in the file by regex, which happily
+ * picks up a license header or a JSDoc written above an import.
+ */
+export function readComponentDescription(
+  typescript: typeof ts,
+  sourceFile: ts.SourceFile
+): ComponentDescription {
+  const blocks = sourceFile.statements.map((statement) => ({
+    statement,
+    tags: tagsOf(typescript, statement),
+    text: freeTextOf(typescript, statement)
+  }));
+
+  const explicit = blocks.find((block) => 'component' in block.tags || 'description' in block.tags);
+
+  if (explicit) {
+    const { description, ...rest } = explicit.tags;
+
+    return {
+      text: description || explicit.text,
+      tags: Object.keys(rest).length > 0 ? rest : undefined
+    };
+  }
+
+  const props = blocks.find(
+    (block) =>
+      (typescript.isInterfaceDeclaration(block.statement) ||
+        typescript.isTypeAliasDeclaration(block.statement)) &&
+      block.statement.name.text === 'Props' &&
+      block.text
+  );
+
+  if (props) {
+    return { text: props.text, tags: tagsOrUndefined(props.tags) };
+  }
+
+  const [leading] = blocks;
+
+  // A JSDoc above an import documents the import, not the component.
+  if (leading?.text && !typescript.isImportDeclaration(leading.statement)) {
+    return { text: leading.text, tags: tagsOrUndefined(leading.tags) };
+  }
+
+  return { text: '' };
+}
+
+function tagsOrUndefined(tags: Record<string, string>): Record<string, string> | undefined {
+  return Object.keys(tags).length > 0 ? tags : undefined;
+}
+
+function tagsOf(typescript: typeof ts, node: ts.Node): Record<string, string> {
+  const tags: Record<string, string> = {};
+
+  for (const tag of typescript.getJSDocTags(node)) {
+    tags[tag.tagName.text] = commentToString(typescript, tag.comment).trim();
+  }
+
+  return tags;
+}
+
+/** The prose above the first block tag, which is what a description should be. */
+function freeTextOf(typescript: typeof ts, node: ts.Node): string {
+  return typescript
+    .getJSDocCommentsAndTags(node)
+    .filter((each): each is ts.JSDoc => !!(each as ts.JSDoc).comment || 'tags' in each)
+    .map((each) => commentToString(typescript, (each as ts.JSDoc).comment))
+    .join('\n')
+    .trim();
+}
+
+function commentToString(
+  typescript: typeof ts,
+  comment: string | ts.NodeArray<ts.JSDocComment> | undefined
+): string {
+  if (comment === undefined) {
+    return '';
+  }
+
+  return typeof comment === 'string' ? comment : typescript.displayPartsToString(comment);
+}

--- a/packages/@storybook-astro/framework/src/docgen/extract.test.ts
+++ b/packages/@storybook-astro/framework/src/docgen/extract.test.ts
@@ -210,12 +210,30 @@ describe('the component from issue #110', () => {
 });
 
 describe('description precedence', () => {
-  test('a JSDoc above an import documents the import, not the component', () => {
+  test('a leading block still counts when an import follows it', () => {
+    // Astro frontmatter puts imports first, so a component description written
+    // at the top of the file lands on one. PageCard.astro is shaped this way.
     const docgen = docgenFor(
       astro(
         [
-          '/** Not the component description. */',
+          '/** Renders a page card. */',
           "import type { HTMLTag } from 'astro/types';",
+          'interface Props { a?: HTMLTag }',
+          'const { a } = Astro.props;'
+        ].join('\n')
+      )
+    );
+
+    expect(docgen?.description).toBe('Renders a page card.');
+  });
+
+  test('a JSDoc buried mid-file is not mistaken for the description', () => {
+    const docgen = docgenFor(
+      astro(
+        [
+          "import type { HTMLTag } from 'astro/types';",
+          '/** A helper, not the component. */',
+          'const helper = 1;',
           'interface Props { a?: HTMLTag }',
           'const { a } = Astro.props;'
         ].join('\n')

--- a/packages/@storybook-astro/framework/src/docgen/extract.test.ts
+++ b/packages/@storybook-astro/framework/src/docgen/extract.test.ts
@@ -209,6 +209,51 @@ describe('the component from issue #110', () => {
   });
 });
 
+describe('components do not leak props into each other', () => {
+  // Frontmatter with no import or export is a global script, so `Props` is a
+  // *global* declaration — and every component shares one TypeScript program.
+  // Two plain components would otherwise collide and the first would win.
+  const plain = (prop: string, doc: string) =>
+    astro(
+      [
+        'interface Props {',
+        `  /** ${doc} */`,
+        `  ${prop}?: string;`,
+        '}',
+        `const { ${prop} } = Astro.props;`
+      ].join('\n')
+    );
+
+  test('two components with no imports each keep their own props', () => {
+    const first = docgenFor(plain('alpha', 'Belongs to Alpha.'), 'Alpha');
+    const second = docgenFor(plain('beta', 'Belongs to Beta.'), 'Beta');
+
+    expect(Object.keys(first!.props)).toEqual(['alpha']);
+    expect(Object.keys(second!.props)).toEqual(['beta']);
+    expect(second!.props.beta.description).toBe('Belongs to Beta.');
+  });
+
+  test('a component with imports does not absorb a plain one', () => {
+    docgenFor(plain('gamma', 'Belongs to Gamma.'), 'Gamma');
+
+    const withImport = docgenFor(
+      astro(
+        [
+          "import type { HTMLTag } from 'astro/types';",
+          'interface Props {',
+          '  /** Belongs to Delta. */',
+          '  delta?: HTMLTag;',
+          '}',
+          'const { delta } = Astro.props;'
+        ].join('\n')
+      ),
+      'Delta'
+    );
+
+    expect(Object.keys(withImport!.props)).toEqual(['delta']);
+  });
+});
+
 describe('description precedence', () => {
   test('a leading block still counts when an import follows it', () => {
     // Astro frontmatter puts imports first, so a component description written

--- a/packages/@storybook-astro/framework/src/docgen/extract.test.ts
+++ b/packages/@storybook-astro/framework/src/docgen/extract.test.ts
@@ -1,0 +1,273 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import typescript from 'typescript';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { extractAstroDocgen } from './extract.ts';
+import { createAstroTsProject, type AstroTsProject } from './tsProject.ts';
+
+// The fixture must live inside the package rather than the OS tmpdir, so
+// TypeScript can resolve `astro/types` by walking up to the workspace's
+// node_modules — the inherited-props cases below depend on it.
+const packageDir = fileURLToPath(new URL('../..', import.meta.url));
+const projectRoot = mkdtempSync(join(packageDir, '.vitest-docgen-fixture-'));
+let project: AstroTsProject;
+
+beforeAll(() => {
+  project = createAstroTsProject(
+    typescript,
+    {
+      target: typescript.ScriptTarget.Latest,
+      module: typescript.ModuleKind.ESNext,
+      moduleResolution: typescript.ModuleResolutionKind.Bundler,
+      skipLibCheck: true
+    },
+    projectRoot
+  );
+});
+
+afterAll(() => {
+  project.dispose();
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+let componentCount = 0;
+
+/** Extracts from real `.astro` source, as the Vite plugin will. */
+function docgenFor(astroSource: string, name = `Component${(componentCount += 1)}`) {
+  const astroFilePath = join(projectRoot, `${name}.astro`);
+
+  return extractAstroDocgen(typescript, project, astroFilePath, astroSource, {});
+}
+
+function astro(frontmatter: string, template = '<div />') {
+  return `---\n${frontmatter}\n---\n${template}`;
+}
+
+describe('a plain component', () => {
+  const docgen = () =>
+    docgenFor(
+      astro(
+        [
+          '/**',
+          ' * A simple content card.',
+          ' */',
+          'interface Props {',
+          '  /** Card heading text. */',
+          '  title?: string;',
+          '  /** Applies a highlighted style. */',
+          '  highlight?: boolean;',
+          '  /** Required, so no default. */',
+          '  id: string;',
+          '}',
+          '',
+          "const { title = 'Default title', highlight = false, id } = Astro.props;"
+        ].join('\n')
+      ),
+      'Card'
+    );
+
+  test('takes its display name from the file', () => {
+    expect(docgen()?.displayName).toBe('Card');
+  });
+
+  test('reads the component description', () => {
+    expect(docgen()?.description).toBe('A simple content card.');
+  });
+
+  test('reads per-prop descriptions from JSDoc', () => {
+    expect(docgen()?.props.title.description).toBe('Card heading text.');
+  });
+
+  test('reads defaults from the Astro.props destructuring', () => {
+    const props = docgen()!.props;
+
+    expect(props.title.defaultValue).toEqual({ value: 'Default title' });
+    expect(props.highlight.defaultValue).toEqual({ value: false });
+  });
+
+  test('a prop with a default is not required', () => {
+    expect(docgen()?.props.title.required).toBe(false);
+  });
+
+  test('a non-optional prop with no default is required', () => {
+    expect(docgen()?.props.id.required).toBe(true);
+  });
+
+  test('strips the redundant undefined from optional prop types', () => {
+    expect(docgen()?.props.title.type.name).toBe('string');
+  });
+});
+
+describe('literal unions drive select controls', () => {
+  test('constituents are surfaced as enum options', () => {
+    const docgen = docgenFor(
+      astro(
+        [
+          "type Framework = 'react' | 'vue' | 'svelte';",
+          'interface Props { framework?: Framework }',
+          "const { framework = 'react' } = Astro.props;"
+        ].join('\n')
+      )
+    );
+
+    expect(docgen?.props.framework.type.name).toBe('enum');
+    expect(docgen?.props.framework.type.value?.map((each) => each.value)).toEqual([
+      '"react"',
+      '"vue"',
+      '"svelte"'
+    ]);
+  });
+});
+
+describe('a Props imported from a sibling module', () => {
+  test('resolves, because the virtual file sits beside the component', () => {
+    writeFileSync(
+      join(projectRoot, 'shared-props.ts'),
+      'export interface CardProps {\n  /** From a sibling file. */\n  heading?: string;\n}\n'
+    );
+
+    const docgen = docgenFor(
+      astro(
+        [
+          "import type { CardProps } from './shared-props.ts';",
+          'interface Props extends CardProps {}',
+          'const { heading } = Astro.props;'
+        ].join('\n')
+      )
+    );
+
+    expect(docgen?.props.heading?.description).toBe('From a sibling file.');
+  });
+});
+
+describe('the component from issue #110', () => {
+  // `interface Props<Tag> extends Polymorphic<…>` is a hard TS2312: TypeScript
+  // drops the whole base type, leaving only the inline members.
+  const source = astro(
+    [
+      "import type { HTMLTag, Polymorphic } from 'astro/types';",
+      '',
+      '/**',
+      ' * @component Button',
+      ' * @description Semantic button for actions and navigation.',
+      ' * @usage Some markdown that should not land in the description.',
+      ' */',
+      "type ButtonVariants = { variant?: 'solid' | 'outline' };",
+      '',
+      "interface Props<Tag extends HTMLTag = 'button' | 'a'>",
+      '  extends Polymorphic<{ as: Tag } & ButtonVariants> {',
+      '  /** Disables interaction. */',
+      '  disabled?: boolean;',
+      '}',
+      '',
+      "const { as: Tag = 'button', variant = 'solid', disabled = false, href, class: className } =",
+      '  Astro.props as Props;'
+    ].join('\n'),
+    '<Tag />'
+  );
+
+  test('recovers inherited props the heritage clause would have dropped', () => {
+    const props = docgenFor(source, 'Button')!.props;
+
+    expect(Object.keys(props)).toContain('variant');
+    expect(Object.keys(props)).toContain('as');
+  });
+
+  test('keeps destructured props whose types come from node_modules', () => {
+    const props = docgenFor(source, 'Button')!.props;
+
+    // `href` and `class` are declared in astro-jsx.d.ts, not the component.
+    expect(Object.keys(props)).toContain('href');
+    expect(Object.keys(props)).toContain('class');
+  });
+
+  test('a prop shared by every constituent keeps its full type', () => {
+    // `as` must offer both tags. Probing only the constituents in turn would
+    // narrow it to whichever was read first.
+    const { as: polymorphicTag } = docgenFor(source, 'Button')!.props;
+
+    expect(polymorphicTag.type.value?.map((each) => each.value).sort()).toEqual([
+      '"a"',
+      '"button"'
+    ]);
+  });
+
+  test('filters the inherited DOM attribute flood down to a readable table', () => {
+    const props = docgenFor(source, 'Button')!.props;
+
+    expect(Object.keys(props).length).toBeLessThan(20);
+    expect(props.disabled.description).toBe('Disables interaction.');
+  });
+
+  test('uses @description for the description and keeps other tags out of it', () => {
+    const docgen = docgenFor(source, 'Button')!;
+
+    expect(docgen.description).toBe('Semantic button for actions and navigation.');
+    expect(docgen.description).not.toContain('markdown');
+    expect(docgen.tags?.usage).toContain('markdown');
+  });
+});
+
+describe('description precedence', () => {
+  test('a JSDoc above an import documents the import, not the component', () => {
+    const docgen = docgenFor(
+      astro(
+        [
+          '/** Not the component description. */',
+          "import type { HTMLTag } from 'astro/types';",
+          'interface Props { a?: HTMLTag }',
+          'const { a } = Astro.props;'
+        ].join('\n')
+      )
+    );
+
+    expect(docgen?.description).toBe('');
+  });
+
+  test('falls back to the JSDoc on the Props declaration', () => {
+    const docgen = docgenFor(
+      astro(
+        [
+          '/** Public props for the widget. */',
+          'interface Props { a?: string }',
+          'const { a } = Astro.props;'
+        ].join('\n')
+      )
+    );
+
+    expect(docgen?.description).toBe('Public props for the widget.');
+  });
+});
+
+describe('components with nothing to extract still behave', () => {
+  test('no frontmatter yields no docgen at all', () => {
+    expect(docgenFor('<p>markup only</p>')).toBeNull();
+  });
+
+  test('no Props still yields the description, which is the point for slot-only components', () => {
+    const docgen = docgenFor(
+      astro(['/**', ' * Wraps its children.', ' */', 'const a = 1;'].join('\n'), '<slot />')
+    );
+
+    expect(docgen?.description).toBe('Wraps its children.');
+    expect(docgen?.props).toEqual({});
+  });
+
+  test('a type error does not stop extraction of the props that do resolve', () => {
+    const docgen = docgenFor(
+      astro(
+        [
+          "import { missing } from './does-not-exist.ts';",
+          'interface Props {',
+          '  /** Still readable. */',
+          '  title?: string;',
+          '}',
+          'const { title } = Astro.props;'
+        ].join('\n')
+      )
+    );
+
+    expect(docgen?.props.title.description).toBe('Still readable.');
+  });
+});

--- a/packages/@storybook-astro/framework/src/docgen/extract.ts
+++ b/packages/@storybook-astro/framework/src/docgen/extract.ts
@@ -20,6 +20,11 @@ const INTERFACE_EXTENDS_NON_OBJECT = 2312;
 /** Guards against `Tag extends HTMLTag = HTMLTag` expanding to every element. */
 const MAX_UNION_CONSTITUENTS = 8;
 
+// ts.TypeFlags.Undefined / ts.TypeFlags.Null, inlined so this module keeps
+// importing TypeScript as a type only.
+const TS_UNDEFINED_FLAG = 32768;
+const TS_NULL_FLAG = 65536;
+
 /**
  * Extracts docgen for one `.astro` component.
  *
@@ -236,10 +241,13 @@ function describeType(
     return { name };
   }
 
-  const literals = type.types.filter((constituent) => constituent.isLiteral());
+  // An optional prop's type includes `undefined` under `strict`, which would
+  // otherwise disqualify every optional literal union — i.e. most of them —
+  // from becoming a select control.
+  const meaningful = type.types.filter((constituent) => !isNullish(constituent));
+  const literals = meaningful.filter((constituent) => constituent.isLiteral());
 
-  // A union of literals drives a select control, so surface the options.
-  if (literals.length === 0 || literals.length !== type.types.length) {
+  if (literals.length === 0 || literals.length !== meaningful.length) {
     return { name, raw };
   }
 
@@ -248,6 +256,13 @@ function describeType(
     raw: name,
     value: literals.map((constituent) => ({ value: checker.typeToString(constituent) }))
   };
+}
+
+/** `undefined` and `null` say nothing about which control a prop should get. */
+function isNullish(type: ts.Type): boolean {
+  return (
+    (type.flags & (TS_UNDEFINED_FLAG | TS_NULL_FLAG)) !== 0
+  );
 }
 
 function declarationRefOf(

--- a/packages/@storybook-astro/framework/src/docgen/extract.ts
+++ b/packages/@storybook-astro/framework/src/docgen/extract.ts
@@ -1,0 +1,313 @@
+import { basename } from 'node:path';
+import type ts from 'typescript';
+import { readAstroPropsBinding } from './defaultValues.ts';
+import { readComponentDescription } from './description.ts';
+import { createDefaultPropFilter } from './propFilter.ts';
+import { rewriteInterfaceToTypeAlias, unionConstituentsOfFirstDefault } from './propsDeclaration.ts';
+import type {
+  AstroDocgenInfo,
+  AstroDocgenOptions,
+  AstroDocgenProp,
+  AstroDocgenPropType,
+  DeclarationRef
+} from './types.ts';
+import type { AstroTsProject } from './tsProject.ts';
+import { appendPropsProbes, buildVirtualSource, virtualFilePathFor } from './virtualFile.ts';
+
+/** "An interface can only extend an object type … with statically known members." */
+const INTERFACE_EXTENDS_NON_OBJECT = 2312;
+
+/** Guards against `Tag extends HTMLTag = HTMLTag` expanding to every element. */
+const MAX_UNION_CONSTITUENTS = 8;
+
+/**
+ * Extracts docgen for one `.astro` component.
+ *
+ * Returns `null` only when there is nothing to look at — no frontmatter. A
+ * component with frontmatter but no `Props` still yields its description with
+ * an empty props table, because that description is most of the value for a
+ * slot-only component (docs/specs/docgen.md#failure-modes).
+ */
+export function extractAstroDocgen(
+  typescript: typeof ts,
+  project: AstroTsProject,
+  astroFilePath: string,
+  astroSource: string,
+  options: AstroDocgenOptions = {}
+): AstroDocgenInfo | null {
+  const virtualSource = buildVirtualSource(astroSource);
+
+  if (virtualSource === null) {
+    return null;
+  }
+
+  const displayName = basename(astroFilePath).replace(/\.astro$/, '');
+
+  // Parsed without a checker first: this is cheap, and it tells us whether
+  // there is a `Props` to instantiate before we involve the program at all.
+  const parsed = typescript.createSourceFile(
+    virtualFilePathFor(astroFilePath),
+    virtualSource,
+    typescript.ScriptTarget.Latest,
+    true
+  );
+
+  const description = readComponentDescription(typescript, parsed);
+  const propsDeclaration = findPropsDeclaration(typescript, parsed);
+
+  if (!propsDeclaration) {
+    return { displayName, description: description.text, tags: description.tags, props: {} };
+  }
+
+  const binding = readAstroPropsBinding(typescript, parsed);
+  const properties = resolveProps(typescript, project, astroFilePath, virtualSource, parsed);
+
+  const propFilter = options.propFilter ?? createDefaultPropFilter(binding.destructured);
+  const props: Record<string, AstroDocgenProp> = {};
+
+  for (const { symbol, checker } of properties) {
+    const prop = buildProp(typescript, checker, symbol, binding.defaults);
+
+    if (propFilter(prop, { name: displayName })) {
+      props[prop.name] = prop;
+    }
+  }
+
+  return { displayName, description: description.text, tags: description.tags, props };
+}
+
+/**
+ * Instantiates `Props` and hands back its properties, merged across union
+ * constituents. Rewrites the declaration and retries once when TypeScript
+ * rejects the heritage clause (docs/specs/docgen.md#heritage-rewrite).
+ */
+function resolveProps(
+  typescript: typeof ts,
+  project: AstroTsProject,
+  astroFilePath: string,
+  virtualSource: string,
+  parsed: ts.SourceFile
+): Array<{ symbol: ts.Symbol; checker: ts.TypeChecker }> {
+  const virtualPath = virtualFilePathFor(astroFilePath);
+  const constituents = unionConstituentsOfFirstDefault(typescript, parsed, MAX_UNION_CONSTITUENTS);
+  // The default instantiation goes first so props common to every constituent
+  // keep their full type — `as` should read `"button" | "a"`, not whichever
+  // constituent happened to be probed first. The per-constituent probes then
+  // only contribute the props the collapsed union dropped.
+  const typeArgumentSets =
+    constituents.length > 1 ? [undefined, ...constituents] : [undefined];
+
+  const read = (source: string) => {
+    const probes = appendPropsProbes(source, typeArgumentSets);
+
+    project.setVirtualFile(virtualPath, probes.source);
+
+    const program = project.getProgram();
+    const sourceFile = program?.getSourceFile(virtualPath);
+
+    if (!program || !sourceFile) {
+      return { properties: [], sourceFile: undefined, program: undefined, probes };
+    }
+
+    const checker = program.getTypeChecker();
+    const seen = new Map<string, ts.Symbol>();
+
+    for (const name of probes.names) {
+      for (const symbol of propertiesOfProbe(typescript, checker, sourceFile, name)) {
+        // First constituent to declare a prop wins; later ones only add.
+        if (!seen.has(symbol.getName())) {
+          seen.set(symbol.getName(), symbol);
+        }
+      }
+    }
+
+    return {
+      properties: [...seen.values()].map((symbol) => ({ symbol, checker })),
+      sourceFile,
+      program,
+      probes
+    };
+  };
+
+  const first = read(virtualSource);
+
+  if (!first.sourceFile || !first.program) {
+    return first.properties;
+  }
+
+  // The rewrite is gated on the diagnostic rather than on an empty result:
+  // a rejected heritage clause still leaves the members written inline, so
+  // #110's Button comes back with `disabled` alone and looks like a success.
+  const rejectedHeritage = first.program
+    .getSemanticDiagnostics(first.sourceFile)
+    .some((diagnostic) => diagnostic.code === INTERFACE_EXTENDS_NON_OBJECT);
+
+  if (!rejectedHeritage) {
+    return first.properties;
+  }
+
+  const rewritten = rewriteInterfaceToTypeAlias(typescript, virtualSource);
+
+  if (rewritten === null) {
+    return first.properties;
+  }
+
+  const retried = read(rewritten);
+
+  // Only take the rewrite when it actually recovered something.
+  return retried.properties.length > first.properties.length
+    ? retried.properties
+    : first.properties;
+}
+
+function propertiesOfProbe(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  probeName: string
+): ts.Symbol[] {
+  for (const statement of sourceFile.statements) {
+    if (!typescript.isVariableStatement(statement)) {
+      continue;
+    }
+
+    for (const declaration of statement.declarationList.declarations) {
+      if (typescript.isIdentifier(declaration.name) && declaration.name.text === probeName) {
+        return checker.getTypeAtLocation(declaration.name).getApparentProperties();
+      }
+    }
+  }
+
+  return [];
+}
+
+function findPropsDeclaration(
+  typescript: typeof ts,
+  sourceFile: ts.SourceFile
+): ts.InterfaceDeclaration | ts.TypeAliasDeclaration | undefined {
+  return sourceFile.statements.find(
+    (statement): statement is ts.InterfaceDeclaration | ts.TypeAliasDeclaration =>
+      (typescript.isInterfaceDeclaration(statement) ||
+        typescript.isTypeAliasDeclaration(statement)) &&
+      statement.name.text === 'Props'
+  );
+}
+
+function buildProp(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  symbol: ts.Symbol,
+  defaults: ReadonlyMap<string, string | number | boolean | null>
+): AstroDocgenProp {
+  const name = symbol.getName();
+  const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+  const type = declaration
+    ? checker.getTypeOfSymbolAtLocation(symbol, declaration)
+    : checker.getDeclaredTypeOfSymbol(symbol);
+
+  const hasDefault = defaults.has(name);
+  const optional = (symbol.flags & typescript.SymbolFlags.Optional) !== 0;
+  const required = !optional && !hasDefault;
+
+  return {
+    name,
+    required,
+    type: describeType(checker, type, required),
+    description: typescript.displayPartsToString(symbol.getDocumentationComment(checker)).trim(),
+    defaultValue: hasDefault ? { value: defaults.get(name) ?? null } : null,
+    parent: declarationRefOf(typescript, declaration),
+    declarations: (symbol.declarations ?? [])
+      .map((each) => declarationRefOf(typescript, each))
+      .filter((each): each is DeclarationRef => each !== undefined),
+    tags: jsDocTagsOf(typescript, symbol, checker)
+  };
+}
+
+function describeType(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  required: boolean
+): AstroDocgenPropType {
+  const raw = checker.typeToString(type);
+  // Optional props read as `string | undefined`; the `?` already says that.
+  const name = required ? raw : raw.replace(/\s*\|\s*undefined$/, '');
+
+  if (!type.isUnion()) {
+    return { name };
+  }
+
+  const literals = type.types.filter((constituent) => constituent.isLiteral());
+
+  // A union of literals drives a select control, so surface the options.
+  if (literals.length === 0 || literals.length !== type.types.length) {
+    return { name, raw };
+  }
+
+  return {
+    name: 'enum',
+    raw: name,
+    value: literals.map((constituent) => ({ value: checker.typeToString(constituent) }))
+  };
+}
+
+function declarationRefOf(
+  typescript: typeof ts,
+  declaration: ts.Declaration | undefined
+): DeclarationRef | undefined {
+  if (!declaration) {
+    return undefined;
+  }
+
+  const fileName = declaration.getSourceFile().fileName;
+  const owner = declaration.parent;
+
+  // Props coming from `VariantProps<typeof x>` are property assignments in an
+  // object literal and have no declaring interface at all, so fall back to the
+  // nearest named ancestor rather than reporting nothing — the prior art's
+  // undefined `parent` is what makes the usual node_modules filter drop them.
+  if (
+    owner &&
+    (typescript.isInterfaceDeclaration(owner) || typescript.isTypeAliasDeclaration(owner))
+  ) {
+    return { fileName, name: owner.name.text };
+  }
+
+  return { fileName, name: nearestNamedAncestor(typescript, declaration) };
+}
+
+function nearestNamedAncestor(typescript: typeof ts, declaration: ts.Declaration): string {
+  let node: ts.Node | undefined = declaration.parent;
+
+  while (node) {
+    if (
+      (typescript.isVariableDeclaration(node) ||
+        typescript.isInterfaceDeclaration(node) ||
+        typescript.isTypeAliasDeclaration(node) ||
+        typescript.isClassDeclaration(node)) &&
+      node.name &&
+      typescript.isIdentifier(node.name)
+    ) {
+      return node.name.text;
+    }
+
+    node = node.parent;
+  }
+
+  return '';
+}
+
+function jsDocTagsOf(
+  typescript: typeof ts,
+  symbol: ts.Symbol,
+  checker: ts.TypeChecker
+): Record<string, string> | undefined {
+  const tags = symbol.getJsDocTags(checker);
+
+  if (tags.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    tags.map((tag) => [tag.name, typescript.displayPartsToString(tag.text ?? []).trim()])
+  );
+}

--- a/packages/@storybook-astro/framework/src/docgen/index.test.ts
+++ b/packages/@storybook-astro/framework/src/docgen/index.test.ts
@@ -1,0 +1,160 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, expect, test } from 'vitest';
+import { createAstroDocgen } from './index.ts';
+
+// Inside the package so `astro/types` resolves by walking up, matching the
+// existing .vitest-*-fixture-* convention.
+const packageDir = fileURLToPath(new URL('../..', import.meta.url));
+const projectRoot = mkdtempSync(join(packageDir, '.vitest-docgen-fixture-'));
+
+afterAll(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+const CARD = [
+  '---',
+  '/** A card. */',
+  'interface Props {',
+  '  /** Heading. */',
+  '  title?: string;',
+  '}',
+  "const { title = 'Hello' } = Astro.props;",
+  '---',
+  '<h1>{title}</h1>'
+].join('\n');
+
+function createDocgen(overrides: Partial<Parameters<typeof createAstroDocgen>[0]> = {}) {
+  const warnings: string[] = [];
+  const docgen = createAstroDocgen({
+    projectRoot,
+    warn: (message) => warnings.push(message),
+    ...overrides
+  });
+
+  return { docgen, warnings };
+}
+
+describe('extraction through the runtime', () => {
+  test('reads a component end to end', async () => {
+    const { docgen } = createDocgen();
+    const result = await docgen.extract(join(projectRoot, 'Card.astro'), CARD);
+
+    expect(result?.displayName).toBe('Card');
+    expect(result?.description).toBe('A card.');
+    expect(result?.props.title.defaultValue).toEqual({ value: 'Hello' });
+
+    docgen.dispose();
+  });
+
+  test('a component with no frontmatter yields nothing', async () => {
+    const { docgen } = createDocgen();
+
+    expect(await docgen.extract(join(projectRoot, 'Plain.astro'), '<p>hi</p>')).toBeNull();
+
+    docgen.dispose();
+  });
+});
+
+describe('results are cached by content', () => {
+  test('the same source is not re-extracted', async () => {
+    const { docgen } = createDocgen();
+    const path = join(projectRoot, 'Cached.astro');
+
+    const first = await docgen.extract(path, CARD);
+    const second = await docgen.extract(path, CARD);
+
+    expect(second).toBe(first);
+
+    docgen.dispose();
+  });
+
+  test('edited source is re-extracted', async () => {
+    const { docgen } = createDocgen();
+    const path = join(projectRoot, 'Edited.astro');
+
+    await docgen.extract(path, CARD);
+    const edited = await docgen.extract(path, CARD.replace('Heading.', 'Changed.'));
+
+    expect(edited?.props.title.description).toBe('Changed.');
+
+    docgen.dispose();
+  });
+
+  test('a component with nothing to extract is not retried on every tick', async () => {
+    const { docgen } = createDocgen();
+    const path = join(projectRoot, 'Empty.astro');
+
+    const first = await docgen.extract(path, '<p>hi</p>');
+    const second = await docgen.extract(path, '<p>hi</p>');
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+
+    docgen.dispose();
+  });
+});
+
+describe('the project tsconfig is honoured', () => {
+  test('path aliases declared by the project resolve', async () => {
+    writeFileSync(
+      join(projectRoot, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: { '@shared/*': ['./shared/*'] },
+          moduleResolution: 'Bundler',
+          module: 'ESNext',
+          target: 'ESNext'
+        }
+      })
+    );
+    writeFileSync(
+      join(projectRoot, 'shared-types.ts'),
+      'export interface Shared {\n  /** Via a path alias. */\n  aliased?: string;\n}\n'
+    );
+
+    const { docgen } = createDocgen();
+    const source = [
+      '---',
+      "import type { Shared } from '@shared/../shared-types.ts';",
+      'interface Props extends Shared {}',
+      'const { aliased } = Astro.props;',
+      '---',
+      '<div />'
+    ].join('\n');
+
+    const result = await docgen.extract(join(projectRoot, 'Aliased.astro'), source);
+
+    expect(result?.props.aliased?.description).toBe('Via a path alias.');
+
+    docgen.dispose();
+  });
+});
+
+describe('failures never take rendering down', () => {
+  test('an unreadable tsconfig warns once and still extracts', async () => {
+    const badRoot = mkdtempSync(join(packageDir, '.vitest-docgen-fixture-'));
+
+    writeFileSync(
+      join(badRoot, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { target: 'not-a-real-target' } })
+    );
+
+    const { docgen, warnings } = createDocgen({ projectRoot: badRoot });
+    const result = await docgen.extract(join(badRoot, 'Card.astro'), CARD);
+
+    expect(result?.props.title).toBeDefined();
+    expect(warnings.some((message) => message.includes('tsconfig.json'))).toBe(true);
+
+    docgen.dispose();
+    rmSync(badRoot, { recursive: true, force: true });
+  });
+
+  test('warming up before any extraction is safe', async () => {
+    const { docgen } = createDocgen();
+
+    await expect(docgen.warmUp()).resolves.toBeUndefined();
+
+    docgen.dispose();
+  });
+});

--- a/packages/@storybook-astro/framework/src/docgen/index.test.ts
+++ b/packages/@storybook-astro/framework/src/docgen/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterAll, describe, expect, test } from 'vitest';
@@ -154,6 +154,107 @@ describe('failures never take rendering down', () => {
     const { docgen } = createDocgen();
 
     await expect(docgen.warmUp()).resolves.toBeUndefined();
+
+    docgen.dispose();
+  });
+});
+
+describe('what reaches the browser bundle', () => {
+  test('declaring paths are project-relative, not absolute machine paths', async () => {
+    writeFileSync(
+      join(projectRoot, 'trim-types.ts'),
+      'export interface Trimmed {\n  /** Declared elsewhere. */\n  elsewhere?: string;\n}\n'
+    );
+
+    const { docgen } = createDocgen();
+    const source = [
+      '---',
+      "import type { Trimmed } from './trim-types.ts';",
+      'interface Props extends Trimmed {}',
+      'const { elsewhere } = Astro.props;',
+      '---',
+      '<div />'
+    ].join('\n');
+
+    const result = await docgen.extract(join(projectRoot, 'Trim.astro'), source);
+    const parentFile = result?.props.elsewhere?.parent?.fileName ?? '';
+
+    // A published static Storybook is public; whoever built it shouldn't be
+    // shipping their home directory in it.
+    expect(parentFile).toBe('trim-types.ts');
+    expect(JSON.stringify(result)).not.toContain(projectRoot);
+
+    docgen.dispose();
+  });
+
+  test('a type from a sibling package stays relative rather than absolute', async () => {
+    // The monorepo case: the app root is integration/astroN while the component
+    // and its types live in packages/components, so the declaring file is above
+    // the root. Climbing out with `../` beats shipping a home directory.
+    const nestedRoot = join(projectRoot, 'app');
+
+    mkdirSync(nestedRoot, { recursive: true });
+    writeFileSync(
+      join(projectRoot, 'outside-types.ts'),
+      'export interface Outside {\n  /** Declared above the app root. */\n  outer?: string;\n}\n'
+    );
+
+    const { docgen } = createDocgen({ projectRoot: nestedRoot });
+    const source = [
+      '---',
+      "import type { Outside } from '../outside-types.ts';",
+      'interface Props extends Outside {}',
+      'const { outer } = Astro.props;',
+      '---',
+      '<div />'
+    ].join('\n');
+
+    const result = await docgen.extract(join(nestedRoot, 'Nested.astro'), source);
+
+    expect(result?.props.outer?.parent?.fileName).toBe('../outside-types.ts');
+    expect(JSON.stringify(result)).not.toContain(packageDir);
+
+    docgen.dispose();
+  });
+
+  test('server-only declaration data is not shipped', async () => {
+    const { docgen } = createDocgen();
+    const result = await docgen.extract(join(projectRoot, 'NoDecls.astro'), CARD);
+
+    expect(result?.props.title).toBeDefined();
+    expect(JSON.stringify(result)).not.toContain('declarations');
+
+    docgen.dispose();
+  });
+
+  test('an optional literal union still becomes a select control under strict', async () => {
+    writeFileSync(
+      join(projectRoot, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { strict: true, moduleResolution: 'Bundler' } })
+    );
+
+    const { docgen } = createDocgen();
+    const source = [
+      '---',
+      "type Tone = 'solid' | 'outline';",
+      'interface Props {',
+      '  /** Visual treatment. */',
+      '  tone?: Tone;',
+      '}',
+      "const { tone = 'solid' } = Astro.props;",
+      '---',
+      '<div />'
+    ].join('\n');
+
+    const result = await docgen.extract(join(projectRoot, 'Strict.astro'), source);
+
+    // Under `strict` an optional prop's type includes `undefined`, which would
+    // otherwise disqualify most real unions from becoming a select.
+    expect(result?.props.tone.type.name).toBe('enum');
+    expect(result?.props.tone.type.value?.map((each) => each.value)).toEqual([
+      '"solid"',
+      '"outline"'
+    ]);
 
     docgen.dispose();
   });

--- a/packages/@storybook-astro/framework/src/docgen/index.ts
+++ b/packages/@storybook-astro/framework/src/docgen/index.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { dirname } from 'node:path';
+import { dirname, relative } from 'node:path';
 import { getTsconfig } from 'get-tsconfig';
 import type ts from 'typescript';
 import { extractAstroDocgen } from './extract.ts';
@@ -82,13 +82,15 @@ export function createAstroDocgen(setup: AstroDocgenSetup): AstroDocgen {
       let docgen: AstroDocgenInfo | null = null;
 
       try {
-        docgen = extractAstroDocgen(
+        const extracted = extractAstroDocgen(
           active.typescript,
           active.project,
           astroFilePath,
           astroSource,
           setup
         );
+
+        docgen = extracted && forPublishing(extracted, setup.projectRoot);
       } catch (error) {
         warn(`Could not read documentation from ${astroFilePath}: ${messageOf(error)}`);
       }
@@ -111,6 +113,46 @@ export function createAstroDocgen(setup: AstroDocgenSetup): AstroDocgen {
       session = undefined;
     }
   };
+}
+
+/**
+ * Strips what shouldn't ship to a browser.
+ *
+ * Docgen goes into the preview bundle, and a published static Storybook is
+ * public — so declaring-file paths get trimmed to project-relative rather than
+ * carrying whatever absolute path the machine that built it happened to use.
+ * `declarations` is dropped entirely: only the prop filter reads it, and that
+ * already ran server-side (docs/specs/docgen.md#prop-filtering).
+ */
+function forPublishing(docgen: AstroDocgenInfo, projectRoot: string): AstroDocgenInfo {
+  const props = Object.fromEntries(
+    Object.entries(docgen.props).map(([name, prop]) => {
+      const { declarations: _serverOnly, parent, ...rest } = prop;
+
+      return [
+        name,
+        parent ? { ...rest, parent: { ...parent, fileName: trim(parent.fileName, projectRoot) } } : rest
+      ];
+    })
+  );
+
+  return { ...docgen, props };
+}
+
+function trim(fileName: string, projectRoot: string): string {
+  // Dependency types are more recognisable by package than by path depth.
+  const installed = fileName.lastIndexOf('node_modules/');
+
+  if (installed !== -1) {
+    return fileName.slice(installed + 'node_modules/'.length);
+  }
+
+  const fromRoot = relative(projectRoot, fileName);
+
+  // Relative even when it climbs out of the app — in a monorepo the declaring
+  // file usually lives in a sibling package, and `../../packages/…` is worth a
+  // few extra segments to keep an absolute home directory out of a public build.
+  return fromRoot || fileName;
 }
 
 interface Session {

--- a/packages/@storybook-astro/framework/src/docgen/index.ts
+++ b/packages/@storybook-astro/framework/src/docgen/index.ts
@@ -1,0 +1,206 @@
+import { createHash } from 'node:crypto';
+import { dirname } from 'node:path';
+import { getTsconfig } from 'get-tsconfig';
+import type ts from 'typescript';
+import { extractAstroDocgen } from './extract.ts';
+import { createAstroTsProject, type AstroTsProject } from './tsProject.ts';
+import type { AstroDocgenInfo, AstroDocgenOptions } from './types.ts';
+
+export type { AstroDocgenInfo, AstroDocgenOptions, PropFilter } from './types.ts';
+
+/** TypeScript below this lacks `resolveModuleNameLiterals`, which we rely on. */
+const MINIMUM_TYPESCRIPT = 5;
+
+export interface AstroDocgen {
+  /**
+   * Loads TypeScript and warms the language service. Call without awaiting from
+   * `buildStart` so the one-time cost overlaps Storybook's own boot rather than
+   * landing on the first story request.
+   */
+  warmUp(): Promise<void>;
+  /** Docgen for one component, or `null` when there is nothing to extract. */
+  extract(astroFilePath: string, astroSource: string): Promise<AstroDocgenInfo | null>;
+  /** Called from Vite's watcher when a file the components depend on changes. */
+  invalidate(filePath: string): void;
+  dispose(): void;
+}
+
+export interface AstroDocgenSetup extends AstroDocgenOptions {
+  projectRoot: string;
+  /** Reports a problem once. Repeats are swallowed. */
+  warn?: (message: string) => void;
+}
+
+/**
+ * Owns the docgen runtime: the TypeScript import, the shared language service
+ * and the extraction cache.
+ *
+ * Everything here is best-effort. Docgen is a side channel — when it cannot
+ * run, components still render (docs/specs/docgen.md#failure-modes).
+ */
+export function createAstroDocgen(setup: AstroDocgenSetup): AstroDocgen {
+  const warned = new Set<string>();
+  const warn = (message: string) => {
+    if (warned.has(message)) {
+      return;
+    }
+
+    warned.add(message);
+    (setup.warn ?? console.warn)(`[storybook-astro] ${message}`);
+  };
+
+  const cache = new Map<string, AstroDocgenInfo | null>();
+  let session: Promise<Session | undefined> | undefined;
+
+  const ensureSession = () => (session ??= startSession(setup, warn));
+
+  return {
+    async warmUp() {
+      const active = await ensureSession();
+
+      // Building the program is what actually costs the ~0.9s; getting the
+      // service alone is nearly free and would just defer it.
+      active?.project.getProgram();
+    },
+
+    async extract(astroFilePath, astroSource) {
+      const active = await ensureSession();
+
+      if (!active) {
+        return null;
+      }
+
+      const key = fingerprint(astroFilePath, astroSource, active.optionsFingerprint);
+      const cached = cache.get(key);
+
+      // Negative results are cached too, so a component that legitimately has
+      // no props doesn't re-run a type check on every HMR tick.
+      if (cached !== undefined) {
+        return cached;
+      }
+
+      let docgen: AstroDocgenInfo | null = null;
+
+      try {
+        docgen = extractAstroDocgen(
+          active.typescript,
+          active.project,
+          astroFilePath,
+          astroSource,
+          setup
+        );
+      } catch (error) {
+        warn(`Could not read documentation from ${astroFilePath}: ${messageOf(error)}`);
+      }
+
+      cache.set(key, docgen);
+
+      return docgen;
+    },
+
+    invalidate(filePath) {
+      // A shared type moving invalidates every component that imported it, and
+      // the cache is keyed by component source — which hasn't changed.
+      cache.clear();
+      void session?.then((active) => active?.project.invalidate(filePath));
+    },
+
+    dispose() {
+      cache.clear();
+      void session?.then((active) => active?.project.dispose());
+      session = undefined;
+    }
+  };
+}
+
+interface Session {
+  typescript: typeof ts;
+  project: AstroTsProject;
+  optionsFingerprint: string;
+}
+
+async function startSession(
+  setup: AstroDocgenSetup,
+  warn: (message: string) => void
+): Promise<Session | undefined> {
+  let typescript: typeof ts;
+
+  try {
+    typescript = (await import('typescript')).default;
+  } catch {
+    warn('TypeScript is not installed, so component documentation cannot be extracted.');
+
+    return undefined;
+  }
+
+  if (Number.parseInt(typescript.versionMajorMinor, 10) < MINIMUM_TYPESCRIPT) {
+    warn(
+      `TypeScript ${typescript.version} is too old for documentation extraction; 5.0 or newer is required.`
+    );
+
+    return undefined;
+  }
+
+  const compilerOptions = readCompilerOptions(typescript, setup, warn);
+
+  return {
+    typescript,
+    project: createAstroTsProject(typescript, compilerOptions, setup.projectRoot),
+    optionsFingerprint: JSON.stringify(compilerOptions)
+  };
+}
+
+/**
+ * Compiler options from the project's own tsconfig, so path aliases and
+ * `moduleResolution` match how the component is actually built. `skipLibCheck`
+ * is forced on because we only ever ask about one file's types.
+ */
+function readCompilerOptions(
+  typescript: typeof ts,
+  setup: AstroDocgenSetup,
+  warn: (message: string) => void
+): ts.CompilerOptions {
+  const found = setup.tsconfigPath
+    ? getTsconfig(setup.tsconfigPath)
+    : getTsconfig(setup.projectRoot);
+
+  const fallback: ts.CompilerOptions = {
+    target: typescript.ScriptTarget.Latest,
+    module: typescript.ModuleKind.ESNext,
+    moduleResolution: typescript.ModuleResolutionKind.Bundler,
+    allowJs: true
+  };
+
+  if (!found) {
+    return { ...fallback, skipLibCheck: true, noEmit: true };
+  }
+
+  const { options, errors } = typescript.convertCompilerOptionsFromJson(
+    found.config.compilerOptions ?? {},
+    dirname(found.path)
+  );
+
+  if (errors.length > 0) {
+    warn(
+      `Could not read ${found.path}, falling back to defaults: ${typescript.flattenDiagnosticMessageText(errors[0].messageText, ' ')}`
+    );
+
+    return { ...fallback, skipLibCheck: true, noEmit: true };
+  }
+
+  return { ...fallback, ...options, skipLibCheck: true, noEmit: true };
+}
+
+function fingerprint(filePath: string, source: string, optionsFingerprint: string): string {
+  return createHash('sha256')
+    .update(filePath)
+    .update('\0')
+    .update(source)
+    .update('\0')
+    .update(optionsFingerprint)
+    .digest('hex');
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/@storybook-astro/framework/src/docgen/propFilter.ts
+++ b/packages/@storybook-astro/framework/src/docgen/propFilter.ts
@@ -1,0 +1,43 @@
+import type { AstroDocgenProp, PropFilter } from './types.ts';
+
+const NODE_MODULES = /[/\\]node_modules[/\\]/;
+
+/**
+ * Keeps the props a reader came to see and drops inherited DOM noise.
+ *
+ * A `Props` extending `HTMLAttributes` or `Polymorphic` resolves to around 200
+ * properties, 191 of them from `astro/astro-jsx.d.ts`. Unfiltered, every Astro
+ * props table is unusable (docs/specs/docgen.md#prop-filtering).
+ *
+ * Two rules that the conventional `react-docgen-typescript` recipe gets wrong
+ * for Astro:
+ *
+ * - A prop survives if *any* declaration sits outside `node_modules`. A
+ *   locally redeclared `disabled` also has a declaration in `astro/types`, so
+ *   dropping on the first `node_modules` hit silently deletes it.
+ * - A prop the component destructures from `Astro.props` always survives,
+ *   wherever its type was declared. That destructuring is the author's own
+ *   statement of the public surface, and it is what recovers `as`, `href` and
+ *   `class` on a polymorphic component whose types all live in `node_modules`.
+ */
+export function createDefaultPropFilter(destructuredProps: ReadonlySet<string>): PropFilter {
+  return (prop) => {
+    // Astro takes content through <slot>, so a `children` prop is inherited
+    // noise from a framework type unless someone documented it.
+    if (prop.name === 'children' && !prop.description) {
+      return false;
+    }
+
+    return destructuredProps.has(prop.name) || isDeclaredInProject(prop);
+  };
+}
+
+function isDeclaredInProject(prop: AstroDocgenProp): boolean {
+  const declarations = prop.declarations ?? [];
+
+  // No declaration information is not evidence of third-party origin.
+  return (
+    declarations.length === 0 ||
+    declarations.some((declaration) => !NODE_MODULES.test(declaration.fileName))
+  );
+}

--- a/packages/@storybook-astro/framework/src/docgen/propsDeclaration.ts
+++ b/packages/@storybook-astro/framework/src/docgen/propsDeclaration.ts
@@ -1,0 +1,101 @@
+import type ts from 'typescript';
+
+/**
+ * Rewrites `interface Props … extends A, B { … }` as `type Props … = A & B & { … }`.
+ *
+ * Astro's polymorphic idiom resolves to a deferred indexed access on a type
+ * parameter, and an interface may only extend types with statically known
+ * members. TypeScript reports 2312 and then drops the *entire* base type, so
+ * the component from #110 yields three props instead of 199. An intersection
+ * has no such restriction (docs/specs/docgen.md#heritage-rewrite).
+ *
+ * Returns `null` when there is nothing to rewrite. This is a fallback path, so
+ * unlike the rest of the virtual file it does not preserve byte offsets — the
+ * extractor reads types through the checker, not positions.
+ */
+export function rewriteInterfaceToTypeAlias(
+  typescript: typeof ts,
+  virtualSource: string
+): string | null {
+  const sourceFile = typescript.createSourceFile(
+    'props-rewrite.ts',
+    virtualSource,
+    typescript.ScriptTarget.Latest,
+    true
+  );
+
+  const declaration = sourceFile.statements.find(
+    (statement): statement is ts.InterfaceDeclaration =>
+      typescript.isInterfaceDeclaration(statement) &&
+      statement.name.text === 'Props' &&
+      (statement.heritageClauses?.length ?? 0) > 0
+  );
+
+  if (!declaration) {
+    return null;
+  }
+
+  const openBrace = declaration
+    .getChildren(sourceFile)
+    .find((child) => child.kind === typescript.SyntaxKind.OpenBraceToken);
+
+  if (!openBrace) {
+    return null;
+  }
+
+  const typeParameters = declaration.typeParameters
+    ? `<${declaration.typeParameters.map((each) => each.getText(sourceFile)).join(', ')}>`
+    : '';
+
+  const bases = (declaration.heritageClauses ?? [])
+    .flatMap((clause) => clause.types)
+    .map((each) => each.getText(sourceFile));
+
+  const members = virtualSource.slice(openBrace.getStart(sourceFile), declaration.end);
+  const alias = `type Props${typeParameters} = ${[...bases, members].join(' & ')};`;
+
+  return (
+    virtualSource.slice(0, declaration.getStart(sourceFile)) +
+    alias +
+    virtualSource.slice(declaration.end)
+  );
+}
+
+/**
+ * String-literal constituents of the first type parameter's default.
+ *
+ * `keyof (A | B)` is the intersection of keys, so instantiating a polymorphic
+ * `Props<'a' | 'button'>` in one go loses `href` and `type` — each exists on
+ * only one constituent. Returning them lets the extractor instantiate per
+ * constituent and merge. Returns an empty array when there is nothing to split,
+ * or when the union is wider than `maxConstituents` — an unbounded default like
+ * `Tag extends HTMLTag = HTMLTag` would otherwise expand to every element.
+ */
+export function unionConstituentsOfFirstDefault(
+  typescript: typeof ts,
+  sourceFile: ts.SourceFile,
+  maxConstituents: number
+): string[] {
+  const declaration = sourceFile.statements.find(
+    (statement): statement is ts.InterfaceDeclaration | ts.TypeAliasDeclaration =>
+      (typescript.isInterfaceDeclaration(statement) ||
+        typescript.isTypeAliasDeclaration(statement)) &&
+      statement.name.text === 'Props'
+  );
+
+  const defaultType = declaration?.typeParameters?.[0]?.default;
+
+  if (!defaultType || !typescript.isUnionTypeNode(defaultType)) {
+    return [];
+  }
+
+  const constituents = defaultType.types.filter(
+    (each) => typescript.isLiteralTypeNode(each) && typescript.isStringLiteral(each.literal)
+  );
+
+  if (constituents.length !== defaultType.types.length || constituents.length > maxConstituents) {
+    return [];
+  }
+
+  return constituents.map((each) => each.getText(sourceFile));
+}

--- a/packages/@storybook-astro/framework/src/docgen/tsProject.test.ts
+++ b/packages/@storybook-astro/framework/src/docgen/tsProject.test.ts
@@ -1,0 +1,186 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import typescript from 'typescript';
+import { afterAll, describe, expect, test } from 'vitest';
+import { createAstroTsProject } from './tsProject.ts';
+
+const projectRoot = mkdtempSync(join(tmpdir(), 'astro-docgen-project-'));
+
+afterAll(() => rmSync(projectRoot, { recursive: true, force: true }));
+
+const compilerOptions: typescript.CompilerOptions = {
+  target: typescript.ScriptTarget.Latest,
+  module: typescript.ModuleKind.ESNext,
+  moduleResolution: typescript.ModuleResolutionKind.Bundler,
+  skipLibCheck: true
+};
+
+function createProject() {
+  return createAstroTsProject(typescript, compilerOptions, projectRoot);
+}
+
+/** Names of the properties on `Props` as the checker sees them. */
+function propNamesOf(program: typescript.Program, filePath: string): string[] {
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(filePath);
+
+  for (const statement of sourceFile?.statements ?? []) {
+    if (typescript.isInterfaceDeclaration(statement) && statement.name.text === 'Props') {
+      const symbol = checker.getSymbolAtLocation(statement.name);
+
+      return checker
+        .getDeclaredTypeOfSymbol(symbol!)
+        .getApparentProperties()
+        .map((property) => property.getName());
+    }
+  }
+
+  return [];
+}
+
+describe('a component resolves imports from its own folder', () => {
+  test('a relative type import is a real type, not a silently empty error type', () => {
+    writeFileSync(
+      join(projectRoot, 'variants.ts'),
+      'export interface Variants { tone?: string; size?: number }\n'
+    );
+
+    const project = createProject();
+    const componentPath = join(projectRoot, 'Sibling.astro.ts');
+
+    project.setVirtualFile(
+      componentPath,
+      [
+        "import type { Variants } from './variants.ts';",
+        'interface Props extends Variants { title?: string }'
+      ].join('\n')
+    );
+
+    expect(propNamesOf(project.getProgram()!, componentPath).sort()).toEqual([
+      'size',
+      'title',
+      'tone'
+    ]);
+
+    project.dispose();
+  });
+});
+
+describe('.astro imports resolve', () => {
+  test('to a registered sibling component rather than failing to resolve', () => {
+    const project = createProject();
+    const parentPath = join(projectRoot, 'Parent.astro.ts');
+    const childPath = join(projectRoot, 'Child.astro.ts');
+
+    project.setVirtualFile(childPath, 'interface Props { label?: string }\nexport {};\n');
+    project.setVirtualFile(
+      parentPath,
+      ["import Child from './Child.astro';", 'const used = Child;', 'export { used };'].join('\n')
+    );
+
+    const program = project.getProgram()!;
+    const unresolved = program
+      .getSemanticDiagnostics(program.getSourceFile(parentPath))
+      .filter((diagnostic) => diagnostic.code === 2307);
+
+    expect(unresolved).toHaveLength(0);
+
+    project.dispose();
+  });
+
+  test('to the ambient shim when the component is not registered', () => {
+    const project = createProject();
+    const parentPath = join(projectRoot, 'Lonely.astro.ts');
+
+    project.setVirtualFile(
+      parentPath,
+      ["import Missing from './NotRegistered.astro';", 'export { Missing };'].join('\n')
+    );
+
+    const program = project.getProgram()!;
+    const unresolved = program
+      .getSemanticDiagnostics(program.getSourceFile(parentPath))
+      .filter((diagnostic) => diagnostic.code === 2307);
+
+    expect(unresolved).toHaveLength(0);
+
+    project.dispose();
+  });
+});
+
+describe('Astro is in scope as a value', () => {
+  test('so `Astro.props as Props` does not take the frontmatter down with it', () => {
+    const project = createProject();
+    const componentPath = join(projectRoot, 'Cast.astro.ts');
+
+    project.setVirtualFile(
+      componentPath,
+      [
+        'interface Props { title?: string }',
+        'const { title } = Astro.props as Props;',
+        'export { title };'
+      ].join('\n')
+    );
+
+    const program = project.getProgram()!;
+    // 2708 is "cannot use namespace 'Astro' as a value".
+    const astroAsValue = program
+      .getSemanticDiagnostics(program.getSourceFile(componentPath))
+      .filter((diagnostic) => diagnostic.code === 2708);
+
+    expect(astroAsValue).toHaveLength(0);
+
+    project.dispose();
+  });
+});
+
+describe('edits are picked up', () => {
+  test('replacing a virtual file changes what the checker reports', () => {
+    const project = createProject();
+    const componentPath = join(projectRoot, 'Edited.astro.ts');
+
+    project.setVirtualFile(componentPath, 'interface Props { before?: string }');
+    expect(propNamesOf(project.getProgram()!, componentPath)).toEqual(['before']);
+
+    project.setVirtualFile(componentPath, 'interface Props { after?: number }');
+    expect(propNamesOf(project.getProgram()!, componentPath)).toEqual(['after']);
+
+    project.dispose();
+  });
+});
+
+describe('the service is shared, not rebuilt per component', () => {
+  test('later components cost a fraction of the first', () => {
+    const project = createProject();
+    const paths: string[] = [];
+
+    for (let index = 0; index < 6; index += 1) {
+      const componentPath = join(projectRoot, `Perf${index}.astro.ts`);
+
+      paths.push(componentPath);
+      project.setVirtualFile(
+        componentPath,
+        `interface Props { label${index}?: string }\nexport {};\n`
+      );
+    }
+
+    const timeOne = (componentPath: string) => {
+      const started = performance.now();
+
+      propNamesOf(project.getProgram()!, componentPath);
+
+      return performance.now() - started;
+    };
+
+    const first = timeOne(paths[0]);
+    const rest = paths.slice(1).map(timeOne);
+    const slowestRest = Math.max(...rest);
+
+    // The point of the shared service: warm-up is paid once. A program per
+    // file would make every one of these cost roughly the same as the first.
+    expect(slowestRest).toBeLessThan(Math.max(first / 4, 25));
+
+    project.dispose();
+  });
+});

--- a/packages/@storybook-astro/framework/src/docgen/tsProject.ts
+++ b/packages/@storybook-astro/framework/src/docgen/tsProject.ts
@@ -1,0 +1,201 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import type ts from 'typescript';
+
+/**
+ * One long-lived TypeScript language service shared by every component.
+ *
+ * Creating a program per `.astro` file re-parses and re-checks the whole
+ * transitive graph each time — measured at 190-711ms per component against
+ * `astro/types`, versus 0-1.4ms once a language service is warm. The legacy
+ * delivery path runs inside a Vite `transform` on the dev server's critical
+ * path, so that difference is the whole feature's viability
+ * (docs/specs/docgen.md#design-decisions, Decision 3).
+ *
+ * Exactly one of these should exist per process: two services with different
+ * compiler options land in different document-registry buckets and pay for
+ * lib.d.ts twice.
+ */
+export interface AstroTsProject {
+  /** Registers or replaces a component's virtual file and invalidates it. */
+  setVirtualFile(filePath: string, contents: string): void;
+  getProgram(): ts.Program | undefined;
+  /** Marks an on-disk file changed, e.g. from Vite's watcher. */
+  invalidate(filePath: string): void;
+  dispose(): void;
+}
+
+/** Ambient declarations nothing imports, so they have to be roots. */
+const SHIM_FILE_NAME = '__storybook-astro-docgen.d.ts';
+
+/**
+ * Astro's own `client.d.ts` declares `astro:assets` and `*.svg` but not
+ * `*.astro`, so without this every `.astro` import in frontmatter is an
+ * unresolved module that silently degrades to `any`. `Astro` needs to be a
+ * value too — `Astro.props as Props` is otherwise "cannot use namespace as a
+ * value", which would take the whole frontmatter's types down with it.
+ */
+const SHIM_SOURCE = [
+  "declare module '*.astro' {",
+  '  const component: (props: Record<string, unknown>) => unknown;',
+  '  export default component;',
+  '}',
+  'declare const Astro: any;',
+  ''
+].join('\n');
+
+export function createAstroTsProject(
+  typescript: typeof ts,
+  compilerOptions: ts.CompilerOptions,
+  projectRoot: string
+): AstroTsProject {
+  const virtualFiles = new Map<string, string>();
+  const versions = new Map<string, number>();
+  let projectVersion = 0;
+
+  const shimPath = join(projectRoot, SHIM_FILE_NAME);
+
+  virtualFiles.set(shimPath, SHIM_SOURCE);
+
+  const bump = (filePath: string) => {
+    versions.set(filePath, (versions.get(filePath) ?? 0) + 1);
+    projectVersion += 1;
+  };
+
+  bump(shimPath);
+
+  // Astro generates these and nothing imports them, so they only enter the
+  // program if we list them as roots.
+  const ambientRoots = [
+    join(projectRoot, '.astro', 'types.d.ts'),
+    join(projectRoot, 'src', 'env.d.ts')
+  ].filter((candidate) => existsSync(candidate));
+
+  const moduleResolutionCache = typescript.createModuleResolutionCache(
+    projectRoot,
+    (fileName) => fileName,
+    compilerOptions
+  );
+
+  const host: ts.LanguageServiceHost = {
+    getScriptFileNames: () => [...virtualFiles.keys(), ...ambientRoots],
+
+    getScriptVersion: (fileName) => {
+      const tracked = versions.get(fileName);
+
+      if (tracked !== undefined) {
+        return String(tracked);
+      }
+
+      // Disk files are versioned by mtime so an edit to a sibling `types.ts`
+      // invalidates the components that import it.
+      return String(typescript.sys.getModifiedTime?.(fileName)?.getTime() ?? 0);
+    },
+
+    // Without this TypeScript re-walks every root on each getProgram() call.
+    getProjectVersion: () => String(projectVersion),
+
+    getScriptSnapshot: (fileName) => {
+      const virtual = virtualFiles.get(fileName);
+
+      if (virtual !== undefined) {
+        return typescript.ScriptSnapshot.fromString(virtual);
+      }
+
+      const contents = typescript.sys.readFile(fileName);
+
+      return contents === undefined
+        ? undefined
+        : typescript.ScriptSnapshot.fromString(contents);
+    },
+
+    getCurrentDirectory: () => projectRoot,
+    getCompilationSettings: () => compilerOptions,
+    getDefaultLibFileName: (options) => typescript.getDefaultLibFilePath(options),
+
+    fileExists: (fileName) => virtualFiles.has(fileName) || typescript.sys.fileExists(fileName),
+    readFile: (fileName) => virtualFiles.get(fileName) ?? typescript.sys.readFile(fileName),
+    readDirectory: typescript.sys.readDirectory,
+    directoryExists: typescript.sys.directoryExists,
+    getDirectories: typescript.sys.getDirectories,
+    realpath: typescript.sys.realpath,
+
+    getModuleResolutionCache: () => moduleResolutionCache,
+
+    resolveModuleNameLiterals: (literals, containingFile, redirected, options) =>
+      literals.map((literal) =>
+        resolveOne(literal.text, containingFile, redirected, options)
+      )
+  };
+
+  /**
+   * `./Child.astro` has no on-disk TypeScript to resolve to, so point it at
+   * that component's own virtual file when we have one. Anything else falls
+   * through to normal resolution, and unregistered `.astro` imports land on
+   * the shim's ambient declaration.
+   */
+  function resolveOne(
+    specifier: string,
+    containingFile: string,
+    redirected: ts.ResolvedProjectReference | undefined,
+    options: ts.CompilerOptions
+  ): ts.ResolvedModuleWithFailedLookupLocations {
+    if (specifier.endsWith('.astro')) {
+      const candidate = specifier.startsWith('.')
+        ? `${resolve(dirname(containingFile), specifier)}.ts`
+        : undefined;
+
+      if (candidate && virtualFiles.has(candidate)) {
+        return {
+          resolvedModule: {
+            resolvedFileName: candidate,
+            extension: typescript.Extension.Ts,
+            isExternalLibraryImport: false
+          }
+        };
+      }
+    }
+
+    return typescript.resolveModuleName(
+      specifier,
+      containingFile,
+      options,
+      host,
+      moduleResolutionCache,
+      redirected
+    );
+  }
+
+  const registry = typescript.createDocumentRegistry();
+  let service: ts.LanguageService | undefined = typescript.createLanguageService(host, registry);
+
+  return {
+    setVirtualFile(filePath, contents) {
+      if (virtualFiles.get(filePath) === contents) {
+        return;
+      }
+
+      virtualFiles.set(filePath, contents);
+      bump(filePath);
+    },
+
+    getProgram: () => service?.getProgram(),
+
+    invalidate(filePath) {
+      // Bumping the project version is what makes the next getProgram() call
+      // re-read the file; the per-file version comes from mtime.
+      projectVersion += 1;
+      versions.delete(filePath);
+      moduleResolutionCache.clear();
+    },
+
+    dispose() {
+      // The registry refcounts source files against the acquiring service, so
+      // skipping this leaks every lib.d.ts and node_modules type it has seen.
+      service?.dispose();
+      service = undefined;
+      virtualFiles.clear();
+      versions.clear();
+    }
+  };
+}

--- a/packages/@storybook-astro/framework/src/docgen/types.ts
+++ b/packages/@storybook-astro/framework/src/docgen/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Docgen output for a single `.astro` component.
+ *
+ * The shape deliberately matches `react-docgen-typescript`: Storybook's
+ * `extractComponentProps` (`storybook/internal/docs-tools`) already consumes it,
+ * which is what gives us JSDoc tag parsing, `@ignore` handling, union control
+ * inference and default-value formatting without reimplementing any of it.
+ * See docs/specs/docgen.md#design-decisions (Decision 2).
+ */
+export interface AstroDocgenInfo {
+  displayName: string;
+  description: string;
+  props: Record<string, AstroDocgenProp>;
+  /** JSDoc block tags from the component description, minus the free text. */
+  tags?: Record<string, string>;
+}
+
+export interface AstroDocgenProp {
+  name: string;
+  required: boolean;
+  type: AstroDocgenPropType;
+  description: string;
+  defaultValue: { value: string | number | boolean | null } | null;
+  parent?: DeclarationRef;
+  declarations?: DeclarationRef[];
+  tags?: Record<string, string>;
+}
+
+export interface AstroDocgenPropType {
+  name: string;
+  /** Full type text, when `name` is a summary like `Array` or `signature`. */
+  raw?: string;
+  /** Constituents of a literal union, for select controls. */
+  value?: Array<{ value: string }>;
+}
+
+/**
+ * Where a prop was declared. `name` is the declaring interface or type alias
+ * when there is one, and otherwise the nearest named ancestor — props coming
+ * from `VariantProps<typeof x>` are property assignments in an object literal
+ * and have no declaring type at all (docs/specs/docgen.md#prop-filtering).
+ */
+export interface DeclarationRef {
+  fileName: string;
+  name: string;
+}
+
+export type PropFilter = (prop: AstroDocgenProp, component: { name: string }) => boolean;
+
+export interface AstroDocgenOptions {
+  /**
+   * Decides which props reach the table. By default props declared only under
+   * `node_modules` are dropped, unless the component destructures them from
+   * `Astro.props` (docs/specs/docgen.md#prop-filtering).
+   */
+  propFilter?: PropFilter;
+  /** Overrides tsconfig discovery, which otherwise walks up from the component. */
+  tsconfigPath?: string;
+}

--- a/packages/@storybook-astro/framework/src/docgen/virtualFile.test.ts
+++ b/packages/@storybook-astro/framework/src/docgen/virtualFile.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import {
-  appendPropsProbe,
-  buildVirtualSource,
-  PROPS_PROBE_NAME,
-  virtualFilePathFor
-} from './virtualFile.ts';
+import { appendPropsProbes, buildVirtualSource, virtualFilePathFor } from './virtualFile.ts';
 
 describe('the virtual file sits beside the component', () => {
   test('so relative imports and path aliases resolve from the component folder', () => {
@@ -87,22 +82,31 @@ describe('components with nothing to extract are skipped', () => {
   });
 });
 
-describe('the Props probe applies generic defaults', () => {
+describe('the Props probes apply generic defaults', () => {
   test('declares a value of type Props so the checker instantiates it', () => {
-    const virtual = appendPropsProbe('interface Props { a?: string }');
+    const { source, names } = appendPropsProbes('interface Props { a?: string }');
 
-    expect(virtual).toContain(`declare const ${PROPS_PROBE_NAME}: Props;`);
+    expect(names).toHaveLength(1);
+    expect(source).toContain(`declare const ${names[0]}: Props;`);
   });
 
-  test('accepts explicit type arguments for the union-constituent pass', () => {
-    expect(appendPropsProbe('type Props<T> = { as: T }', "'a'")).toContain(
-      `${PROPS_PROBE_NAME}: Props<'a'>;`
-    );
+  test('one probe per union constituent, so per-element props are not lost', () => {
+    const { source, names } = appendPropsProbes('type Props<T> = { as: T }', ["'a'", "'button'"]);
+
+    expect(names).toHaveLength(2);
+    expect(source).toContain(`${names[0]}: Props<'a'>;`);
+    expect(source).toContain(`${names[1]}: Props<'button'>;`);
+  });
+
+  test('probe names do not collide', () => {
+    const { names } = appendPropsProbes('type Props<T> = { as: T }', ["'a'", "'b'", "'c'"]);
+
+    expect(new Set(names).size).toBe(3);
   });
 
   test('is appended past the original content so no offset moves', () => {
     const original = 'interface Props { a?: string }';
 
-    expect(appendPropsProbe(original).startsWith(original)).toBe(true);
+    expect(appendPropsProbes(original).source.startsWith(original)).toBe(true);
   });
 });

--- a/packages/@storybook-astro/framework/src/docgen/virtualFile.test.ts
+++ b/packages/@storybook-astro/framework/src/docgen/virtualFile.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'vitest';
+import {
+  appendPropsProbe,
+  buildVirtualSource,
+  PROPS_PROBE_NAME,
+  virtualFilePathFor
+} from './virtualFile.ts';
+
+describe('the virtual file sits beside the component', () => {
+  test('so relative imports and path aliases resolve from the component folder', () => {
+    expect(virtualFilePathFor('/src/components/Button.astro')).toBe(
+      '/src/components/Button.astro.ts'
+    );
+  });
+});
+
+describe('frontmatter is kept and everything else is blanked', () => {
+  test('the template is replaced by whitespace', () => {
+    const source = ['---', "const label = 'hi';", '---', '<button>{label}</button>'].join('\n');
+
+    const virtual = buildVirtualSource(source);
+
+    expect(virtual).toContain("const label = 'hi';");
+    expect(virtual).not.toContain('<button>');
+  });
+
+  test('every TypeScript offset is the offset in the original .astro file', () => {
+    const source = [
+      '---',
+      'interface Props {',
+      '  title?: string;',
+      '}',
+      '---',
+      '<h1>{Astro.props.title}</h1>'
+    ].join('\n');
+
+    const virtual = buildVirtualSource(source) as string;
+
+    expect(virtual).toHaveLength(source.length);
+    expect(virtual.indexOf('interface Props')).toBe(source.indexOf('interface Props'));
+    expect(virtual.indexOf('title?: string')).toBe(source.indexOf('title?: string'));
+  });
+
+  test('line numbers are preserved so diagnostics point at the right line', () => {
+    const source = ['---', 'const a = 1;', '---', '<p>one</p>', '<p>two</p>'].join('\n');
+
+    const lineCount = (text: string) => text.split('\n').length;
+
+    expect(lineCount(buildVirtualSource(source) as string)).toBe(lineCount(source));
+  });
+
+  test('the opening fence becomes a comment rather than disappearing', () => {
+    const virtual = buildVirtualSource(['---', 'const a = 1;', '---', ''].join('\n')) as string;
+
+    expect(virtual.startsWith('// ')).toBe(true);
+  });
+
+  test('a --- inside a frontmatter string does not end the frontmatter early', () => {
+    const source = ['---', "const divider = '---';", 'const after = 2;', '---', '<hr />'].join('\n');
+
+    const virtual = buildVirtualSource(source) as string;
+
+    expect(virtual).toContain('const after = 2;');
+  });
+
+  test('an indented closing fence still closes the frontmatter', () => {
+    const source = ['---', 'const a = 1;', '  ---  ', '<p>hi</p>'].join('\n');
+
+    const virtual = buildVirtualSource(source) as string;
+
+    expect(virtual).toContain('const a = 1;');
+    expect(virtual).not.toContain('<p>');
+  });
+});
+
+describe('components with nothing to extract are skipped', () => {
+  test('a file with no frontmatter', () => {
+    expect(buildVirtualSource('<p>just markup</p>')).toBeNull();
+  });
+
+  test('a file whose frontmatter is never closed', () => {
+    expect(buildVirtualSource('---\nconst a = 1;\n')).toBeNull();
+  });
+
+  test('an empty frontmatter block', () => {
+    expect(buildVirtualSource(['---', '', '---', '<p>hi</p>'].join('\n'))).toBeNull();
+  });
+});
+
+describe('the Props probe applies generic defaults', () => {
+  test('declares a value of type Props so the checker instantiates it', () => {
+    const virtual = appendPropsProbe('interface Props { a?: string }');
+
+    expect(virtual).toContain(`declare const ${PROPS_PROBE_NAME}: Props;`);
+  });
+
+  test('accepts explicit type arguments for the union-constituent pass', () => {
+    expect(appendPropsProbe('type Props<T> = { as: T }', "'a'")).toContain(
+      `${PROPS_PROBE_NAME}: Props<'a'>;`
+    );
+  });
+
+  test('is appended past the original content so no offset moves', () => {
+    const original = 'interface Props { a?: string }';
+
+    expect(appendPropsProbe(original).startsWith(original)).toBe(true);
+  });
+});

--- a/packages/@storybook-astro/framework/src/docgen/virtualFile.ts
+++ b/packages/@storybook-astro/framework/src/docgen/virtualFile.ts
@@ -1,0 +1,93 @@
+import { basename, dirname, join } from 'node:path';
+
+/**
+ * Turns a `.astro` file into the TypeScript file we hand to the compiler.
+ *
+ * Two properties matter and both are load-bearing
+ * (docs/specs/docgen.md#the-virtual-typescript-file):
+ *
+ * 1. The virtual file sits *beside* the component, so relative imports,
+ *    tsconfig `paths`, package `exports` and nearest-package.json resolution
+ *    all behave as they would for a real file in that folder. Naming it
+ *    something rootless resolves `./types` against the process working
+ *    directory instead, and the failure is invisible — TypeScript's error type
+ *    still stringifies to the written type name while the type has no members,
+ *    so the props table comes out plausible and empty.
+ * 2. Every byte outside the frontmatter is blanked rather than removed, so a
+ *    TypeScript position is the exact offset in the original `.astro` file and
+ *    diagnostics need no translation.
+ */
+
+/** The name TypeScript sees. `.astro.ts` matches svelte2tsx and vue-tsc. */
+export function virtualFilePathFor(astroFilePath: string): string {
+  return join(dirname(astroFilePath), `${basename(astroFilePath)}.ts`);
+}
+
+/**
+ * Builds the virtual source, or `null` when the file has no frontmatter and
+ * therefore nothing to extract.
+ */
+export function buildVirtualSource(astroSource: string): string | null {
+  if (!astroSource.startsWith('---')) {
+    return null;
+  }
+
+  const closingFence = findClosingFence(astroSource);
+
+  if (closingFence === -1) {
+    return null;
+  }
+
+  // `// ` is the same three bytes as the opening `---`, so it comments out the
+  // rest of that line without shifting anything after it.
+  const frontmatter = astroSource.slice(3, closingFence);
+
+  if (!frontmatter.trim()) {
+    return null;
+  }
+
+  return `// ${frontmatter}${blankOut(astroSource.slice(closingFence))}`;
+}
+
+/**
+ * Index of the closing `---`, searching line by line rather than with a lazy
+ * regex so a `---` inside a frontmatter string or comment doesn't end it early.
+ */
+function findClosingFence(source: string): number {
+  let cursor = source.indexOf('\n');
+
+  while (cursor !== -1) {
+    const lineStart = cursor + 1;
+    const nextNewline = source.indexOf('\n', lineStart);
+    const lineEnd = nextNewline === -1 ? source.length : nextNewline;
+
+    if (source.slice(lineStart, lineEnd).trim() === '---') {
+      return lineStart;
+    }
+
+    cursor = nextNewline;
+  }
+
+  return -1;
+}
+
+/** Replaces every character with a space, keeping newlines so offsets hold. */
+function blankOut(text: string): string {
+  return text.replace(/[^\n]/g, ' ');
+}
+
+/**
+ * Appends a declaration whose type is `Props` with its type arguments defaulted.
+ *
+ * Reading `getDeclaredTypeOfSymbol` on a generic `Props` hands back `Props<Tag>`
+ * with the parameter unapplied; reading the type of this declaration applies the
+ * defaults instead (docs/specs/docgen.md#heritage-rewrite, Decision 6). Appended
+ * past the end of the original file so no existing offset moves.
+ */
+export const PROPS_PROBE_NAME = '__SB_ASTRO_PROPS__';
+
+export function appendPropsProbe(virtualSource: string, typeArguments?: string): string {
+  const args = typeArguments ? `<${typeArguments}>` : '';
+
+  return `${virtualSource}\ndeclare const ${PROPS_PROBE_NAME}: Props${args};\n`;
+}

--- a/packages/@storybook-astro/framework/src/docgen/virtualFile.ts
+++ b/packages/@storybook-astro/framework/src/docgen/virtualFile.ts
@@ -77,17 +77,39 @@ function blankOut(text: string): string {
 }
 
 /**
- * Appends a declaration whose type is `Props` with its type arguments defaulted.
+ * Appends declarations whose type is `Props`, so the checker instantiates it.
  *
  * Reading `getDeclaredTypeOfSymbol` on a generic `Props` hands back `Props<Tag>`
- * with the parameter unapplied; reading the type of this declaration applies the
- * defaults instead (docs/specs/docgen.md#heritage-rewrite, Decision 6). Appended
- * past the end of the original file so no existing offset moves.
+ * with the parameter unapplied; reading the type of a declaration applies the
+ * defaults instead (docs/specs/docgen.md#heritage-rewrite, Decision 6).
+ *
+ * More than one probe is emitted when the default is a union of string
+ * literals. `keyof (A | B)` is the *intersection* of keys, so a polymorphic
+ * `Props<'a' | 'button'>` drops `href` and `type` — the props only exist on one
+ * constituent each. Instantiating per constituent and merging recovers them.
+ *
+ * Everything is appended past the end of the original file, so no offset moves.
  */
-export const PROPS_PROBE_NAME = '__SB_ASTRO_PROPS__';
+const PROBE_PREFIX = '__SB_ASTRO_PROPS_';
 
-export function appendPropsProbe(virtualSource: string, typeArguments?: string): string {
-  const args = typeArguments ? `<${typeArguments}>` : '';
+export interface PropsProbes {
+  source: string;
+  /** Declaration names to read types from, in merge order. */
+  names: string[];
+}
 
-  return `${virtualSource}\ndeclare const ${PROPS_PROBE_NAME}: Props${args};\n`;
+export function appendPropsProbes(
+  virtualSource: string,
+  typeArgumentSets: ReadonlyArray<string | undefined> = [undefined]
+): PropsProbes {
+  const names: string[] = [];
+  const declarations = typeArgumentSets.map((typeArguments, index) => {
+    const name = `${PROBE_PREFIX}${index}__`;
+
+    names.push(name);
+
+    return `declare const ${name}: Props${typeArguments ? `<${typeArguments}>` : ''};`;
+  });
+
+  return { source: `${virtualSource}\n${declarations.join('\n')}\n`, names };
 }

--- a/packages/@storybook-astro/framework/src/docgen/virtualFile.ts
+++ b/packages/@storybook-astro/framework/src/docgen/virtualFile.ts
@@ -111,5 +111,10 @@ export function appendPropsProbes(
     return `declare const ${name}: Props${typeArguments ? `<${typeArguments}>` : ''};`;
   });
 
-  return { source: `${virtualSource}\n${declarations.join('\n')}\n`, names };
+  // `export {}` is load-bearing. Frontmatter without an import or export is a
+  // global script, not a module, so its `Props` and these probes would be
+  // *global* declarations — and every component shares one TypeScript program.
+  // Without this, two components that both declare `Props` collide and the
+  // first one wins, so a component silently inherits another's props table.
+  return { source: `${virtualSource}\n${declarations.join('\n')}\nexport {};\n`, names };
 }

--- a/packages/@storybook-astro/framework/src/index.ts
+++ b/packages/@storybook-astro/framework/src/index.ts
@@ -9,6 +9,7 @@ export type {
 
 import { definePreview as definePreviewBase, type PreviewAddon, type InferTypes, type Preview as CsfPreview } from 'storybook/internal/csf';
 import { combineParameters } from 'storybook/internal/preview-api';
+import { enhanceArgTypes } from 'storybook/internal/docs-tools';
 import type { ArgsStoryFn, ProjectAnnotations, RenderContext, Renderer } from 'storybook/internal/types';
 import { defaultPreviewParameters } from '@storybook-astro/renderer/preview-defaults';
 import { applyDecorators } from '@storybook-astro/renderer/decorators';
@@ -117,6 +118,11 @@ export function definePreview<Addons extends PreviewAddon<never>[] = []>(
       renderer: 'astro' as const,
       ...input.parameters
     }),
+    // `defaultPreviewParameters` carries `docs.extractArgTypes`, but nothing
+    // calls it without this enhancer — and CSF-factory stories never see the
+    // renderer's entry-preview annotation that registers it there
+    // (docs/specs/docgen.md#design-decisions).
+    argTypesEnhancers: [enhanceArgTypes, ...(input.argTypesEnhancers ?? [])],
     render: input.render ?? composedRender,
     renderToCanvas: input.renderToCanvas ?? composedRenderToCanvas,
     applyDecorators: input.applyDecorators ?? applyDecorators

--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -81,7 +81,8 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
   // to `vitePluginAstroBuildServer` below.
   const clientAstroComponentIds = new Set<string>();
   const componentMarkerPlugin = vitePluginAstroComponentMarker({
-    onClientAstroModuleId: (moduleId) => clientAstroComponentIds.add(moduleId)
+    onClientAstroModuleId: (moduleId) => clientAstroComponentIds.add(moduleId),
+    docgen: await createDocgenIfEnabled(options, resolveFrom, storybookOptions)
   });
 
   config.plugins.push(
@@ -301,4 +302,32 @@ function mergeEnvPrefixes(
   const prefixes = Array.isArray(existing) ? existing : existing ? [existing] : [];
 
   return Array.from(new Set([...prefixes, additionalPrefix]));
+}
+
+/**
+ * Builds the docgen runtime for the props table and description autodocs shows,
+ * or returns undefined when extraction shouldn't run at all.
+ *
+ * Skipped when the user opted out, when the docs addon isn't installed (nothing
+ * would render the output), and when Storybook is building for tests — docgen
+ * costs a type check per component and none of those need it.
+ */
+async function createDocgenIfEnabled(
+  options: FrameworkOptions,
+  projectRoot: string,
+  storybookOptions: Parameters<NonNullable<StorybookConfigVite['viteFinal']>>[1]
+) {
+  if (options.docgen === false || storybookOptions.build?.test?.disableDocgen) {
+    return undefined;
+  }
+
+  const docsConfig = await storybookOptions.presets.apply('docs', {}, storybookOptions);
+
+  if (Object.keys(docsConfig ?? {}).length === 0) {
+    return undefined;
+  }
+
+  const { createAstroDocgen } = await import('./docgen/index.ts');
+
+  return createAstroDocgen({ projectRoot, ...options.docgen });
 }

--- a/packages/@storybook-astro/framework/src/types.ts
+++ b/packages/@storybook-astro/framework/src/types.ts
@@ -1,5 +1,6 @@
 import type { CompatibleString, Options, StorybookConfig as StorybookConfigBase } from 'storybook/internal/types';
 import type { InlineConfig } from 'vite';
+import type { AstroDocgenOptions } from './docgen/index.ts';
 import type { Integration } from './integrations/index.ts';
 import type { SanitizationOptions } from './lib/sanitization.ts';
 import type { StoryRulesOptions } from './rules-options.ts';
@@ -7,7 +8,7 @@ import type { StorybookFontFamily } from './vitePluginAstroFonts.ts';
 
 type FrameworkName = CompatibleString<'@storybook-astro/framework'>;
 
-export type { Integration, SanitizationOptions, StoryRulesOptions, StorybookFontFamily };
+export type { AstroDocgenOptions, Integration, SanitizationOptions, StoryRulesOptions, StorybookFontFamily };
 export type RenderMode = 'server' | 'static';
 
 export type ServerBuildOptions = {
@@ -33,6 +34,12 @@ type BaseFrameworkOptions = {
    * back to no-op stubs.
    */
   fonts?: StorybookFontFamily[];
+  /**
+   * Controls the props table and description autodocs generates from a
+   * component's frontmatter JSDoc. Pass `false` to turn extraction off
+   * entirely (docs/specs/docgen.md).
+   */
+  docgen?: false | AstroDocgenOptions;
 };
 
 type ServerFrameworkOptions = BaseFrameworkOptions & {

--- a/packages/@storybook-astro/framework/src/vitePluginAstroComponentMarker.test.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroComponentMarker.test.ts
@@ -30,12 +30,12 @@ function writeAstroFile(relativePath: string, source: string): string {
 
 type TransformablePlugin = {
   configResolved: (config: { command: string }) => void;
-  transform: (code: string, id: string) => { code: string } | null;
+  transform: (code: string, id: string) => Promise<{ code: string } | null>;
 };
 
 function createPlugin(
   command: 'serve' | 'build' = 'serve',
-  options?: { onClientAstroModuleId?: (moduleId: string) => void }
+  options?: Parameters<typeof vitePluginAstroComponentMarker>[0]
 ) {
   const plugin = vitePluginAstroComponentMarker(options) as unknown as TransformablePlugin;
 
@@ -45,17 +45,17 @@ function createPlugin(
 }
 
 describe('vitePluginAstroComponentMarker transform', () => {
-  test('ignores non-astro modules and non-stub code', () => {
+  test('ignores non-astro modules and non-stub code', async () => {
     const plugin = createPlugin();
 
-    expect(plugin.transform(ASTRO6_CLIENT_STUB, '/some/module.ts')).toBeNull();
-    expect(plugin.transform('export default {};', '/some/Component.astro')).toBeNull();
+    expect(await plugin.transform(ASTRO6_CLIENT_STUB, '/some/module.ts')).toBeNull();
+    expect(await plugin.transform('export default {};', '/some/Component.astro')).toBeNull();
   });
 
-  test('replaces the stub with a marked component factory', () => {
+  test('replaces the stub with a marked component factory', async () => {
     const filePath = writeAstroFile('Plain.astro', '<div>Hello</div>');
     const plugin = createPlugin();
-    const result = plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
 
     expect(result?.code).toContain('isAstroComponentFactory = true');
     expect(result?.code).toContain(JSON.stringify(filePath));
@@ -64,62 +64,62 @@ describe('vitePluginAstroComponentMarker transform', () => {
   // Server-mode snapshots need every client-imported .astro id, not just story
   // components (docs/specs/decorators.md#static-prerender, Gap B) — vitePluginAstroBuildServer
   // collects them through this callback.
-  test('reports every marked module id via onClientAstroModuleId', () => {
+  test('reports every marked module id via onClientAstroModuleId', async () => {
     const filePath = writeAstroFile('Wrapper.astro', '<div><slot /></div>');
     const seenModuleIds: string[] = [];
     const plugin = createPlugin('serve', {
       onClientAstroModuleId: (moduleId) => seenModuleIds.push(moduleId)
     });
 
-    plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+    await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
 
     expect(seenModuleIds).toEqual([filePath]);
   });
 
-  test('does not report modules that are not the Astro browser stub', () => {
+  test('does not report modules that are not the Astro browser stub', async () => {
     const filePath = writeAstroFile('Untouched.astro', '<div>Hello</div>');
     const seenModuleIds: string[] = [];
     const plugin = createPlugin('serve', {
       onClientAstroModuleId: (moduleId) => seenModuleIds.push(moduleId)
     });
 
-    plugin.transform('export default {};', filePath);
+    await plugin.transform('export default {};', filePath);
 
     expect(seenModuleIds).toEqual([]);
   });
 
-  test('inlines CSS for own <style> blocks in dev mode (hybrid approach)', () => {
+  test('inlines CSS for own <style> blocks in dev mode (hybrid approach)', async () => {
     const filePath = writeAstroFile(
       'Styled.astro',
       '<div class="a">Hi</div>\n<style>.a { color: red; }</style>'
     );
     const plugin = createPlugin();
-    const result = plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
 
     // Dev mode uses inline CSS instead of sub-module imports to avoid Astro cache issues
     expect(result?.code).toContain('.a { color: red; }');
     expect(result?.code).toContain('data-astro-dev');
   });
 
-  test('unwraps :global() selectors so the CSS is valid in the browser', () => {
+  test('unwraps :global() selectors so the CSS is valid in the browser', async () => {
     const filePath = writeAstroFile(
       'Global.astro',
       '<div class="wrap"><slot /></div>\n<style>.wrap > :global(img) { width: 100%; }</style>'
     );
     const plugin = createPlugin();
-    const result = plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
 
     expect(result?.code).toContain('.wrap > img { width: 100%; }');
     expect(result?.code).not.toContain(':global(');
   });
 
-  test('skips preprocessed <style lang="..."> blocks with a console warning in dev mode', () => {
+  test('skips preprocessed <style lang="..."> blocks with a console warning in dev mode', async () => {
     const filePath = writeAstroFile(
       'Scss.astro',
       '<div class="a">Hi</div>\n<style lang="scss">.a { .b { color: red; } }</style>'
     );
     const plugin = createPlugin();
-    const result = plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
 
     // The raw SCSS source must not be injected as a stylesheet.
     expect(result?.code).not.toContain('document.createElement');
@@ -127,20 +127,20 @@ describe('vitePluginAstroComponentMarker transform', () => {
     expect(result?.code).toContain('scss');
   });
 
-  test('dedupes injected styles so repeated module evaluation does not pile up', () => {
+  test('dedupes injected styles so repeated module evaluation does not pile up', async () => {
     const filePath = writeAstroFile(
       'Dedupe.astro',
       '<div class="a">Hi</div>\n<style>.a { color: red; }</style>'
     );
     const plugin = createPlugin();
-    const result = plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
 
     // The injection snippet bails out if a style with the same marker already exists.
     expect(result?.code).toContain("getAttribute");
     expect(result?.code).toContain('data-astro-dev');
   });
 
-  test('re-imports child .astro components so their scoped styles load in dev mode', () => {
+  test('re-imports child .astro components so their scoped styles load in dev mode', async () => {
     const filePath = writeAstroFile(
       'Parent.astro',
       [
@@ -153,13 +153,13 @@ describe('vitePluginAstroComponentMarker transform', () => {
       ].join('\n')
     );
     const plugin = createPlugin();
-    const result = plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
 
     expect(result?.code).toContain(`import "./Child.astro";`);
     expect(result?.code).toContain(`import "@components/Other.astro";`);
   });
 
-  test('inlines CSS from the component and its children in build mode', () => {
+  test('inlines CSS from the component and its children in build mode', async () => {
     writeAstroFile(
       'build/Child.astro',
       '<div class="child">Hello</div>\n<style>.child { color: red; }</style>'
@@ -175,25 +175,25 @@ describe('vitePluginAstroComponentMarker transform', () => {
       ].join('\n')
     );
     const plugin = createPlugin('build');
-    const result = plugin.transform(ASTRO6_CLIENT_STUB, parentPath);
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, parentPath);
 
     expect(result?.code).toContain('.parent { padding: 16px; }');
     expect(result?.code).toContain('.child { color: red; }');
   });
 
-  test('unwraps :global() selectors in build mode too', () => {
+  test('unwraps :global() selectors in build mode too', async () => {
     const filePath = writeAstroFile(
       'build/Global.astro',
       '<div class="wrap"><slot /></div>\n<style>.wrap :global(img) { width: 100%; }</style>'
     );
     const plugin = createPlugin('build');
-    const result = plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
 
     expect(result?.code).toContain('.wrap img { width: 100%; }');
     expect(result?.code).not.toContain(':global(');
   });
 
-  test('handles circular child imports in build mode without recursing forever', () => {
+  test('handles circular child imports in build mode without recursing forever', async () => {
     const aPath = writeAstroFile(
       'cycle/A.astro',
       "---\nimport B from './B.astro';\n---\n<B />\n<style>.a { color: blue; }</style>"
@@ -205,7 +205,7 @@ describe('vitePluginAstroComponentMarker transform', () => {
     );
 
     const plugin = createPlugin('build');
-    const result = plugin.transform(ASTRO6_CLIENT_STUB, aPath);
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, aPath);
 
     expect(result?.code).toContain('.a { color: blue; }');
     expect(result?.code).toContain('.b { color: green; }');
@@ -213,7 +213,7 @@ describe('vitePluginAstroComponentMarker transform', () => {
 });
 
 describe('extractAstroImportSpecifiers', () => {
-  test('finds default, side-effect, and dynamic .astro imports in the frontmatter', () => {
+  test('finds default, side-effect, and dynamic .astro imports in the frontmatter', async () => {
     const source = [
       '---',
       "import Child from './Child.astro';",
@@ -231,7 +231,7 @@ describe('extractAstroImportSpecifiers', () => {
     ]);
   });
 
-  test('ignores commented-out imports', () => {
+  test('ignores commented-out imports', async () => {
     const source = [
       '---',
       "// import Old from './Old.astro';",
@@ -244,11 +244,11 @@ describe('extractAstroImportSpecifiers', () => {
     expect(extractAstroImportSpecifiers(source)).toEqual(['./Current.astro']);
   });
 
-  test('returns nothing for components without frontmatter', () => {
+  test('returns nothing for components without frontmatter', async () => {
     expect(extractAstroImportSpecifiers('<div>Hello</div>')).toEqual([]);
   });
 
-  test('deduplicates repeated specifiers', () => {
+  test('deduplicates repeated specifiers', async () => {
     const source = [
       '---',
       "import A from './Child.astro';",
@@ -257,5 +257,71 @@ describe('extractAstroImportSpecifiers', () => {
     ].join('\n');
 
     expect(extractAstroImportSpecifiers(source)).toEqual(['./Child.astro']);
+  });
+});
+
+describe('component documentation rides along on the stub', () => {
+  /** Stands in for the real extractor; this test is about the wiring. */
+  function fakeDocgen(info: unknown) {
+    return {
+      warmUp: async () => {},
+      extract: async () => info,
+      invalidate: () => {},
+      dispose: () => {}
+    } as unknown as NonNullable<
+      Parameters<typeof vitePluginAstroComponentMarker>[0]
+    >['docgen'];
+  }
+
+  test('attaches __docgenInfo where the renderer reads it', async () => {
+    const filePath = writeAstroFile('docgen/Card.astro', '---\ninterface Props {}\n---\n<div />');
+    const plugin = createPlugin('serve', {
+      docgen: fakeDocgen({ displayName: 'Card', description: 'A card.', props: {} })
+    });
+
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+
+    expect(result?.code).toContain('__astro_component.__docgenInfo =');
+    expect(result?.code).toContain('"description":"A card."');
+  });
+
+  test('omits the assignment when there is nothing to document', async () => {
+    const filePath = writeAstroFile('docgen/Bare.astro', '<div />');
+    const plugin = createPlugin('serve', { docgen: fakeDocgen(null) });
+
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+
+    expect(result?.code).not.toContain('__docgenInfo');
+    expect(result?.code).toContain('isAstroComponentFactory = true');
+  });
+
+  test('marks the component even with no docgen configured at all', async () => {
+    const filePath = writeAstroFile('docgen/NoDocgen.astro', '---\nconst a = 1;\n---\n<div />');
+    const plugin = createPlugin();
+
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+
+    expect(result?.code).toContain('isAstroComponentFactory = true');
+    expect(result?.code).not.toContain('__docgenInfo');
+  });
+
+  test('an extractor that throws never breaks the transform', async () => {
+    const filePath = writeAstroFile('docgen/Throws.astro', '---\nconst a = 1;\n---\n<div />');
+    const plugin = createPlugin('serve', {
+      docgen: {
+        warmUp: async () => {},
+        extract: async () => {
+          throw new Error('type checker exploded');
+        },
+        invalidate: () => {},
+        dispose: () => {}
+      } as unknown as NonNullable<
+        Parameters<typeof vitePluginAstroComponentMarker>[0]
+      >['docgen']
+    });
+
+    const result = await plugin.transform(ASTRO6_CLIENT_STUB, filePath);
+
+    expect(result?.code).toContain('isAstroComponentFactory = true');
   });
 });

--- a/packages/@storybook-astro/framework/src/vitePluginAstroComponentMarker.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroComponentMarker.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import type { PluginOption } from 'vite';
+import type { AstroDocgen } from './docgen/index.ts';
 
 /**
  * Vite plugin that patches Astro 6's client-side .astro file transforms for Storybook.
@@ -27,6 +28,14 @@ export function vitePluginAstroComponentMarker(options?: {
    * still be copied into the deployed snapshot (docs/specs/decorators.md#server-snapshot).
    */
   onClientAstroModuleId?: (moduleId: string) => void;
+  /**
+   * Extracts the component's props and description so Storybook's autodocs can
+   * render them. The result rides along on the stub as `__docgenInfo`, which is
+   * where the renderer's `extractArgTypes` reads it from
+   * (docs/specs/docgen.md#design-decisions). Omitted when the Docgen Server is
+   * handling extraction instead, or when the user turned docgen off.
+   */
+  docgen?: AstroDocgen;
 }): PluginOption {
   let isBuild = false;
 
@@ -38,7 +47,25 @@ export function vitePluginAstroComponentMarker(options?: {
       isBuild = config.command === 'build';
     },
 
-    transform(code: string, id: string) {
+    buildStart() {
+      // Loading TypeScript and warming its language service costs about a
+      // second, once. Kicking it off here without awaiting overlaps that with
+      // Storybook's own boot instead of landing on the first story request.
+      void options?.docgen?.warmUp();
+    },
+
+    configureServer(server) {
+      // A component's docgen depends on files it imports, so an edit to a
+      // shared `types.ts` has to invalidate the components that read it.
+      // Vite's watcher ignores node_modules, so installs still need a restart.
+      for (const event of ['change', 'add', 'unlink'] as const) {
+        server.watcher.on(event, (changedPath: string) => {
+          options?.docgen?.invalidate(changedPath);
+        });
+      }
+    },
+
+    async transform(code: string, id: string) {
       // Only process main .astro modules (not sub-modules like ?astro&type=style)
       if (!id.endsWith('.astro')) {return null;}
 
@@ -63,6 +90,8 @@ export function vitePluginAstroComponentMarker(options?: {
         ? generateInlineStyles(moduleId)
         : generateHybridStyles(moduleId);
 
+      const docgenCode = await generateDocgenAssignment(options?.docgen, moduleId);
+
       return {
         code: `
 ${styleCode}
@@ -71,12 +100,38 @@ const __astro_component = () => {
 };
 __astro_component.isAstroComponentFactory = true;
 __astro_component.moduleId = ${JSON.stringify(moduleId)};
+${docgenCode}
 export default __astro_component;
 `,
         map: null,
       };
     },
   };
+}
+
+/**
+ * Builds the `__docgenInfo` assignment Storybook's autodocs reads, or an empty
+ * string when there is nothing to attach.
+ *
+ * Docgen is a side channel: a component that can't be analysed still renders,
+ * so every failure here degrades to no documentation rather than a broken
+ * transform (docs/specs/docgen.md#failure-modes).
+ */
+async function generateDocgenAssignment(
+  docgen: AstroDocgen | undefined,
+  filePath: string
+): Promise<string> {
+  if (!docgen) {
+    return '';
+  }
+
+  try {
+    const info = await docgen.extract(filePath, readFileSync(filePath, 'utf-8'));
+
+    return info ? `__astro_component.__docgenInfo = ${JSON.stringify(info)};` : '';
+  } catch {
+    return '';
+  }
 }
 
 /**

--- a/packages/@storybook-astro/framework/tsup.config.ts
+++ b/packages/@storybook-astro/framework/tsup.config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
     'astro',
     'storybook',
     'storybook/internal/types',
+    // Optional peer, loaded through a guarded dynamic import so docgen degrades
+    // to a no-op when a project has no TypeScript (docs/specs/docgen.md#failure-modes).
+    'typescript',
     'vite',
     'react',
     'react-dom',

--- a/packages/@storybook-astro/renderer/src/entry-preview.ts
+++ b/packages/@storybook-astro/renderer/src/entry-preview.ts
@@ -1,6 +1,7 @@
 // import 'astro/runtime/server/astro-island';
 
 import * as astroRenderer from 'virtual:storybook-astro-renderer';
+import { enhanceArgTypes } from 'storybook/internal/docs-tools';
 
 import { defaultPreviewParameters } from './preview-defaults.ts';
 
@@ -20,33 +21,41 @@ function isAstroComponent(component: unknown): boolean {
 
 // In static mode, Astro components are pre-rendered and cannot be re-rendered with different args.
 // Disable controls for Astro components to prevent user confusion.
-export const argTypesEnhancers = astroRenderer.isStaticMode
-  ? [
-      (context: { component: unknown; argTypes: Record<string, Record<string, unknown>> }) => {
-        const { component, argTypes } = context;
+function disablePrerenderedControls(context: {
+  component: unknown;
+  argTypes: Record<string, Record<string, unknown>>;
+}) {
+  const { component, argTypes } = context;
 
-        if (!isAstroComponent(component)) {
-          return argTypes;
-        }
+  if (!isAstroComponent(component)) {
+    return argTypes;
+  }
 
-        const disabledArgTypes: Record<string, Record<string, unknown>> = {};
+  const disabledArgTypes: Record<string, Record<string, unknown>> = {};
 
-        for (const [key, argType] of Object.entries(argTypes)) {
-          disabledArgTypes[key] = { ...argType, control: false };
-        }
+  for (const [key, argType] of Object.entries(argTypes)) {
+    disabledArgTypes[key] = { ...argType, control: false };
+  }
 
-        disabledArgTypes['_astroPrerendered'] = {
-          name: 'Pre-rendered',
-          description:
-            'This Astro component is pre-rendered at build time. Controls are unavailable in static builds.',
-          control: false,
-          table: { category: 'ℹ️ Astro' },
-        };
+  disabledArgTypes['_astroPrerendered'] = {
+    name: 'Pre-rendered',
+    description:
+      'This Astro component is pre-rendered at build time. Controls are unavailable in static builds.',
+    control: false,
+    table: { category: 'ℹ️ Astro' },
+  };
 
-        return disabledArgTypes;
-      },
-    ]
-  : [];
+  return disabledArgTypes;
+}
+
+// `enhanceArgTypes` reads the component's `__docgenInfo` through
+// `parameters.docs.extractArgTypes`, so it must run before the static-mode pass
+// — otherwise the props it adds arrive too late to be disabled and would show
+// live controls that do nothing (docs/specs/docgen.md#design-decisions).
+export const argTypesEnhancers = [
+  enhanceArgTypes,
+  ...(astroRenderer.isStaticMode ? [disablePrerenderedControls] : []),
+];
 
 export { renderToCanvas, render } from './render.tsx';
 export { applyDecorators } from './decorators.ts';

--- a/packages/@storybook-astro/renderer/src/extractArgTypes.ts
+++ b/packages/@storybook-astro/renderer/src/extractArgTypes.ts
@@ -1,0 +1,44 @@
+import { extractComponentProps } from 'storybook/internal/docs-tools';
+import type { ArgTypesExtractor } from 'storybook/internal/docs-tools';
+import type { StrictArgTypes } from 'storybook/internal/types';
+
+/**
+ * Turns the `__docgenInfo` the framework attached to an Astro component stub
+ * into the rows Storybook's Controls panel and props table render.
+ *
+ * The heavy lifting is `extractComponentProps`, which already understands the
+ * `react-docgen-typescript` shape our extractor emits — that is why it emits
+ * that shape (docs/specs/docgen.md#design-decisions). It gives us JSDoc tag
+ * parsing, `@ignore` handling, union-to-select inference and default-value
+ * formatting, so all that is left here is the mapping onto `StrictArgTypes`.
+ */
+export const extractArgTypes: ArgTypesExtractor = (component): StrictArgTypes | null => {
+  if (!component) {
+    return null;
+  }
+
+  const props = extractComponentProps(component, 'props');
+
+  if (props.length === 0) {
+    return null;
+  }
+
+  const argTypes: StrictArgTypes = {};
+
+  for (const { propDef } of props) {
+    const { name, description, type, sbType, defaultValue, jsDocTags, required } = propDef;
+
+    argTypes[name] = {
+      name,
+      description,
+      type: { required, ...sbType },
+      table: {
+        type: type ?? undefined,
+        jsDocTags,
+        defaultValue: defaultValue ?? undefined
+      }
+    };
+  }
+
+  return argTypes;
+};

--- a/packages/@storybook-astro/renderer/src/preview-defaults.ts
+++ b/packages/@storybook-astro/renderer/src/preview-defaults.ts
@@ -6,8 +6,16 @@
 // entry-preview re-exports these for the legacy (CSF3) annotation path, while
 // `definePreview` merges them for CSF-factory consumers, who otherwise bypass
 // the entry-preview annotation entirely (see framework/src/index.ts).
+import { extractComponentDescription } from 'storybook/internal/docs-tools';
+import { extractArgTypes } from './extractArgTypes.ts';
+
 export const defaultPreviewParameters = {
   docs: {
+    // Autodocs reads the component's props table and description through these.
+    // They live here rather than in entry-preview so CSF-factory stories, which
+    // bypass that annotation, get them too (docs/specs/docgen.md#design-decisions).
+    extractArgTypes,
+    extractComponentDescription,
     story: {
       // Render Docs (autodocs) stories inline rather than in a nested iframe.
       // Storybook's default (inline: false) embeds each story in an iframe, and

--- a/packages/@storybook-astro/renderer/src/preview-defaults.ts
+++ b/packages/@storybook-astro/renderer/src/preview-defaults.ts
@@ -7,6 +7,7 @@
 // `definePreview` merges them for CSF-factory consumers, who otherwise bypass
 // the entry-preview annotation entirely (see framework/src/index.ts).
 import { extractComponentDescription } from 'storybook/internal/docs-tools';
+
 import { extractArgTypes } from './extractArgTypes.ts';
 
 export const defaultPreviewParameters = {

--- a/packages/components/src/Accordion/alpine/Accordion.astro
+++ b/packages/components/src/Accordion/alpine/Accordion.astro
@@ -1,11 +1,21 @@
 ---
+/**
+ * A collapsible section list built as an Astro component with Alpine.js
+ * directives for interactivity. Props are received server-side via
+ * `Astro.props`; toggle behavior uses `x-data` and `x-show`.
+ */
 interface AccordionItem {
   title: string;
   content: string;
 }
 
 interface Props {
+  /** Sections to render. Each item has a `title` (header text) and `content` (body text). */
   items?: AccordionItem[];
+  /**
+   * When true, multiple sections can be open at the same time. When false,
+   * opening one section closes the others.
+   */
   allowMultiple?: boolean;
 }
 

--- a/packages/components/src/Accordion/alpine/Accordion.stories.js
+++ b/packages/components/src/Accordion/alpine/Accordion.stories.js
@@ -3,31 +3,6 @@ import Accordion from './Accordion.astro';
 export default {
   title: 'Alpine/Accordion',
   component: Accordion,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A collapsible section list built as an Astro component with Alpine.js directives for interactivity. Props are received server-side via `Astro.props`, toggle behavior uses `x-data` and `x-show`.',
-      },
-    },
-  },
-  argTypes: {
-    items: {
-      description: 'Sections to render. Each item has a `title` and `content`.',
-      control: 'object',
-      table: {
-        type: { summary: '{ title: string, content: string }[]' },
-        defaultValue: { summary: '[]' },
-      },
-    },
-    allowMultiple: {
-      description: 'When true, multiple sections can be open simultaneously.',
-      control: 'boolean',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-  },
 };
 
 export const Default = {

--- a/packages/components/src/Accordion/astro/Accordion.astro
+++ b/packages/components/src/Accordion/astro/Accordion.astro
@@ -1,11 +1,21 @@
 ---
+/**
+ * A collapsible section list with vanilla JS toggle behavior. Renders
+ * server-side with no framework runtime — interactivity uses an inline
+ * `<script>` tag.
+ */
 interface AccordionItem {
   title: string;
   content: string;
 }
 
 interface Props {
+  /** Sections to render. Each item has a `title` (header text) and `content` (body text). */
   items?: AccordionItem[];
+  /**
+   * When true, multiple sections can be open at the same time. When false,
+   * opening one section closes the others.
+   */
   allowMultiple?: boolean;
 }
 

--- a/packages/components/src/Button/astro/Button.astro
+++ b/packages/components/src/Button/astro/Button.astro
@@ -1,0 +1,82 @@
+---
+import type { HTMLTag, Polymorphic } from 'astro/types';
+import { VARIANT_CLASSES, type ButtonVariants } from './buttonVariants.ts';
+
+/**
+ * A polymorphic button that renders as `<button>` or `<a>` depending on `as`.
+ *
+ * This is the docgen stress case (docs/specs/docgen.md): a generic `Props`
+ * extending Astro's `Polymorphic` helper, variant props coming from a sibling
+ * module, and DOM attributes like `href` and `class` reaching the public API
+ * only through the `Astro.props` destructuring.
+ */
+interface Props<Tag extends HTMLTag = 'button' | 'a'>
+  extends Polymorphic<{ as: Tag } & ButtonVariants> {
+  /** Disables interaction and dims the control. */
+  disabled?: boolean;
+  /** Stretches the button to the full available width. */
+  fullWidth?: boolean;
+}
+
+const {
+  as: Tag = 'button',
+  variant = 'solid',
+  size = 'md',
+  disabled = false,
+  fullWidth = false,
+  href,
+  class: className,
+  ...rest
+} = Astro.props as Props;
+
+const classes = [
+  'button',
+  VARIANT_CLASSES[variant] ?? VARIANT_CLASSES.solid,
+  `button--${size}`,
+  fullWidth ? 'button--full' : '',
+  className
+]
+  .filter(Boolean)
+  .join(' ');
+
+---
+
+<Tag
+  {...rest}
+  class={classes}
+  href={Tag === 'a' ? href : undefined}
+  disabled={Tag === 'button' ? disabled || undefined : undefined}
+  aria-disabled={Tag === 'a' ? disabled || undefined : undefined}
+>
+  <slot>Button</slot>
+</Tag>
+
+<style>
+  .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border: 1px solid transparent;
+    border-radius: 0.5rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .button--sm { padding: 0.25rem 0.75rem; font-size: 0.875rem; }
+  .button--md { padding: 0.5rem 1rem; font-size: 1rem; }
+  .button--lg { padding: 0.75rem 1.5rem; font-size: 1.125rem; }
+
+  .button--solid { background: #7c3aed; color: #fff; }
+  .button--soft { background: #ede9fe; color: #5b21b6; }
+  .button--outline { background: transparent; border-color: #7c3aed; color: #7c3aed; }
+
+  .button--full { width: 100%; }
+
+  .button[disabled],
+  .button[aria-disabled='true'] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/packages/components/src/Button/astro/buttonVariants.ts
+++ b/packages/components/src/Button/astro/buttonVariants.ts
@@ -1,0 +1,20 @@
+/**
+ * Variant map for Button, kept in a sibling module on purpose.
+ *
+ * Every other component in this repo declares `Props` inline, so nothing
+ * covered cross-file type resolution — the case that breaks when the virtual
+ * TypeScript file is not placed beside the component
+ * (docs/specs/docgen.md#the-virtual-typescript-file).
+ */
+export type ButtonVariants = {
+  /** Visual treatment. */
+  variant?: 'solid' | 'soft' | 'outline';
+  /** Control size. */
+  size?: 'sm' | 'md' | 'lg';
+};
+
+export const VARIANT_CLASSES: Record<string, string> = {
+  solid: 'button--solid',
+  soft: 'button--soft',
+  outline: 'button--outline'
+};

--- a/packages/components/src/Card/astro/Card.astro
+++ b/packages/components/src/Card/astro/Card.astro
@@ -1,7 +1,14 @@
 ---
+/**
+ * A simple content card with optional highlight styling. Supports a `main`
+ * named slot for additional content below the body text.
+ */
 interface Props {
+  /** Card heading text. */
   title?: string;
+  /** Card body text. */
   content?: string;
+  /** Applies a highlighted visual style with a yellow background and border. */
   highlight?: boolean;
 }
 

--- a/packages/components/src/CodeTabs/astro/CodeTabs.astro
+++ b/packages/components/src/CodeTabs/astro/CodeTabs.astro
@@ -8,7 +8,13 @@ import AlpineCodeTabs from '../alpine/CodeTabs.astro';
 
 type Framework = 'react' | 'solid' | 'preact' | 'svelte' | 'vue' | 'alpine';
 
+/**
+ * Code snippet tabs rendered by Astro, implemented by framework components.
+ * React/Solid/Preact/Svelte/Vue are hydrated with `client:load`; Alpine uses
+ * runtime directives.
+ */
 interface Props {
+  /** Client framework implementation mounted under Astro. */
   framework?: Framework;
 }
 

--- a/packages/components/src/Decorator/GlobalWrapper.astro
+++ b/packages/components/src/Decorator/GlobalWrapper.astro
@@ -1,10 +1,18 @@
 ---
+/**
+ * An unstyled passthrough that wraps every Astro story in the demo apps,
+ * tagging the output with the active theme.
+ */
 // Global Astro decorator target (docs/specs/decorators.md#global-decorators). Installed
-// in every app's `.storybook/preview.js` global `decorators` array, so it
-// wraps EVERY Astro story in that app. Deliberately has no `<style>` block and
-// sets no classes — any visible styling here would change every Astro
-// story's rendered appearance at once, breaking Chromatic snapshots and any
-// test asserting exact markup. Keep it a plain, unstyled passthrough.
+// in every app's `.storybook/preview.js` global `decorators` array. Deliberately has
+// no `<style>` block and sets no classes — any visible styling here would change every
+// Astro story's appearance at once, breaking Chromatic snapshots and any test asserting
+// exact markup. Keep it a plain, unstyled passthrough.
+interface Props {
+  /** Theme name written to `data-theme` on the wrapper. */
+  theme?: string;
+}
+
 const { theme } = Astro.props;
 
 ---

--- a/packages/components/src/Decorator/LayoutWithSlots.astro
+++ b/packages/components/src/Decorator/LayoutWithSlots.astro
@@ -1,8 +1,10 @@
 ---
+/**
+ * A two-region layout with a default slot and a named `sidebar` slot, so a
+ * decorator can place the story in one and unrelated content in the other.
+ */
 // Named-slot decorator target (docs/specs/decorators.md#supported-decorator-shapes:
-// "Named slots are supported explicitly"). Renders both a default slot and a
-// second, named `sidebar` slot, so a decorator descriptor can place the story
-// in one and unrelated content in the other:
+// "Named slots are supported explicitly"), e.g.
 // `(Story) => ({ component: LayoutWithSlots, slots: { default: Story(), sidebar: '...' } })`.
 ---
 <div data-testid="layout-with-slots">

--- a/packages/components/src/Decorator/Wrapper.astro
+++ b/packages/components/src/Decorator/Wrapper.astro
@@ -1,8 +1,15 @@
 ---
+/**
+ * Wraps a decorated story in a labelled box, so the decorator is visible in
+ * the rendered output.
+ */
 // Component-level decorator target (docs/specs/decorators.md#supported-decorator-shapes,
-// form 1 — "Descriptor returning an Astro component"). Wraps whatever
-// the decorator places in its default slot, plus an optional label so the
-// wrapper is visually obvious in the rendered story.
+// form 1 — "Descriptor returning an Astro component").
+interface Props {
+  /** Caption shown above the wrapped story. */
+  label?: string;
+}
+
 const { label = 'Decorated' } = Astro.props;
 
 ---

--- a/packages/components/src/Footer/astro/Footer.astro
+++ b/packages/components/src/Footer/astro/Footer.astro
@@ -1,11 +1,18 @@
 ---
+/**
+ * A site footer with configurable links and license text. Responsive layout —
+ * links stack vertically on mobile and align horizontally with dot separators
+ * on desktop.
+ */
 interface FooterLink {
   label: string;
   href: string;
 }
 
 interface Props {
+  /** Footer links. Each item has a `label` and `href`. */
   links?: FooterLink[];
+  /** License notice displayed below the links. */
   licenseText?: string;
 }
 

--- a/packages/components/src/GithubContributors/astro/GithubContributors.astro
+++ b/packages/components/src/GithubContributors/astro/GithubContributors.astro
@@ -6,9 +6,16 @@ import {
   normalizeGithubRepository,
 } from '../../ProjectStats/astro/projectStatsData.ts';
 
+/**
+ * Fetches contributors on the Astro server and renders a compact avatar list
+ * with a total count.
+ */
 interface Props {
+  /** GitHub repository in `owner/name` format. */
   repository?: string;
+  /** Small label shown above the count and avatars. */
   label?: string;
+  /** Maximum number of avatars to render before showing `+X`. */
   visibleContributors?: number;
 }
 

--- a/packages/components/src/GithubContributors/astro/GithubContributors.stories.js
+++ b/packages/components/src/GithubContributors/astro/GithubContributors.stories.js
@@ -10,25 +10,6 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    docs: {
-      description: {
-        component: 'Fetches contributors on the Astro server and renders a compact avatar list with a total count.',
-      },
-    },
-  },
-  argTypes: {
-    repository: {
-      description: 'GitHub repository in `owner/name` format.',
-      control: { type: 'text' },
-    },
-    label: {
-      description: 'Small label shown above the count and avatars.',
-      control: { type: 'text' },
-    },
-    visibleContributors: {
-      description: 'Maximum number of avatars to render before showing `+X`.',
-      control: { type: 'number' },
-    },
   },
 };
 

--- a/packages/components/src/GithubStars/astro/GithubStars.astro
+++ b/packages/components/src/GithubStars/astro/GithubStars.astro
@@ -6,9 +6,16 @@ import {
   normalizeGithubRepository,
 } from '../../ProjectStats/astro/projectStatsData.ts';
 
+/**
+ * Fetches star counts on the Astro server, then hydrates a Preact component
+ * that counts from 0 to the latest value.
+ */
 interface Props {
+  /** GitHub repository in `owner/name` format. */
   repository?: string;
+  /** Small label displayed above the animated number. */
   label?: string;
+  /** Count shown when the GitHub API is unavailable or rate-limited. */
   fallbackStars?: number;
 }
 

--- a/packages/components/src/GithubStars/astro/GithubStars.stories.js
+++ b/packages/components/src/GithubStars/astro/GithubStars.stories.js
@@ -9,22 +9,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    docs: {
-      description: {
-        component: 'Fetches star counts on the Astro server, then hydrates a Preact component that counts from 0 to the latest value.',
-      },
-    },
   },
-  argTypes: {
-    repository: {
-      description: 'GitHub repository in `owner/name` format.',
-      control: { type: 'text' },
-    },
-    label: {
-      description: 'Small label displayed above the animated number.',
-      control: { type: 'text' },
-    },
-  }
 };
 
 export const Default = {

--- a/packages/components/src/Header/astro/Header.astro
+++ b/packages/components/src/Header/astro/Header.astro
@@ -1,12 +1,22 @@
 ---
+/**
+ * A responsive site header with logo, navigation links, and a mobile hamburger
+ * menu. The active link is highlighted based on `currentPath`.
+ */
 interface NavItem {
   label: string;
   href: string;
 }
 
 interface Props {
+  /** Logo text displayed in the top-left. */
   logoText?: string;
+  /** Navigation links. Each item has a `label` and `href`. */
   navItems?: NavItem[];
+  /**
+   * Current URL path used to highlight the active nav link.
+   * @default Astro.url.pathname
+   */
   currentPath?: string;
 }
 

--- a/packages/components/src/ImageText/astro/ImageText.astro
+++ b/packages/components/src/ImageText/astro/ImageText.astro
@@ -1,10 +1,18 @@
 ---
+import type { ImageMetadata } from 'astro';
 import { Image } from 'astro:assets';
 
+/**
+ * A two-column layout with an image and text content side by side. Supports
+ * reversing the order and accepts a `default` slot for the text column.
+ * Responsive — stacks vertically on mobile.
+ */
 interface Props {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  imageSrc: any;
+  /** Image source — an imported asset (ImageMetadata) or a URL string. */
+  imageSrc: ImageMetadata | string;
+  /** Alt text for the image. */
   imageAlt?: string;
+  /** Places the image on the right side instead of the left. */
   reversed?: boolean;
 }
 

--- a/packages/components/src/Nesting/Badge.astro
+++ b/packages/components/src/Nesting/Badge.astro
@@ -1,5 +1,10 @@
 ---
-// Small child component used both as slot content and as a prop in the nesting stories.
+/** A small pill label, used as both slot content and a prop in the nesting stories. */
+interface Props {
+  /** Text inside the pill. */
+  label?: string;
+}
+
 const { label = 'badge' } = Astro.props;
 
 ---

--- a/packages/components/src/Nesting/IconButton.astro
+++ b/packages/components/src/Nesting/IconButton.astro
@@ -1,5 +1,5 @@
 ---
-// Parent that renders a component passed as a prop, via `<Icon />`.
+/** A button that renders an Astro component passed as the `Icon` prop. */
 const { Icon, label = 'Click' } = Astro.props;
 
 ---

--- a/packages/components/src/Nesting/Panel.astro
+++ b/packages/components/src/Nesting/Panel.astro
@@ -1,6 +1,14 @@
 ---
-// Parent with a default slot — the issue #128 repro target. Slot content may be
-// an HTML string or another Astro component.
+/**
+ * A titled section whose default slot accepts either an HTML string or another
+ * Astro component.
+ */
+// Nesting repro target for issue #128.
+interface Props {
+  /** Heading shown above the slot content. */
+  title?: string;
+}
+
 const { title = 'Panel' } = Astro.props;
 
 ---

--- a/packages/components/src/NpmWeeklyDownloads/astro/NpmWeeklyDownloads.astro
+++ b/packages/components/src/NpmWeeklyDownloads/astro/NpmWeeklyDownloads.astro
@@ -6,8 +6,14 @@ import {
   normalizePackageName,
 } from '../../ProjectStats/astro/projectStatsData.ts';
 
+/**
+ * Fetches last-week download data in Astro and hydrates a Preact SVG chart
+ * whose line draws itself on load.
+ */
 interface Props {
+  /** npm package name used in the weekly downloads API request. */
   packageName?: string;
+  /** Small label shown at the top of the chart card. */
   label?: string;
 }
 

--- a/packages/components/src/NpmWeeklyDownloads/astro/NpmWeeklyDownloads.stories.js
+++ b/packages/components/src/NpmWeeklyDownloads/astro/NpmWeeklyDownloads.stories.js
@@ -9,21 +9,6 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    docs: {
-      description: {
-        component: 'Fetches last-week download data in Astro and hydrates a Preact SVG chart whose line draws itself on load.',
-      },
-    },
-  },
-  argTypes: {
-    packageName: {
-      description: 'npm package name used in the weekly downloads API request.',
-      control: { type: 'text' },
-    },
-    label: {
-      description: 'Small label shown at the top of the chart card.',
-      control: { type: 'text' },
-    },
   },
 };
 

--- a/packages/components/src/PageCard/astro/PageCard.astro
+++ b/packages/components/src/PageCard/astro/PageCard.astro
@@ -1,21 +1,25 @@
 ---
 /**
- * PageCard — a composite component that nests Card.astro and renders an image
- * using astro:assets <Image>. Used in integration tests to verify that:
+ * A composite card that nests Card.astro and renders an image with
+ * astro:assets `<Image>`.
  *
- * 1. Template nesting (using another .astro component) renders correctly via
- *    the Astro Container API.
- * 2. astro:assets <Image> works with an ImageMetadata prop, rendered via the
- *    inline passthrough image service injected by the Storybook middleware.
+ * Exercises three things at once in the integration Storybooks: template
+ * nesting through the Astro Container API, `<Image>` with an ImageMetadata
+ * prop via the passthrough image service the Storybook middleware injects,
+ * and the nested Card's scoped styles reaching the browser (issue #114).
  */
 import type { ImageMetadata } from 'astro';
 import { Image } from 'astro:assets';
 import Card from '../../Card/astro/Card.astro';
 
 interface Props {
+  /** Heading passed through to the nested Card. */
   title: string;
+  /** Body text passed through to the nested Card. */
   content?: string;
+  /** Image source — an imported asset (ImageMetadata) or a URL string. */
   imageSrc: ImageMetadata | string;
+  /** Alt text for the image. */
   imageAlt?: string;
 }
 

--- a/packages/components/src/ThemeProvider/astro/ThemeProvider.astro
+++ b/packages/components/src/ThemeProvider/astro/ThemeProvider.astro
@@ -1,5 +1,5 @@
 ---
-// Force light theme — prevents Starlight from switching to dark mode.
+/** Pins the document to the light theme, stopping Starlight switching to dark. */
 ---
 <script is:inline>
 	document.documentElement.dataset.theme = 'light';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4743,6 +4743,7 @@ __metadata:
     sanitize-html: "npm:^2.17.0"
     storybook-solidjs: "npm:^1.0.0-beta.7"
     tsup: "npm:^8.5.1"
+    typescript: "npm:^5.8.3"
     vite: "npm:^6.4.1 || ^7.0.0 || ^8.0.0"
     vite-plugin-solid: "npm:^2.11.10"
     vitest: "npm:^4.1.9"
@@ -4764,6 +4765,7 @@ __metadata:
     astro: ^5.5.3 || ^6.0.0 || ^7.0.0
     storybook: ^10.0.0
     storybook-solidjs: ^1.0.0-beta.7
+    typescript: ^5.0.0 || ^6.0.0
     vite: ^6.4.1 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     "@astrojs/alpinejs":
@@ -4795,6 +4797,8 @@ __metadata:
     "@vitejs/plugin-vue-jsx":
       optional: true
     storybook-solidjs:
+      optional: true
+    typescript:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Closes #163. Fixes #110.

Component descriptions and props tables are now generated from the JSDoc in a component's `.astro` frontmatter, so autodocs pages populate without any `argTypes` boilerplate in story files.

```astro
---
/** A simple content card with optional highlight styling. */
interface Props {
  /** Card heading text. */
  title?: string;
  /** Applies a highlighted visual style. */
  highlight?: boolean;
}

const { title = 'Default title', highlight = false } = Astro.props;
---
```

The story file is now just `component: Card`.

Design record: [`docs/specs/docgen.md`](docs/specs/docgen.md).

## Why the legacy path, not the Docgen Server

Storybook's [Docgen Server RFC](https://github.com/storybookjs/storybook/discussions/35333) is the newer pattern, and the spec evaluates it in full. It isn't what ships here, for two reasons:

- It needs Storybook 10.5+ **and** `features.experimentalDocgenServer`, against a `storybook: ^10.0.0` peer range. Shipping only that path would mean most users see no change.
- The helpers Vue and Angular lean on — `createMetaComponentResolver`, `createLazyDocgenMiddleware` — **do not exist in 10.5.2**; they landed during 10.6-alpha. The provider types and preset key do exist, but building against them today means hand-rolling both and deleting them later.

The extractor is deliberately shaped so the server provider is a thin wrapper over the same code when a 10.6 floor is reasonable. Tracked as a follow-up.

## What the extractor handles

Benchmarked and probed against the repo's own `astro@6.4.8` rather than assumed. On the `Button` shape from #110 — a generic `Props` extending `Polymorphic`, variants from a sibling module, `href`/`class` reaching the API only through destructuring:

```
description: "A polymorphic button that renders as <button> or <a> depending on `as`."
variant:   enum ["solid", "soft", "outline"] = "solid"
size:      enum ["sm", "md", "lg"] = "md"
as:        enum ["a", "button"] = "button"
disabled:  boolean = false     // Disables interaction and dims the control.
fullWidth: boolean = false     // Stretches the button to the full available width.
class:     string
href:      string | URL
```

That component previously extracted **three** props, and ~200 with no filtering. Four things had to be right:

- **`interface Props<T> extends Polymorphic<…>` is a hard TS2312.** TypeScript drops the entire base type, so `as`, `variant`, `size` and `href` all vanish. The declaration is rewritten to a type alias in the virtual file when that diagnostic fires — 0 diagnostics and 199 properties afterwards. Gated on the diagnostic, not on an empty result: a rejected clause still leaves the inline members, so the naive check sees `disabled` alone and reports success.
- **`keyof (A | B)` is the intersection of keys**, so `Props<'a' | 'button'>` silently loses `href`. Each constituent is probed and merged, with the default instantiation first so shared props keep their full type.
- **The virtual TypeScript file sits beside the component.** Naming it rootless resolves `./types` against the process cwd, and the failure is invisible — the error type still stringifies to the written type name while carrying no members, so the table comes out plausible and empty. This is very likely a root cause of #110.
- **The prop filter keeps anything destructured from `Astro.props`**, and drops a prop only when *every* declaration is under `node_modules`. Filtering on the first declaration deletes locally-redeclared props like `disabled`; filtering on `prop.parent` deletes CVA-style variant props, which have no declaring type at all.

## Performance

A single `ts.createProgram` pulls in 243 source files. The prior art creates one per component, and the legacy path runs inside a Vite `transform` on the dev server's critical path:

| Strategy | first component | each subsequent |
|---|---|---|
| Program per file | 358 ms | 190–711 ms |
| Shared `LanguageService` + `DocumentRegistry` | ~0.9 s once | 0–1.4 ms |

The service is warmed from `buildStart` without awaiting, so that one-time cost overlaps Storybook's boot rather than the first story request.

## Integration environments

The workaround had to go, or the feature would be invisible — `combineParameters` lets an author's `argTypes` win over extracted ones. Ten components gained frontmatter JSDoc and every Astro story's `argTypes` and `docs.description.component` were deleted across all three apps.

Two of those blocks had already drifted: `Footer` documented a `links` default of *"Storybook feature request, framework docs, Container API"* against seven different links, and `Header` documented *"About, Contribute, Sample Components, Storybook Demo"* against a nav reading Docs, Contribute, Storybook Demo, GitHub. Generating from source removes that failure mode.

Also adds a polymorphic `Button` fixture — nothing in the repo covered type inheritance, generics, or a `Props` imported from another file before this.

## Verification

- 261 framework tests, full suite green, lint and `yarn lint:links` clean.
- Static builds of `integration/astro5`, `astro6` and `astro7` (including Astro 7's Rust compiler): every description and prop description in those docs pages comes from the component, and no `__docgenInfo` carries an absolute path.

Three bugs the real build caught that unit tests didn't, each now covered:

- Optional literal unions weren't becoming select controls — under `strict` the type includes `undefined`, which failed the all-literals check. Only visible once docgen ran against a project tsconfig.
- Absolute home-directory paths were shipping in the preview bundle. Paths are now project-relative, dependency types read from `node_modules/` onward, and `declarations` is dropped entirely since only the server-side filter reads it.
- The description precedence rejected any leading block attached to an import — but Astro puts imports first, so it dropped descriptions from exactly the components that had them, `PageCard` included.

## Notes

- `typescript` becomes an **optional** peer dependency, loaded through a guarded dynamic import. Without it docgen is skipped with one warning and everything else keeps working.
- Extraction is skipped when the docs addon is absent, under `build.test.disableDocgen`, and when `docgen: false` is set.
- The extraction cache is in-memory only, so a cold restart re-runs a type check per component. Recorded as a known gap.
- Prior art credit: [`astro-docgen-typescript`](https://github.com/SalahAdDin/astro-docgen-typescript) by @SalahAdDin established the virtual-source-file technique and the output shape. Reimplemented rather than depended on — it is unpublished, and four of its behaviours needed to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
