### PR TITLE
feat: support the Storybook Test addon on Astro 5, 6 and 7 (#159)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,18 @@ jobs:
         run: yarn workspace @storybook-astro/integration-astro5 test:browser
         env:
           STORYBOOK_DISABLE_TELEMETRY: 1
+
+      - name: Storybook Test addon (Astro 7)
+        run: yarn workspace @storybook-astro/integration-astro7 test:storybook
+        env:
+          STORYBOOK_DISABLE_TELEMETRY: 1
+
+      - name: Storybook Test addon (Astro 6)
+        run: yarn workspace @storybook-astro/integration-astro6 test:storybook
+        env:
+          STORYBOOK_DISABLE_TELEMETRY: 1
+
+      - name: Storybook Test addon (Astro 5)
+        run: yarn workspace @storybook-astro/integration-astro5 test:storybook
+        env:
+          STORYBOOK_DISABLE_TELEMETRY: 1

--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -91,26 +91,6 @@ A dedicated "Astro" panel tab in the Storybook UI (alongside Actions, Controls, 
 
 The render time and HTML string are already available when `renderAstroComponent` resolves in `render.tsx` — this is mostly about emitting them over the addon channel rather than discarding them.
 
-### Automatic Documentation Extraction from JSDoc
-
-✅ **Done**
-
-Component descriptions and prop documentation are extracted from JSDoc in a
-component's `.astro` frontmatter, so autodocs pages populate without any
-`argTypes` boilerplate in story files.
-
-**Tracking**: [Issue #163](https://github.com/storybook-astro/storybook-astro/issues/163), [Issue #110](https://github.com/storybook-astro/storybook-astro/issues/110)
-
-**What you get**:
-- Component description from a JSDoc block in the frontmatter
-- Per-prop descriptions, types and defaults in the properties table
-- Select controls for literal union props
-- Inherited DOM attributes filtered out, while props you destructure are kept
-- Types imported from other files, including through tsconfig `paths` aliases
-
-See [Controls & ArgTypes](/writing-stories/controls/) for the conventions and the
-`docgen` framework option.
-
 ## Future Enhancements
 
 ### Render Performance
@@ -158,6 +138,16 @@ Integration with Astro's middleware system and `astro:env` module for managing e
 Support for Astro's built-in i18n routing and helpers, enabling documentation of multi-language components.
 
 ## Recently Completed
+
+### Automatic Documentation Extraction from JSDoc
+
+**Status**: Shipped (unreleased)
+
+Component descriptions and prop documentation are extracted from JSDoc in a component's `.astro` frontmatter, so autodocs pages populate without any `argTypes` boilerplate in story files. Covers per-prop descriptions, types and defaults, select controls for literal union props, and types imported from other files (including through tsconfig `paths` aliases). Inherited DOM attributes are filtered out, while props you destructure are kept.
+
+**Tracking**: [Issue #163](https://github.com/storybook-astro/storybook-astro/issues/163), [Issue #110](https://github.com/storybook-astro/storybook-astro/issues/110)
+
+**Documentation**: See [Controls & ArgTypes](/writing-stories/controls/) for the conventions and the `docgen` framework option, and the [design record](https://github.com/storybook-astro/storybook-astro/blob/develop/docs/specs/docgen.md)
 
 ### Storybook Test Addon (`@storybook/addon-vitest`) Support
 
@@ -300,7 +290,7 @@ This table tracks compatibility of Storybook's built-in features when used with 
 | Backgrounds | ✅ Supported | Test components against different background colors |
 | Measure & Outline | ✅ Supported | Visual debugging tools for spacing and layout |
 | Component Description | 🚧 Manual | Component descriptions must be set manually via `parameters.docs.description.component` (automatic extraction from JSDoc planned) |
-| ArgTypes Documentation | 🚧 Manual | Prop documentation must be set manually via `argTypes[].description` (automatic extraction from JSDoc planned) |
+| ArgTypes Documentation | ✅ Supported | Descriptions, types and defaults are extracted from `.astro` frontmatter JSDoc; `argTypes[].description` still overrides. See [Controls & ArgTypes](/writing-stories/controls/) |
 | Source Code Display | 🚧 Partial | Shows story file source; doesn't generate component usage syntax (e.g. `<Component prop="value" />`). See roadmap item above |
 | Decorators | ✅ Supported | Wrapper components/HTML for stories, in global/component/story positions. See [Decorators guide](/writing-stories/decorators/) and [design record](https://github.com/storybook-astro/storybook-astro/blob/develop/docs/specs/decorators.md) |
 | Portable Stories | ✅ Supported | `composeStories`, `composeStory`, `setProjectAnnotations` for testing |

--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -37,16 +37,6 @@ Expand testing capabilities for Astro components tested in isolation, including 
 - Integration with testing libraries (Testing Library, Vitest patterns)
 - Guidance on testing both server-rendered and client-side behavior
 
-### Storybook Test Addon (`@storybook/addon-vitest`) Support
-
-✅ **Supported** — Astro 5, 6 and 7
-
-Storybook's official "Storybook Test" runner (`@storybook/addon-vitest`) runs your stories as Vitest browser tests. Astro component stories render through the same server-side pipeline the canvas uses, and play functions run against the resulting DOM. See the [Testing guide](/guides/testing/) for setup.
-
-**On the upstream Astro bug**: This feature was previously listed as blocked by [withastro/astro#16275](https://github.com/withastro/astro/issues/16275) (`TypeError: Cannot read properties of undefined (reading 'wrapDynamicImport')`), and then as gated on the `astro@7.0.6` fix. Neither is accurate for Storybook Astro. The crash comes from Astro's `astro:server` Vite plugin booting dev-server middleware inside Vitest, and Storybook Astro already strips that plugin from the Storybook Vite config. Astro 5 and 6 — which never received the fix — work here too, and no version guard is needed.
-
-**Known limitation**: `@storybook/addon-vitest` resolves each `stories` entry against your `.storybook` directory, so an absolute story glob matches nothing and those stories are silently untested. Keep story globs relative — see [Story globs must be relative](/guides/testing/#story-globs-must-be-relative).
-
 ### Play Functions for Astro Components
 
 🚧 **Partial** — works under the Storybook Test addon; unverified in the canvas
@@ -168,6 +158,18 @@ Integration with Astro's middleware system and `astro:env` module for managing e
 Support for Astro's built-in i18n routing and helpers, enabling documentation of multi-language components.
 
 ## Recently Completed
+
+### Storybook Test Addon (`@storybook/addon-vitest`) Support
+
+**Status**: Shipped (unreleased)
+
+Storybook's official "Storybook Test" runner (`@storybook/addon-vitest`) runs your stories as Vitest browser tests on **Astro 5, 6 and 7**. Astro component stories render through the same server-side pipeline the canvas uses, and play functions run against the resulting DOM.
+
+This was previously listed as blocked by [withastro/astro#16275](https://github.com/withastro/astro/issues/16275) and then as gated on the `astro@7.0.6` fix. Neither turned out to be accurate for Storybook Astro: the crash comes from Astro's `astro:server` Vite plugin, which Storybook Astro already strips from the Storybook Vite config, so Astro 5 and 6 work too and no version guard is needed.
+
+**Known limitation**: `@storybook/addon-vitest` resolves each `stories` entry against your `.storybook` directory, so an absolute story glob matches nothing and those stories are silently untested. Keep story globs relative — see [Story globs must be relative](/guides/testing/#story-globs-must-be-relative).
+
+**Documentation**: See the [Testing guide](/guides/testing/#storybook-test-addon-storybookaddon-vitest)
 
 ### Decorator Support
 

--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -39,39 +39,27 @@ Expand testing capabilities for Astro components tested in isolation, including 
 
 ### Storybook Test Addon (`@storybook/addon-vitest`) Support
 
-🚧 **Partially Unblocked** — Astro 7.0.6+ only
+✅ **Supported** — Astro 5, 6 and 7
 
-Storybook's official "Storybook Test" runner (`@storybook/addon-vitest`) runs stories as Vitest browser tests. It previously crashed when combined with Astro's `getViteConfig` — this was an upstream Astro bug, not a storybook-astro issue.
+Storybook's official "Storybook Test" runner (`@storybook/addon-vitest`) runs your stories as Vitest browser tests. Astro component stories render through the same server-side pipeline the canvas uses, and play functions run against the resulting DOM. See the [Testing guide](/guides/testing/) for setup.
 
-**Complexity**: Unknown — depends on what surfaces during verification
-**Tracking**: [withastro/astro#16275](https://github.com/withastro/astro/issues/16275) — fixed via [PR #17248](https://github.com/withastro/astro/pull/17248), merged and released in `astro@7.0.6`
+**On the upstream Astro bug**: This feature was previously listed as blocked by [withastro/astro#16275](https://github.com/withastro/astro/issues/16275) (`TypeError: Cannot read properties of undefined (reading 'wrapDynamicImport')`), and then as gated on the `astro@7.0.6` fix. Neither is accurate for Storybook Astro. The crash comes from Astro's `astro:server` Vite plugin booting dev-server middleware inside Vitest, and Storybook Astro already strips that plugin from the Storybook Vite config. Astro 5 and 6 — which never received the fix — work here too, and no version guard is needed.
 
-**What was blocking it**: Vitest's browser-mode module evaluator doesn't implement `wrapDynamicImport`, and Astro's `configureServer` hook unconditionally booted dev-server middleware even inside Vitest, causing `TypeError: Cannot read properties of undefined (reading 'wrapDynamicImport')`.
-
-**Astro 5 / 6 are not fixed**: The fix is absent from every `astro@5.x` and `astro@6.x` release — the last published versions on those lines (`5.18.2`, `6.4.8`) predate the fix merge, and neither line has shipped since. Since Storybook Astro supports Astro 5.5.3+, 6.x, and 7.x uniformly, this feature is version-gated by an upstream constraint outside our control. Astro 5/6 users hitting this today still get the raw `wrapDynamicImport` crash.
-
-**What this requires now that it's unblocked (for Astro 7.0.6+)**:
-- A runtime version guard that detects Astro <7.0.6 and surfaces a clear error ("requires Astro 7.0.6+; use `composeStories` on Astro 5/6") instead of the cryptic crash
-- Verifying `@storybook/addon-vitest`'s browser-mode test runner actually renders Astro components correctly through storybook-astro's SSR pipeline on Astro 7 (this is untested — distinct from the portable-stories/`composeStories` testing API, which already works on all supported majors)
-- Documentation covering setup and the Astro 7.0.6+ requirement alongside the existing Testing guide, pointing Astro 5/6 users to `composeStories` as the supported alternative
+**Known limitation**: `@storybook/addon-vitest` resolves each `stories` entry against your `.storybook` directory, so an absolute story glob matches nothing and those stories are silently untested. Keep story globs relative — see [Story globs must be relative](/guides/testing/#story-globs-must-be-relative).
 
 ### Play Functions for Astro Components
 
-📋 **To Do**
+🚧 **Partial** — works under the Storybook Test addon; unverified in the canvas
 
-Enable Storybook's [play functions](https://storybook.js.org/docs/writing-stories/play-function) for Astro component stories. Astro components are server-rendered to static HTML, which is a valid target for DOM interaction testing — play functions could drive `@testing-library/user-event` queries and assertions against that output the same way they do for React and Vue stories today.
+Play functions on Astro component stories **do** run under [`@storybook/addon-vitest`](/guides/testing/#storybook-test-addon-storybookaddon-vitest): `@testing-library/user-event` interactions and assertions resolve against the server-rendered HTML, on Astro 5, 6 and 7. The `Counter` and `Accordion` stories in the integration apps cover this.
 
-**Complexity**: Medium
-**Tracking**: See the existing [Play Functions support entry](#storybook-features) — currently framework components only.
+What has *not* been verified is the same story running in the Storybook UI — the canvas and the Interactions panel. Both paths go through the renderer's `renderToCanvas`, so this is likely to work already, but until someone checks it this entry stays partial rather than supported.
 
-**What this enables**:
-- Writing interaction tests directly in story files for Astro components
-- Using the Interactions panel to step through and debug story interactions
-- Parity with framework component play function support
+**Complexity**: Low — most likely verification and documentation rather than new code
 
-**What this requires**:
-- Wiring the play function execution lifecycle to run after the server-rendered HTML is injected into the canvas
-- Ensuring `@testing-library/dom` queries resolve against the injected HTML
+**What this still requires**:
+- Confirming play functions execute in the dev canvas after the server-rendered HTML is injected
+- Confirming the Interactions panel steps through them
 - Handling re-renders with new args (Controls changes) between play function runs
 
 ### Code Panel Source for Astro Components
@@ -315,8 +303,8 @@ This table tracks compatibility of Storybook's built-in features when used with 
 | Decorators | ✅ Supported | Wrapper components/HTML for stories, in global/component/story positions. See [Decorators guide](/writing-stories/decorators/) and [design record](https://github.com/storybook-astro/storybook-astro/blob/develop/docs/specs/decorators.md) |
 | Portable Stories | ✅ Supported | `composeStories`, `composeStory`, `setProjectAnnotations` for testing |
 | Portable Stories Testing (Vitest) | ✅ Supported | Test stories with `@storybook-astro/framework/testing`'s `composeStories`/`renderStory` and Vitest, outside Storybook |
-| Storybook Test Addon (`@storybook/addon-vitest`) | 🚧 Partial | Runs stories as Vitest browser tests. Upstream Astro bug fixed for Astro 7.0.6+ only; Astro 5/6 remain blocked — see roadmap item above |
-| Play Functions | 🚧 Partial | Supported for framework components. Astro component support planned — see roadmap item above |
+| Storybook Test Addon (`@storybook/addon-vitest`) | ✅ Supported | Runs stories as Vitest browser tests on Astro 5, 6 and 7. See the [Testing guide](/guides/testing/) |
+| Play Functions | 🚧 Partial | Supported for framework components. Astro components: verified under the Storybook Test addon, unverified in the canvas — see roadmap item above |
 | Interactions Panel | ✅ Supported | Debug play function interactions |
 | Accessibility Addon | ✅ Supported | Automated accessibility testing with a11y addon |
 | Theming | ✅ Supported | Storybook UI theming and customization |

--- a/apps/website/src/content/docs/guides/testing.md
+++ b/apps/website/src/content/docs/guides/testing.md
@@ -64,3 +64,96 @@ From `@storybook-astro/framework/testing`:
 - `composeStory(story, componentAnnotations, projectAnnotations?, exportsName?)`
 - `setProjectAnnotations(annotations)`
 - `renderStory(story)`
+
+## Storybook Test addon (`@storybook/addon-vitest`)
+
+Storybook's official test runner turns every story into a Vitest browser test — no
+test file to write. It works with Astro components on **Astro 5, 6 and 7**: each
+story is rendered through the same server-side pipeline the Storybook canvas
+uses, and any [play function](https://storybook.js.org/docs/writing-stories/play-function)
+runs against the resulting DOM.
+
+### Setup
+
+Install the addon and Vitest's browser mode:
+
+```bash
+npm install --save-dev @storybook/addon-vitest vitest @vitest/browser @vitest/browser-playwright playwright
+npx playwright install chromium
+```
+
+Register the addon in `.storybook/main.js`:
+
+```javascript
+const config = {
+  addons: ['@storybook/addon-docs', '@storybook/addon-vitest'],
+  // ...
+};
+```
+
+Then add a dedicated Vitest config:
+
+```typescript
+// vitest.storybook.config.ts
+import { defineConfig } from 'vitest/config';
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import { playwright } from '@vitest/browser-playwright';
+
+export default defineConfig({
+  plugins: [storybookTest({ configDir: '.storybook' })],
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: 'chromium' }]
+    }
+  }
+});
+```
+
+```bash
+npx vitest --config vitest.storybook.config.ts --run
+```
+
+### Keep it separate from your portable-stories config
+
+Use a **separate config file** from the `vitest.config.ts` described above, and
+give it no `setupFiles`. Two reasons:
+
+- `storybookTest` replaces `test.include` with your story globs, so merging the
+  two configs silently drops your existing `*.test.ts` suite.
+- `storybookTest` already applies this framework's Vite configuration, which
+  merges your Astro config. Do **not** wrap it in `defineConfig` from
+  `@storybook-astro/framework/vitest` — that layer is for the portable-stories
+  API and would apply the Astro config a second time.
+- The addon supplies Storybook's project annotations itself. A setup file
+  calling `setProjectAnnotations`, or installing a `happy-dom` window, conflicts
+  with the real browser environment.
+
+### Story globs must be relative
+
+`@storybook/addon-vitest` resolves each `stories` entry against your config
+directory, so an **absolute** path silently matches nothing and those stories are
+never tested. If you pull stories out of another package, make the glob relative:
+
+```javascript
+import { fileURLToPath } from 'node:url';
+import { dirname, relative } from 'node:path';
+
+function relativeToConfig(pkg) {
+  const pkgDir = dirname(fileURLToPath(import.meta.resolve(`${pkg}/package.json`)));
+
+  return relative(dirname(fileURLToPath(import.meta.url)), pkgDir);
+}
+
+const config = {
+  stories: [
+    '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    relativeToConfig('@my/components') + '/src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
+  ]
+};
+```
+
+Stories in `.mdx` files are documentation-only and produce no tests, so they are
+reported as skipped.

--- a/apps/website/src/content/docs/guides/troubleshooting.md
+++ b/apps/website/src/content/docs/guides/troubleshooting.md
@@ -276,6 +276,30 @@ rm -rf node_modules package-lock.json
 npm install
 ```
 
+### Storybook Test addon: "Vitest failed to find the current suite"
+
+**Symptom:** Running stories through `@storybook/addon-vitest` fails to collect
+tests, sometimes alongside `Failed to run dependency scan. Skipping dependency
+pre-bundling` or a `TypeError: Illegal invocation` from `userEvent`.
+
+**Cause:** Vite could not pre-bundle a dependency up front, so it discovered one
+mid-run and reloaded the test page during collection.
+
+**Fix:** Upgrade to a Storybook Astro version that teaches Vite's dependency
+scanner to read `.astro` files. If it persists, a dependency of your own is being
+discovered late — add it to `optimizeDeps.include` in your Vitest config and
+open an issue so it can be handled by default.
+
+### Storybook Test addon: some stories are never tested
+
+**Symptom:** The run passes, but stories from another package never appear.
+
+**Cause:** `@storybook/addon-vitest` resolves each `stories` entry against your
+`.storybook` directory, so an absolute path silently matches nothing.
+
+**Fix:** Make the glob relative — see
+[Story globs must be relative](/guides/testing/#story-globs-must-be-relative).
+
 ---
 
 ## Known Limitations

--- a/integration/astro5/.storybook/main.js
+++ b/integration/astro5/.storybook/main.js
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { dirname, relative } from 'node:path';
 // This file has been automatically migrated to valid ESM format by Storybook.
 import {
   react,
@@ -15,10 +15,14 @@ const config = {
   stories: [
     '../src/**/*.mdx',
     '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
-    getAbsolutePath('@storybook-astro/components') + '/src/*.mdx',
-    getAbsolutePath('@storybook-astro/components') + '/src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
+    relativeToConfig('@storybook-astro/components') + '/src/*.mdx',
+    relativeToConfig('@storybook-astro/components') + '/src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
   ],
-  addons: [getAbsolutePath('@chromatic-com/storybook'), getAbsolutePath('@storybook/addon-docs')],
+  addons: [
+    getAbsolutePath('@chromatic-com/storybook'),
+    getAbsolutePath('@storybook/addon-docs'),
+    getAbsolutePath('@storybook/addon-vitest')
+  ],
   framework: {
     name: '@storybook-astro/framework',
     options: {
@@ -49,4 +53,13 @@ export default config;
 function getAbsolutePath(value) {
   // eslint-disable-next-line n/no-unsupported-features/node-builtins
   return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));
+}
+
+// `@storybook/addon-vitest` builds its test globs with `join(configDir, ...)`,
+// which mangles an absolute story path into `.storybook/Users/...` and silently
+// matches nothing. Resolving the package the portable way and then making the
+// result relative to this config dir keeps both Storybook and the test runner
+// pointed at the same files.
+function relativeToConfig(value) {
+  return relative(dirname(fileURLToPath(import.meta.url)), getAbsolutePath(value));
 }

--- a/integration/astro5/package.json
+++ b/integration/astro5/package.json
@@ -52,7 +52,6 @@
     "happy-dom": "^20.10.6",
     "http-server": "^14.1.1",
     "msw": "^2.12.10",
-    "playwright": "^1.49.0",
     "prop-types": "^15.8.1",
     "solid-js": "^1.9.10",
     "storybook": "10.5.2",

--- a/integration/astro5/package.json
+++ b/integration/astro5/package.json
@@ -9,7 +9,8 @@
     "serve": "http-server storybook-static -p 6007 -s",
     "test": "vitest",
     "test:browser": "playwright test",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:storybook": "vitest --config vitest.storybook.config.ts --run"
   },
   "dependencies": {
     "@astrojs/alpinejs": "^0.4.5",
@@ -44,11 +45,14 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/prop-types": "^15.7.14",
+    "@vitest/browser": "4.1.9",
+    "@vitest/browser-playwright": "4.1.9",
     "@vitest/ui": "^4.1.9",
     "eslint": "^9.39.2",
     "happy-dom": "^20.10.6",
     "http-server": "^14.1.1",
     "msw": "^2.12.10",
+    "playwright": "^1.49.0",
     "prop-types": "^15.8.1",
     "solid-js": "^1.9.10",
     "storybook": "10.5.2",

--- a/integration/astro5/vitest.storybook.config.ts
+++ b/integration/astro5/vitest.storybook.config.ts
@@ -1,0 +1,25 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import { playwright } from '@vitest/browser-playwright';
+
+// Deliberately NOT using `defineConfig` from '@storybook-astro/framework/vitest':
+// `storybookTest` applies the framework's `viteFinal`, which already merges the
+// Astro Vite config. Layering our own `getViteConfig` wrapper on top would
+// duplicate every Astro plugin and re-introduce `astro:server`.
+//
+// No `setupFiles` either — addon-vitest provides the project annotations itself,
+// and this app's existing setup file installs a happy-dom `window`, which would
+// clobber the real one in browser mode.
+export default defineConfig({
+  plugins: [storybookTest({ configDir: '.storybook' })],
+  test: {
+    name: 'astro5-storybook',
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: 'chromium' }]
+    }
+  }
+});

--- a/integration/astro6/.storybook/main.js
+++ b/integration/astro6/.storybook/main.js
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { dirname, relative } from 'node:path';
 // This file has been automatically migrated to valid ESM format by Storybook.
 import {
   react,
@@ -15,10 +15,14 @@ const config = {
   stories: [
     '../src/**/*.mdx',
     '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
-    getAbsolutePath('@storybook-astro/components') + '/src/*.mdx',
-    getAbsolutePath('@storybook-astro/components') + '/src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
+    relativeToConfig('@storybook-astro/components') + '/src/*.mdx',
+    relativeToConfig('@storybook-astro/components') + '/src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
   ],
-  addons: [getAbsolutePath('@chromatic-com/storybook'), getAbsolutePath('@storybook/addon-docs')],
+  addons: [
+    getAbsolutePath('@chromatic-com/storybook'),
+    getAbsolutePath('@storybook/addon-docs'),
+    getAbsolutePath('@storybook/addon-vitest')
+  ],
   framework: {
     name: '@storybook-astro/framework',
     options: {
@@ -49,4 +53,13 @@ export default config;
 function getAbsolutePath(value) {
   // eslint-disable-next-line n/no-unsupported-features/node-builtins
   return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));
+}
+
+// `@storybook/addon-vitest` builds its test globs with `join(configDir, ...)`,
+// which mangles an absolute story path into `.storybook/Users/...` and silently
+// matches nothing. Resolving the package the portable way and then making the
+// result relative to this config dir keeps both Storybook and the test runner
+// pointed at the same files.
+function relativeToConfig(value) {
+  return relative(dirname(fileURLToPath(import.meta.url)), getAbsolutePath(value));
 }

--- a/integration/astro6/package.json
+++ b/integration/astro6/package.json
@@ -51,7 +51,6 @@
     "happy-dom": "^20.10.6",
     "http-server": "^14.1.1",
     "msw": "^2.12.10",
-    "playwright": "^1.49.0",
     "prop-types": "^15.8.1",
     "solid-js": "^1.9.10",
     "storybook": "10.5.2",

--- a/integration/astro6/package.json
+++ b/integration/astro6/package.json
@@ -9,7 +9,8 @@
     "serve": "http-server storybook-static -p 6006 -s",
     "test": "vitest",
     "test:browser": "playwright test",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:storybook": "vitest --config vitest.storybook.config.ts --run"
   },
   "dependencies": {
     "@astrojs/alpinejs": "0.5.0",
@@ -43,11 +44,14 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@types/prop-types": "^15.7.14",
+    "@vitest/browser": "4.1.9",
+    "@vitest/browser-playwright": "4.1.9",
     "@vitest/ui": "^4.1.9",
     "eslint": "^9.39.2",
     "happy-dom": "^20.10.6",
     "http-server": "^14.1.1",
     "msw": "^2.12.10",
+    "playwright": "^1.49.0",
     "prop-types": "^15.8.1",
     "solid-js": "^1.9.10",
     "storybook": "10.5.2",

--- a/integration/astro6/vitest.storybook.config.ts
+++ b/integration/astro6/vitest.storybook.config.ts
@@ -1,0 +1,25 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import { playwright } from '@vitest/browser-playwright';
+
+// Deliberately NOT using `defineConfig` from '@storybook-astro/framework/vitest':
+// `storybookTest` applies the framework's `viteFinal`, which already merges the
+// Astro Vite config. Layering our own `getViteConfig` wrapper on top would
+// duplicate every Astro plugin and re-introduce `astro:server`.
+//
+// No `setupFiles` either — addon-vitest provides the project annotations itself,
+// and this app's existing setup file installs a happy-dom `window`, which would
+// clobber the real one in browser mode.
+export default defineConfig({
+  plugins: [storybookTest({ configDir: '.storybook' })],
+  test: {
+    name: 'astro6-storybook',
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: 'chromium' }]
+    }
+  }
+});

--- a/integration/astro7/.storybook/main.js
+++ b/integration/astro7/.storybook/main.js
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { dirname, relative } from 'node:path';
 // This file has been automatically migrated to valid ESM format by Storybook.
 import {
   react,
@@ -15,10 +15,14 @@ const config = {
   stories: [
     '../src/**/*.mdx',
     '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
-    getAbsolutePath('@storybook-astro/components') + '/src/*.mdx',
-    getAbsolutePath('@storybook-astro/components') + '/src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
+    relativeToConfig('@storybook-astro/components') + '/src/*.mdx',
+    relativeToConfig('@storybook-astro/components') + '/src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
   ],
-  addons: [getAbsolutePath('@chromatic-com/storybook'), getAbsolutePath('@storybook/addon-docs')],
+  addons: [
+    getAbsolutePath('@chromatic-com/storybook'),
+    getAbsolutePath('@storybook/addon-docs'),
+    getAbsolutePath('@storybook/addon-vitest')
+  ],
   framework: {
     name: '@storybook-astro/framework',
     options: {
@@ -49,4 +53,13 @@ export default config;
 function getAbsolutePath(value) {
   // eslint-disable-next-line n/no-unsupported-features/node-builtins
   return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));
+}
+
+// `@storybook/addon-vitest` builds its test globs with `join(configDir, ...)`,
+// which mangles an absolute story path into `.storybook/Users/...` and silently
+// matches nothing. Resolving the package the portable way and then making the
+// result relative to this config dir keeps both Storybook and the test runner
+// pointed at the same files.
+function relativeToConfig(value) {
+  return relative(dirname(fileURLToPath(import.meta.url)), getAbsolutePath(value));
 }

--- a/integration/astro7/package.json
+++ b/integration/astro7/package.json
@@ -51,7 +51,6 @@
     "happy-dom": "^20.10.6",
     "http-server": "^14.1.1",
     "msw": "^2.12.10",
-    "playwright": "^1.49.0",
     "prop-types": "^15.8.1",
     "solid-js": "^1.9.10",
     "storybook": "10.5.2",

--- a/integration/astro7/package.json
+++ b/integration/astro7/package.json
@@ -9,7 +9,8 @@
     "serve": "http-server storybook-static -p 6008 -s",
     "test": "vitest",
     "test:browser": "playwright test",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:storybook": "vitest --config vitest.storybook.config.ts --run"
   },
   "dependencies": {
     "@astrojs/alpinejs": "1.0.0",
@@ -23,7 +24,7 @@
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.6",
     "alpinejs": "^3.14.9",
-    "astro": "7.0.0",
+    "astro": "7.2.8",
     "preact": "^10.28.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
@@ -43,11 +44,14 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@types/prop-types": "^15.7.14",
+    "@vitest/browser": "4.1.9",
+    "@vitest/browser-playwright": "4.1.9",
     "@vitest/ui": "^4.1.9",
     "eslint": "^9.39.2",
     "happy-dom": "^20.10.6",
     "http-server": "^14.1.1",
     "msw": "^2.12.10",
+    "playwright": "^1.49.0",
     "prop-types": "^15.8.1",
     "solid-js": "^1.9.10",
     "storybook": "10.5.2",

--- a/integration/astro7/vitest.storybook.config.ts
+++ b/integration/astro7/vitest.storybook.config.ts
@@ -1,0 +1,25 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import { playwright } from '@vitest/browser-playwright';
+
+// Deliberately NOT using `defineConfig` from '@storybook-astro/framework/vitest':
+// `storybookTest` applies the framework's `viteFinal`, which already merges the
+// Astro Vite config. Layering our own `getViteConfig` wrapper on top would
+// duplicate every Astro plugin and re-introduce `astro:server`.
+//
+// No `setupFiles` either — addon-vitest provides the project annotations itself,
+// and this app's existing setup file installs a happy-dom `window`, which would
+// clobber the real one in browser mode.
+export default defineConfig({
+  plugins: [storybookTest({ configDir: '.storybook' })],
+  test: {
+    name: 'astro7-storybook',
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: 'chromium' }]
+    }
+  }
+});

--- a/packages/@storybook-astro/framework/src/integrations/alpine.ts
+++ b/packages/@storybook-astro/framework/src/integrations/alpine.ts
@@ -12,6 +12,7 @@ export class AlpineIntegration implements Integration {
   ];
   readonly options: Options;
   readonly renderer = {};
+  readonly clientOptimizeDeps = ['alpinejs'];
 
   constructor(options: Options = {}) {
     this.options = options;

--- a/packages/@storybook-astro/framework/src/integrations/base.ts
+++ b/packages/@storybook-astro/framework/src/integrations/base.ts
@@ -23,6 +23,12 @@ export abstract class Integration {
   abstract readonly options: Record<string | number | symbol, unknown>;
   abstract readonly renderer: RendererDeclaration;
   abstract readonly storybookEntryPreview?: string;
+  // Packages this integration pulls into the browser through a client
+  // entrypoint the dependency scanner cannot reach (a virtual module, or a
+  // config-supplied entrypoint file). Vite would otherwise find them only once
+  // the preview is running and reload the page to optimize them — harmless in
+  // Storybook dev, but fatal mid-collection under `@storybook/addon-vitest`.
+  readonly clientOptimizeDeps?: string[];
 
   abstract resolveClient(moduleName: string): string | undefined;
   abstract loadIntegration(resolveFrom?: string): Promise<AstroIntegration>;

--- a/packages/@storybook-astro/framework/src/integrations/react.ts
+++ b/packages/@storybook-astro/framework/src/integrations/react.ts
@@ -9,6 +9,7 @@ export class ReactIntegration implements Integration {
   readonly dependencies = ['@astrojs/react', '@storybook/react', 'react', 'react-dom'];
   readonly options: Options;
   readonly storybookEntryPreview = '@storybook/react/entry-preview';
+  readonly clientOptimizeDeps = ['react-dom/test-utils'];
 
   readonly renderer = {
     server: {

--- a/packages/@storybook-astro/framework/src/preset.ts
+++ b/packages/@storybook-astro/framework/src/preset.ts
@@ -1,4 +1,5 @@
 import { dirname } from 'node:path';
+import { createRequire } from 'node:module';
 import { version as viteVersion } from 'vite';
 import type { StorybookConfigVite, FrameworkOptions } from './types.ts';
 import { vitePluginStorybookAstroMiddleware } from './viteStorybookAstroMiddlewarePlugin.ts';
@@ -13,6 +14,10 @@ import { vitePluginAstroVueFallback } from './vitePluginAstroVueFallback.ts';
 import { vitePluginAstroToolbarFallback } from './vitePluginAstroToolbarFallback.ts';
 import { resolveSanitizationOptions } from './lib/sanitization.ts';
 import { mergeWithAstroConfig } from './vitePluginAstro.ts';
+import {
+  astroDepScanEsbuildPlugin,
+  astroDepScanRolldownPlugin
+} from './vitePluginAstroDepScan.ts';
 import {
   appendUserVitePlugins,
   loadUserAstroFonts,
@@ -211,6 +216,31 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
       finalConfig.optimizeDeps.exclude.push(pkg);
     }
   }
+  // `@storybook-astro/renderer` is excluded from pre-bundling just above, and
+  // `optimizeDeps.exclude` also stops the dependency scanner from crawling into
+  // it — so the packages it imports are never found at scan time. Vite then
+  // discovers them once the preview is already running and reloads the page to
+  // swap in the newly optimized deps. That reload is invisible in Storybook dev,
+  // but under `@storybook/addon-vitest` it lands mid test-collection and fails
+  // the run. Listing them here gets them pre-bundled up front.
+  // `storybook/internal/preview-api` is deliberately absent: it stays excluded
+  // for the duplicate-injectQuery reason above.
+  if (!finalConfig.optimizeDeps.include) {
+    finalConfig.optimizeDeps.include = [];
+  }
+  const scannerBlindDeps = [
+    'storybook/internal/csf',
+    'storybook/internal/docs-tools',
+    'ts-dedent',
+    ...integrations.flatMap((integration) => integration.clientOptimizeDeps ?? [])
+  ];
+
+  for (const pkg of scannerBlindDeps) {
+    if (!finalConfig.optimizeDeps.include.includes(pkg)) {
+      finalConfig.optimizeDeps.include.push(pkg);
+    }
+  }
+
   // Mark integration virtual modules as external so the dep bundler doesn't
   // try to resolve them (they are Vite virtual modules with no real package).
   // Vite ≤7 reads these from esbuildOptions; Vite 8+ uses Rolldown and reads
@@ -223,7 +253,7 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
     'astro:toolbar:internal'
   ];
 
-  const viteMajor = Number.parseInt(viteVersion, 10);
+  const viteMajor = resolveProjectViteMajor(resolveFrom);
 
   // Vite ≤7 (esbuild-based optimizer). On Vite 8+ setting esbuildOptions logs a
   // deprecation warning, so only touch it on older Vite.
@@ -239,26 +269,38 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
         finalConfig.optimizeDeps.esbuildOptions.external.push(mod);
       }
     }
+
+    if (!finalConfig.optimizeDeps.esbuildOptions.plugins) {
+      finalConfig.optimizeDeps.esbuildOptions.plugins = [];
+    }
+    finalConfig.optimizeDeps.esbuildOptions.plugins.push(astroDepScanEsbuildPlugin());
   }
 
   // Vite 8+ uses Rolldown for dependency optimization.
   const optimizeDepsMut = finalConfig.optimizeDeps as Record<string, unknown>;
-  const rolldownOpts = (optimizeDepsMut.rolldownOptions ?? {}) as { external?: string[] };
+  const rolldownOpts = (optimizeDepsMut.rolldownOptions ?? {}) as {
+    external?: string[];
+    plugins?: unknown[];
+  };
 
   rolldownOpts.external = Array.from(
     new Set([...(rolldownOpts.external ?? []), ...integrationVirtualModules])
   );
+
+  if (viteMajor >= 8) {
+    rolldownOpts.plugins = [...(rolldownOpts.plugins ?? []), astroDepScanRolldownPlugin()];
+  }
   optimizeDepsMut.rolldownOptions = rolldownOpts;
 
   // Vite 8 dev-server compatibility (Astro 7+). Vite ≤7 (Astro 5/6) is unaffected.
   if (configType === 'DEVELOPMENT' && viteMajor >= 8) {
-    // 1. Drop @vitejs/plugin-react's Vite 8 native Fast Refresh wrapper. Under
-    //    Vite 8 the plugin delegates Fast Refresh to a Rolldown builtin
-    //    (`builtin:vite-react-refresh-wrapper`) that throws
-    //    "Missing field `moduleType`" while transforming Storybook's iframe.html
-    //    inline bootstrap script — 500-ing every preview load. There is no
-    //    config opt-out, so we remove the plugin. React components still render;
-    //    only Fast Refresh is lost (component edits full-reload instead).
+    // Drop @vitejs/plugin-react's Vite 8 native Fast Refresh wrapper. Under
+    // Vite 8 the plugin delegates Fast Refresh to a Rolldown builtin
+    // (`builtin:vite-react-refresh-wrapper`) that throws
+    // "Missing field `moduleType`" while transforming Storybook's iframe.html
+    // inline bootstrap script — 500-ing every preview load. There is no
+    // config opt-out, so we remove the plugin. React components still render;
+    // only Fast Refresh is lost (component edits full-reload instead).
     const stripReactRefreshWrapper = (plugins: unknown[]): unknown[] =>
       plugins
         .map((plugin) => (Array.isArray(plugin) ? stripReactRefreshWrapper(plugin) : plugin))
@@ -275,12 +317,14 @@ export const viteFinal: StorybookConfigVite['viteFinal'] = async (config, storyb
       finalConfig.plugins ?? []
     ) as typeof finalConfig.plugins;
 
-    // 2. Exclude the Storybook renderer entry-previews from dependency
-    //    optimization. Some ship non-JS source (e.g. `@storybook/svelte`'s
-    //    `.svelte` files) that the esbuild dep scanner cannot load
-    //    ("No loader is configured for .svelte"), which fails optimization and
-    //    504s every renderer entry. Serving them as source lets the framework's
-    //    own Vite plugins transform them.
+  }
+
+  // Exclude the Storybook renderer entry-previews from dependency optimization.
+  // Some ship non-JS source (e.g. `@storybook/svelte`'s `.svelte` files) that
+  // the dep scanner cannot load ("No loader is configured for .svelte"), which
+  // fails optimization and 504s every renderer entry. Serving them as source
+  // lets the framework's own Vite plugins transform them.
+  if (configType === 'DEVELOPMENT') {
     const entryPreviews = integrations
       .map((integration) => integration.storybookEntryPreview)
       .filter((specifier): specifier is string => Boolean(specifier));
@@ -330,4 +374,22 @@ async function createDocgenIfEnabled(
   const { createAstroDocgen } = await import('./docgen/index.ts');
 
   return createAstroDocgen({ projectRoot, ...options.docgen });
+}
+
+/**
+ * The Vite major the *project* runs on — not the copy hoisted next to this
+ * package. In a monorepo those diverge (an Astro 6 app on Vite 7 alongside a
+ * hoisted Vite 8), and every version gate above is about the app's Vite: which
+ * optimizer it uses, and which dev-server workarounds it needs.
+ */
+function resolveProjectViteMajor(resolveFrom: string): number {
+  const require = createRequire(import.meta.url);
+
+  try {
+    const pkgPath = require.resolve('vite/package.json', { paths: [resolveFrom] });
+
+    return Number.parseInt(require(pkgPath).version, 10);
+  } catch {
+    return Number.parseInt(viteVersion, 10);
+  }
 }

--- a/packages/@storybook-astro/framework/src/vitePluginAstroDepScan.test.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroDepScan.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from 'vitest';
+import { collectAstroScanImports, astroScanModule } from './vitePluginAstroDepScan.ts';
+
+describe('what the dependency scanner sees in a .astro file', () => {
+  test('a <script> mentioned in a frontmatter comment is prose, not a script block', () => {
+    // The real Accordion.astro shape that broke the scan: Vite matched this
+    // `<script>` as markup, sliced the file from there, and failed to parse.
+    const source = [
+      '---',
+      '/**',
+      ' * Interactivity uses an inline `<script>` tag.',
+      ' */',
+      "import Icon from './Icon.astro';",
+      '---',
+      '<div></div>'
+    ].join('\n');
+
+    expect(collectAstroScanImports(source)).toEqual(['./Icon.astro']);
+  });
+
+  test('frontmatter imports are reported, which Vite misses on its own', () => {
+    const source = [
+      '---',
+      "import Card from './Card.astro';",
+      "import { format } from 'date-fns';",
+      "import styles from './card.css';",
+      '---',
+      '<article></article>'
+    ].join('\n');
+
+    expect(collectAstroScanImports(source)).toEqual([
+      './Card.astro',
+      'date-fns',
+      './card.css'
+    ]);
+  });
+
+  test('real <script> blocks below the frontmatter still contribute imports', () => {
+    const source = [
+      '---',
+      "import Counter from './Counter.astro';",
+      '---',
+      '<div></div>',
+      '<script>',
+      "  import confetti from 'canvas-confetti';",
+      '  confetti();',
+      '</script>'
+    ].join('\n');
+
+    expect(collectAstroScanImports(source)).toEqual(['./Counter.astro', 'canvas-confetti']);
+  });
+
+  test('a <script src> contributes its src', () => {
+    const source = '---\n---\n<script src="./widget.js"></script>';
+
+    expect(collectAstroScanImports(source)).toEqual(['./widget.js']);
+  });
+
+  test('imports commented out in frontmatter are ignored', () => {
+    const source = [
+      '---',
+      "// import Old from './Old.astro';",
+      "/* import Older from './Older.astro'; */",
+      "import New from './New.astro';",
+      '---'
+    ].join('\n');
+
+    expect(collectAstroScanImports(source)).toEqual(['./New.astro']);
+  });
+
+  test("Astro's virtual modules are skipped — the scanner cannot resolve them", () => {
+    const source = [
+      '---',
+      "import { Image } from 'astro:assets';",
+      "import thing from 'virtual:something';",
+      "import real from './Real.astro';",
+      '---'
+    ].join('\n');
+
+    expect(collectAstroScanImports(source)).toEqual(['./Real.astro']);
+  });
+
+  test('a duplicated specifier is reported once', () => {
+    const source = [
+      '---',
+      "import a from './Shared.astro';",
+      "import b from './Shared.astro';",
+      '---'
+    ].join('\n');
+
+    expect(collectAstroScanImports(source)).toEqual(['./Shared.astro']);
+  });
+
+  test('a file with no imports still yields a loadable module', () => {
+    expect(astroScanModule('---\n---\n<p>hi</p>')).toBe('export default {};');
+  });
+
+  test('the emitted module is import statements plus the default every story imports', () => {
+    const source = "---\nimport Card from './Card.astro';\n---";
+
+    expect(astroScanModule(source)).toBe('import "./Card.astro";\nexport default {};');
+  });
+});
+
+describe('type-only imports', () => {
+  test('are skipped — they resolve to .d.ts files the scanner chokes on', () => {
+    const source = [
+      '---',
+      "import type { HTMLAttributes } from 'astro/types';",
+      "import type Props from './props';",
+      "export type { Foo } from './foo';",
+      "import Card from './Card.astro';",
+      '---'
+    ].join('\n');
+
+    expect(collectAstroScanImports(source)).toEqual(['./Card.astro']);
+  });
+
+  test('an inline type specifier does not discard the whole statement', () => {
+    const source = "---\nimport { type Variant, renderBadge } from './badge';\n---";
+
+    expect(collectAstroScanImports(source)).toEqual(['./badge']);
+  });
+});

--- a/packages/@storybook-astro/framework/src/vitePluginAstroDepScan.ts
+++ b/packages/@storybook-astro/framework/src/vitePluginAstroDepScan.ts
@@ -1,0 +1,171 @@
+/**
+ * Teaches Vite's dependency scanner how to read `.astro` files.
+ *
+ * Vite classifies `.astro` as an "HTML type" and, during the scan, reads the raw
+ * file and regex-matches `<script>` blocks out of it. The regex strips HTML
+ * comments but not JavaScript ones, so a `<script>` mentioned inside a
+ * frontmatter JSDoc comment is matched as if it opened a real script block. The
+ * slice that follows starts mid-comment and fails to parse, and because a scan
+ * failure is fatal Vite gives up on pre-bundling entirely:
+ *
+ *     Failed to run dependency scan. Skipping dependency pre-bundling.
+ *
+ * Everything then gets discovered while tests or the preview are already
+ * running, and Vite reloads the page mid-flight to swap in the newly optimized
+ * deps. Under `@storybook/addon-vitest` that reload lands during test
+ * collection and surfaces as unrelated-looking failures.
+ *
+ * The scanner only ever needs the import graph, so we hand it exactly that: one
+ * `import` statement per specifier the file references. Frontmatter imports are
+ * included, which Vite's own extraction misses entirely — fewer deps discovered
+ * late means fewer mid-run reloads.
+ *
+ * Known gap: `import.meta.glob()` inside a `.astro` file is not expanded, so
+ * globbed modules stay invisible to the scanner. Vite doesn't crawl frontmatter
+ * at all today, so this is no worse than the status quo.
+ */
+
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---/;
+const BLOCK_COMMENT = /\/\*[\s\S]*?\*\//g;
+const LINE_COMMENT = /\/\/[^\n]*/g;
+const SCRIPT_BLOCK = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+const SCRIPT_SRC = /\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i;
+const IMPORT_SPECIFIER = /(?:\bfrom\s*|\bimport\s*\(?\s*|\bexport\s+\*\s+from\s*)['"]([^'"]+)['"]/g;
+// `import type { Props } from 'astro/types'` has no runtime module behind it —
+// following it leads the scanner into .d.ts files it cannot resolve.
+const TYPE_ONLY_STATEMENT = /\b(?:import|export)\s+type\s[^;]*?['"][^'"]+['"]/g;
+
+/**
+ * Specifiers the scanner cannot resolve on its own. Astro's virtual modules are
+ * served by plugins, and the scanner runs without the user plugin pipeline — so
+ * leaving these in would just populate Vite's "missing dependency" warnings.
+ */
+function isScannable(specifier: string): boolean {
+  return !specifier.startsWith('astro:') && !specifier.startsWith('virtual:');
+}
+
+function importsIn(code: string): string[] {
+  const withoutComments = code
+    .replace(BLOCK_COMMENT, '')
+    .replace(LINE_COMMENT, '')
+    .replace(TYPE_ONLY_STATEMENT, '');
+  const specifiers: string[] = [];
+  let match;
+
+  IMPORT_SPECIFIER.lastIndex = 0;
+  while ((match = IMPORT_SPECIFIER.exec(withoutComments)) !== null) {
+    specifiers.push(match[1]);
+  }
+
+  return specifiers;
+}
+
+/**
+ * Collects every module specifier a `.astro` file imports, from its frontmatter
+ * and from its `<script>` blocks. Deduplicated, source order preserved.
+ */
+export function collectAstroScanImports(source: string): string[] {
+  const specifiers = new Set<string>();
+  const frontmatter = source.match(FRONTMATTER);
+
+  if (frontmatter) {
+    importsIn(frontmatter[1]).forEach((specifier) => specifiers.add(specifier));
+  }
+
+  // Only look for <script> blocks below the frontmatter. A `<script>` written
+  // inside a frontmatter comment is prose, not markup — matching it there is
+  // the exact bug this plugin exists to avoid.
+  const template = frontmatter ? source.slice(frontmatter[0].length) : source;
+
+  let block;
+
+  SCRIPT_BLOCK.lastIndex = 0;
+  while ((block = SCRIPT_BLOCK.exec(template)) !== null) {
+    const [, attributes, content] = block;
+    const src = SCRIPT_SRC.exec(attributes);
+
+    if (src) {
+      specifiers.add(src[1] ?? src[2] ?? src[3]);
+
+      continue;
+    }
+
+    importsIn(content).forEach((specifier) => specifiers.add(specifier));
+  }
+
+  return Array.from(specifiers).filter(isScannable);
+}
+
+/**
+ * The JS module the scanner sees in place of the `.astro` source.
+ *
+ * The trailing `export default {}` matches what Vite's own loader appends for
+ * HTML-type files: the bundler resolves exports while crawling, and every story
+ * imports its component as a default. Named imports from a `.astro` file are
+ * not supported here — nor are they by Vite's loader.
+ */
+export function astroScanModule(source: string): string {
+  const imports = collectAstroScanImports(source).map(
+    (specifier) => `import ${JSON.stringify(specifier)};`
+  );
+
+  return [...imports, 'export default {};'].join('\n');
+}
+
+const ASTRO_FILE = /\.astro$/;
+
+/**
+ * Scanner plugin for Vite 8+, whose optimizer runs on Rolldown. Registered via
+ * `optimizeDeps.rolldownOptions.plugins`, which the scanner loads ahead of its
+ * own plugins — so this `load` wins over Vite's `<script>` extraction.
+ */
+export function astroDepScanRolldownPlugin() {
+  return {
+    name: 'storybook-astro:dep-scan',
+    load: {
+      filter: { id: ASTRO_FILE },
+      async handler(id: string) {
+        const { readFile } = await import('node:fs/promises');
+
+        return {
+          code: astroScanModule(await readFile(id, 'utf-8')),
+          moduleType: 'js'
+        };
+      }
+    }
+  };
+}
+
+/**
+ * Scanner plugin for Vite 6 and 7, whose optimizer runs on esbuild. Registered
+ * via `optimizeDeps.esbuildOptions.plugins`, which the scanner loads ahead of
+ * its own plugin — so these `onLoad` callbacks win over Vite's `<script>`
+ * extraction.
+ *
+ * Resolution is left entirely to Vite: it routes `.astro` into either the
+ * `html` or the `file` namespace depending on how the file was imported (bare
+ * package specifier vs. relative path), and registers its own loader for both.
+ * Claiming both namespaces here covers the same ground without this plugin
+ * needing to resolve anything itself.
+ */
+export function astroDepScanEsbuildPlugin() {
+  return {
+    name: 'storybook-astro:dep-scan',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setup(build: any) {
+      const loadAstro = async (args: { path: string }) => {
+        const { readFile } = await import('node:fs/promises');
+        const { dirname } = await import('node:path');
+
+        return {
+          contents: astroScanModule(await readFile(args.path, 'utf-8')),
+          loader: 'js',
+          resolveDir: dirname(args.path)
+        };
+      };
+
+      build.onLoad({ filter: ASTRO_FILE, namespace: 'html' }, loadAstro);
+      build.onLoad({ filter: ASTRO_FILE, namespace: 'file' }, loadAstro);
+    }
+  };
+}

--- a/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
+++ b/packages/@storybook-astro/framework/src/viteStorybookAstroMiddlewarePlugin.ts
@@ -108,6 +108,14 @@ export async function vitePluginStorybookAstroMiddleware(options: FrameworkOptio
           } satisfies RenderResponseMessage['data']);
         }
       });
+    },
+    // The internal Astro SSR server owns a file watcher and an HTTP server, so
+    // leaving it running keeps the whole process alive after Storybook or Vitest
+    // is done. Vite calls this when the parent server closes. During builds
+    // `configureServer` never ran, so there is nothing to close.
+    async closeBundle() {
+      await viteServer?.close();
+      viteServer = null;
     }
   } satisfies PluginOption;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,9 +96,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@astrojs/compiler-binding-darwin-arm64@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding-darwin-arm64@npm:0.4.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@astrojs/compiler-binding-darwin-x64@npm:0.2.2":
   version: 0.2.2
   resolution: "@astrojs/compiler-binding-darwin-x64@npm:0.2.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@astrojs/compiler-binding-darwin-x64@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding-darwin-x64@npm:0.4.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -110,9 +124,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@astrojs/compiler-binding-linux-arm64-gnu@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding-linux-arm64-gnu@npm:0.4.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@astrojs/compiler-binding-linux-arm64-musl@npm:0.2.2":
   version: 0.2.2
   resolution: "@astrojs/compiler-binding-linux-arm64-musl@npm:0.2.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@astrojs/compiler-binding-linux-arm64-musl@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding-linux-arm64-musl@npm:0.4.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -124,9 +152,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@astrojs/compiler-binding-linux-x64-gnu@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding-linux-x64-gnu@npm:0.4.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@astrojs/compiler-binding-linux-x64-musl@npm:0.2.2":
   version: 0.2.2
   resolution: "@astrojs/compiler-binding-linux-x64-musl@npm:0.2.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@astrojs/compiler-binding-linux-x64-musl@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding-linux-x64-musl@npm:0.4.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -140,6 +182,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@astrojs/compiler-binding-wasm32-wasi@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding-wasm32-wasi@npm:0.4.0"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:^1.2.2"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
 "@astrojs/compiler-binding-win32-arm64-msvc@npm:0.2.2":
   version: 0.2.2
   resolution: "@astrojs/compiler-binding-win32-arm64-msvc@npm:0.2.2"
@@ -147,9 +198,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@astrojs/compiler-binding-win32-arm64-msvc@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding-win32-arm64-msvc@npm:0.4.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@astrojs/compiler-binding-win32-x64-msvc@npm:0.2.2":
   version: 0.2.2
   resolution: "@astrojs/compiler-binding-win32-x64-msvc@npm:0.2.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@astrojs/compiler-binding-win32-x64-msvc@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding-win32-x64-msvc@npm:0.4.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -190,12 +255,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@astrojs/compiler-binding@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-binding@npm:0.4.0"
+  dependencies:
+    "@astrojs/compiler-binding-darwin-arm64": "npm:0.4.0"
+    "@astrojs/compiler-binding-darwin-x64": "npm:0.4.0"
+    "@astrojs/compiler-binding-linux-arm64-gnu": "npm:0.4.0"
+    "@astrojs/compiler-binding-linux-arm64-musl": "npm:0.4.0"
+    "@astrojs/compiler-binding-linux-x64-gnu": "npm:0.4.0"
+    "@astrojs/compiler-binding-linux-x64-musl": "npm:0.4.0"
+    "@astrojs/compiler-binding-wasm32-wasi": "npm:0.4.0"
+    "@astrojs/compiler-binding-win32-arm64-msvc": "npm:0.4.0"
+    "@astrojs/compiler-binding-win32-x64-msvc": "npm:0.4.0"
+  dependenciesMeta:
+    "@astrojs/compiler-binding-darwin-arm64":
+      optional: true
+    "@astrojs/compiler-binding-darwin-x64":
+      optional: true
+    "@astrojs/compiler-binding-linux-arm64-gnu":
+      optional: true
+    "@astrojs/compiler-binding-linux-arm64-musl":
+      optional: true
+    "@astrojs/compiler-binding-linux-x64-gnu":
+      optional: true
+    "@astrojs/compiler-binding-linux-x64-musl":
+      optional: true
+    "@astrojs/compiler-binding-wasm32-wasi":
+      optional: true
+    "@astrojs/compiler-binding-win32-arm64-msvc":
+      optional: true
+    "@astrojs/compiler-binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/bed8bd622549a3b60a867938a715bb826493c93ac24425c6ca19ecf9cd8b97abd8b6ce6a3f13d8a96538fffe4b019be010202a83120abb47f3c1322903e842c1
+  languageName: node
+  linkType: hard
+
 "@astrojs/compiler-rs@npm:^0.2.2":
   version: 0.2.2
   resolution: "@astrojs/compiler-rs@npm:0.2.2"
   dependencies:
     "@astrojs/compiler-binding": "npm:0.2.2"
   checksum: 10c0/d258cbecda5ff709d1d10a8cc64f361c34434c894063229650f7afc7717d1a46e87577c0669f50532b822e6291df117f11892879bdbc6127583490cb3550b402
+  languageName: node
+  linkType: hard
+
+"@astrojs/compiler-rs@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@astrojs/compiler-rs@npm:0.4.0"
+  dependencies:
+    "@astrojs/compiler-binding": "npm:0.4.0"
+  checksum: 10c0/663810868196c5af67ed6d737e47fc1b626bee88e95d3e4ecf3997d90aa71afd4c63f0d7d0d32b1f3dda5d9ae8a791c1c9e7be08fd851d0dab5dddf43650f5a6
   languageName: node
   linkType: hard
 
@@ -233,6 +343,22 @@ __metadata:
     smol-toml: "npm:^1.6.0"
     unified: "npm:^11.0.5"
   checksum: 10c0/e6729142b607b9aebaf36afeb045c5e137a4dd2a89051a5221c16c8d55379e6986e663c683ec524459dd3f35965027b94cbd02c9034bddc5a6acd0da21dfe5d4
+  languageName: node
+  linkType: hard
+
+"@astrojs/internal-helpers@npm:0.10.4":
+  version: 0.10.4
+  resolution: "@astrojs/internal-helpers@npm:0.10.4"
+  dependencies:
+    "@types/hast": "npm:^3.0.4"
+    "@types/mdast": "npm:^4.0.4"
+    js-yaml: "npm:^4.3.0"
+    picomatch: "npm:^4.0.4"
+    retext-smartypants: "npm:^6.2.0"
+    shiki: "npm:^4.0.2"
+    smol-toml: "npm:^1.6.0"
+    unified: "npm:^11.0.5"
+  checksum: 10c0/2e789920c52597cfde72cb46524be92331b3a9b1d97a03d01e6d714fbbc905202b6949cfd9e5a33d241bf0b3275f5cfe7ffcbf3dd8652b3bc9345a8631b5af3c
   languageName: node
   linkType: hard
 
@@ -343,6 +469,18 @@ __metadata:
     github-slugger: "npm:^2.0.0"
     satteri: "npm:^0.9.1"
   checksum: 10c0/1ca83aba58a88ad4c2b5d8d30c81f7a488a887b8d791fb307b7d0a9cbca483fdfe35f2b33ca79f508ab1c4ff3d367006c549ff3c6f4ae34fe76772bf306a08d4
+  languageName: node
+  linkType: hard
+
+"@astrojs/markdown-satteri@npm:0.3.8":
+  version: 0.3.8
+  resolution: "@astrojs/markdown-satteri@npm:0.3.8"
+  dependencies:
+    "@astrojs/internal-helpers": "npm:0.10.4"
+    "@astrojs/prism": "npm:4.0.2"
+    github-slugger: "npm:^2.0.0"
+    satteri: "npm:^0.10.3"
+  checksum: 10c0/58dc4567a795d19a8cf94d3cdf98b42189b6d71de25e05bb5bc8ca8bf201a30920ee067ecf6b7999035f30f2ec0f7d1525346d5580ae03c8c29545d113ac311c
   languageName: node
   linkType: hard
 
@@ -678,6 +816,18 @@ __metadata:
     is-wsl: "npm:^3.1.1"
     which-pm-runs: "npm:^1.1.0"
   checksum: 10c0/7af9e10bfb45bde66ce882c0aceec54141cf63255a4d85e2f99f6cebc2a0b388c38a0b7fe3c3eb3b20ae8a41b9a5103e22e27255582d8bf961cc47d71c29d230
+  languageName: node
+  linkType: hard
+
+"@astrojs/telemetry@npm:3.3.3":
+  version: 3.3.3
+  resolution: "@astrojs/telemetry@npm:3.3.3"
+  dependencies:
+    ci-info: "npm:^4.4.0"
+    dset: "npm:^3.1.4"
+    is-docker: "npm:^4.0.0"
+    package-manager-detector: "npm:^1.6.0"
+  checksum: 10c0/d5373e0aa8cbfd684143027dce4e31f7fd45e90df799ce4d255fb750109173a3dd2fc3ef26532b298c715fe063d6e955984d238e323d96e1d8f6c0a03fbbbc73
   languageName: node
   linkType: hard
 
@@ -1431,6 +1581,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@blazediff/core@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@blazediff/core@npm:1.9.1"
+  checksum: 10c0/fd45cdd0544002341d74831a179ef693a81414abd348c1ff0c01086c0ea03f5e5ee284c4e16c2e6fb3670c265f90a3d85752b9360320efa9a835928e604dae77
+  languageName: node
+  linkType: hard
+
 "@bramus/specificity@npm:^2.4.2":
   version: 2.4.2
   resolution: "@bramus/specificity@npm:2.4.2"
@@ -1442,10 +1599,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bruits/satteri-darwin-arm64@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@bruits/satteri-darwin-arm64@npm:0.10.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@bruits/satteri-darwin-arm64@npm:0.9.1":
   version: 0.9.1
   resolution: "@bruits/satteri-darwin-arm64@npm:0.9.1"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@bruits/satteri-darwin-x64@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@bruits/satteri-darwin-x64@npm:0.10.5"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1456,10 +1627,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bruits/satteri-linux-arm64-gnu@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@bruits/satteri-linux-arm64-gnu@npm:0.10.5"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@bruits/satteri-linux-arm64-musl@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@bruits/satteri-linux-arm64-musl@npm:0.10.5"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@bruits/satteri-linux-x64-gnu@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@bruits/satteri-linux-x64-gnu@npm:0.10.5"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@bruits/satteri-linux-x64-gnu@npm:0.9.1":
   version: 0.9.1
   resolution: "@bruits/satteri-linux-x64-gnu@npm:0.9.1"
   conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@bruits/satteri-linux-x64-musl@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@bruits/satteri-linux-x64-musl@npm:0.10.5"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@bruits/satteri-wasm32-wasi@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@bruits/satteri-wasm32-wasi@npm:0.10.5"
+  dependencies:
+    "@emnapi/core": "npm:1.11.1"
+    "@emnapi/runtime": "npm:1.11.1"
+    "@napi-rs/wasm-runtime": "npm:^1.2.3"
+  conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
@@ -1471,6 +1681,20 @@ __metadata:
     "@emnapi/runtime": "npm:1.9.1"
     "@napi-rs/wasm-runtime": "npm:^1.1.5"
   conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@bruits/satteri-win32-arm64-msvc@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@bruits/satteri-win32-arm64-msvc@npm:0.10.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@bruits/satteri-win32-x64-msvc@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@bruits/satteri-win32-x64-msvc@npm:0.10.5"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1604,6 +1828,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/core@npm:1.11.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.2"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/2c6defdac2d1d26090384655d7d6c9614fa553853b1760597686749e9375dc2aa0dae80a2615b81c254600f5d531d07d8466cde0d331a8caae64b93f3ca5937e
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:1.9.1, @emnapi/core@npm:^1.7.1":
   version: 1.9.1
   resolution: "@emnapi/core@npm:1.9.1"
@@ -1642,6 +1876,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/runtime@npm:1.11.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/04332fb62076afc440aa23316c04bec42f584ca8b074e5507d08e2b33a47cbe0493b1aadb8f3c1057b64ae1e17f5bde1a7bc37f7facc9d0bc25c18197cbd366f
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.9.1, @emnapi/runtime@npm:^1.7.1":
   version: 1.9.1
   resolution: "@emnapi/runtime@npm:1.9.1"
@@ -1657,6 +1900,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/61c3a59e0c36784558b8d58eb02bd04815aa5fb0dbfbaf84d1b3050a78aa0cc63ea129ae806bd1e48062bfeb7fc36eb0e5431740d62f64ea51bdf426404b8caa
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:^1.11.3":
+  version: 1.11.3
+  resolution: "@emnapi/runtime@npm:1.11.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/a00f1020fefb9d4145c367f93a9fddb383a00da8ffd7871e20b19659890379b83aeecb9f84d7d0eda5456343f4a09eb05b0acb5153b0d3d889539dedb1ed87c3
   languageName: node
   linkType: hard
 
@@ -2623,11 +2875,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/colour@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@img/colour@npm:1.1.0"
+  checksum: 10c0/2ebea2c0bbaee73b99badcefa04e1e71d83f36e5369337d3121dca841f4569533c4e2faddda6d62dd247f0d5cca143711f9446c59bcce81e427ba433a7a94a17
+  languageName: node
+  linkType: hard
+
 "@img/sharp-darwin-arm64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-darwin-arm64@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-darwin-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-darwin-arm64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-darwin-arm64@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-darwin-arm64": "npm:1.3.3"
   dependenciesMeta:
     "@img/sharp-libvips-darwin-arm64":
       optional: true
@@ -2647,9 +2918,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-darwin-x64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-darwin-x64@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-darwin-x64": "npm:1.3.3"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-freebsd-wasm32@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-freebsd-wasm32@npm:0.35.4"
+  dependencies:
+    "@img/sharp-wasm32": "npm:0.35.4"
+  conditions: os=freebsd
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-darwin-arm64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-darwin-arm64@npm:1.2.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-arm64@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-darwin-arm64@npm:1.3.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -2661,9 +2960,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-darwin-x64@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-darwin-x64@npm:1.3.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-linux-arm64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linux-arm64@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm64@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-linux-arm64@npm:1.3.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2675,9 +2988,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-linux-arm@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-linux-arm@npm:1.3.3"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-linux-ppc64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linux-ppc64@npm:1.2.4"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-ppc64@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-linux-ppc64@npm:1.3.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2689,9 +3016,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-linux-riscv64@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-linux-riscv64@npm:1.3.3"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-linux-s390x@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linux-s390x@npm:1.2.4"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-s390x@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-linux-s390x@npm:1.3.3"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -2703,9 +3044,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-linux-x64@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-linux-x64@npm:1.3.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-arm64@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.3.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -2717,11 +3072,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-linuxmusl-x64@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@img/sharp-libvips-linuxmusl-x64@npm:1.3.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@img/sharp-linux-arm64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linux-arm64@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-linux-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-linux-arm64@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-linux-arm64": "npm:1.3.3"
   dependenciesMeta:
     "@img/sharp-libvips-linux-arm64":
       optional: true
@@ -2741,11 +3115,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-linux-arm@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-linux-arm@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-linux-arm": "npm:1.3.3"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-linux-ppc64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linux-ppc64@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-linux-ppc64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-ppc64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-linux-ppc64@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-linux-ppc64": "npm:1.3.3"
   dependenciesMeta:
     "@img/sharp-libvips-linux-ppc64":
       optional: true
@@ -2765,11 +3163,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-linux-riscv64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-linux-riscv64@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-linux-riscv64": "npm:1.3.3"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-linux-s390x@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linux-s390x@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-linux-s390x": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-s390x@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-linux-s390x@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-linux-s390x": "npm:1.3.3"
   dependenciesMeta:
     "@img/sharp-libvips-linux-s390x":
       optional: true
@@ -2789,11 +3211,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-linux-x64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-linux-x64@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-linux-x64": "npm:1.3.3"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-linuxmusl-arm64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linuxmusl-arm64@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-linuxmusl-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-arm64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-linuxmusl-arm64@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.3.3"
   dependenciesMeta:
     "@img/sharp-libvips-linuxmusl-arm64":
       optional: true
@@ -2813,11 +3259,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-linuxmusl-x64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-linuxmusl-x64@npm:0.35.4"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.3.3"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@img/sharp-wasm32@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-wasm32@npm:0.34.5"
   dependencies:
     "@emnapi/runtime": "npm:^1.7.0"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-wasm32@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-wasm32@npm:0.35.4"
+  dependencies:
+    "@emnapi/runtime": "npm:^1.11.3"
+  checksum: 10c0/7f5e394f168eb2f038b8ae4949fb5434085d1db931ede2ae1389479d7a1dbe11e2fc9d58e8e9830bff744ba996256c9e411be1d466dfcbf6e1f4d153b84f25ff
+  languageName: node
+  linkType: hard
+
+"@img/sharp-webcontainers-wasm32@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-webcontainers-wasm32@npm:0.35.4"
+  dependencies:
+    "@img/sharp-wasm32": "npm:0.35.4"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
@@ -2829,6 +3305,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-win32-arm64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-win32-arm64@npm:0.35.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@img/sharp-win32-ia32@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-win32-ia32@npm:0.34.5"
@@ -2836,9 +3319,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-win32-ia32@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-win32-ia32@npm:0.35.4"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@img/sharp-win32-x64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-win32-x64@npm:0.34.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-x64@npm:0.35.4":
+  version: 0.35.4
+  resolution: "@img/sharp-win32-x64@npm:0.35.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -3099,6 +3596,18 @@ __metadata:
     "@emnapi/core": ^1.7.1
     "@emnapi/runtime": ^1.7.1
   checksum: 10c0/727f2b6ae0e68bbe5d39aeb68aa6f183314e9f03dc50bb55a962849535b2db53ecc3fbf1554d8656a54488a608df5a2634670595cf5874dc4af2ee59f817c65d
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^1.2.2, @napi-rs/wasm-runtime@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "@napi-rs/wasm-runtime@npm:1.2.3"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.3"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.4
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.4
+  checksum: 10c0/6da0a4bf9df79e9abfb3e3d462f6a5d42889be39426040038c9dd5925865585d7dbd06dd439c2ffc20f49ef2751412da5bd748cfb3c5b049142d72c0550f6f79
   languageName: node
   linkType: hard
 
@@ -4830,6 +5339,8 @@ __metadata:
     "@types/prop-types": "npm:^15.7.14"
     "@types/react": "npm:^18.3.20"
     "@types/react-dom": "npm:^18.3.6"
+    "@vitest/browser": "npm:4.1.9"
+    "@vitest/browser-playwright": "npm:4.1.9"
     "@vitest/ui": "npm:^4.1.9"
     alpinejs: "npm:^3.14.9"
     astro: "npm:5.17.2"
@@ -4837,6 +5348,7 @@ __metadata:
     happy-dom: "npm:^20.10.6"
     http-server: "npm:^14.1.1"
     msw: "npm:^2.12.10"
+    playwright: "npm:^1.49.0"
     preact: "npm:^10.28.1"
     prop-types: "npm:^15.8.1"
     react: "npm:^19.2.3"
@@ -4896,6 +5408,8 @@ __metadata:
     "@types/prop-types": "npm:^15.7.14"
     "@types/react": "npm:^18.3.20"
     "@types/react-dom": "npm:^18.3.6"
+    "@vitest/browser": "npm:4.1.9"
+    "@vitest/browser-playwright": "npm:4.1.9"
     "@vitest/ui": "npm:^4.1.9"
     alpinejs: "npm:^3.14.9"
     astro: "npm:6.4.8"
@@ -4903,6 +5417,7 @@ __metadata:
     happy-dom: "npm:^20.10.6"
     http-server: "npm:^14.1.1"
     msw: "npm:^2.12.10"
+    playwright: "npm:^1.49.0"
     preact: "npm:^10.28.1"
     prop-types: "npm:^15.8.1"
     react: "npm:^19.2.3"
@@ -4962,13 +5477,16 @@ __metadata:
     "@types/prop-types": "npm:^15.7.14"
     "@types/react": "npm:^18.3.20"
     "@types/react-dom": "npm:^18.3.6"
+    "@vitest/browser": "npm:4.1.9"
+    "@vitest/browser-playwright": "npm:4.1.9"
     "@vitest/ui": "npm:^4.1.9"
     alpinejs: "npm:^3.14.9"
-    astro: "npm:7.0.0"
+    astro: "npm:7.2.8"
     eslint: "npm:^9.39.2"
     happy-dom: "npm:^20.10.6"
     http-server: "npm:^14.1.1"
     msw: "npm:^2.12.10"
+    playwright: "npm:^1.49.0"
     preact: "npm:^10.28.1"
     prop-types: "npm:^15.8.1"
     react: "npm:^19.2.3"
@@ -5551,6 +6069,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/fd2bd2a79c6cd8c79ed1cf7a0fa375c64589264c88a27acaf9756d556b453ea222b62a4f68dd2fbb8b3a78b6bab3b1f4fb2431b6afc6aeda8344b53a521a1cd3
+  languageName: node
+  linkType: hard
+
 "@types/alpinejs@npm:^3.13.11":
   version: 3.13.11
   resolution: "@types/alpinejs@npm:3.13.11"
@@ -5667,6 +6194,15 @@ __metadata:
   dependencies:
     "@types/unist": "npm:*"
   checksum: 10c0/3249781a511b38f1d330fd1e3344eed3c4e7ea8eff82e835d35da78e637480d36fad37a78be5a7aed8465d237ad0446abc1150859d0fde395354ea634decf9f7
+  languageName: node
+  linkType: hard
+
+"@types/hast@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@types/hast@npm:3.0.5"
+  dependencies:
+    "@types/unist": "npm:*"
+  checksum: 10c0/f3af8594a6903a507ed191eda944af18099198d6708c29102ae17118c3e20779f6929e91ed37e033541fd28d58055d8a5910a4366dbdf976cf81b13a464741fb
   languageName: node
   linkType: hard
 
@@ -6198,6 +6734,41 @@ __metadata:
     vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     vue: ^3.2.25
   checksum: 10c0/16e7673ded56ce2b3ebb2a71e7e22208328da6f0f4fdd1b87e1b3622690471dbccdad82dc4cccb7330da2c783a1204a37edc1f9155567bd852be6e76c76a4b52
+  languageName: node
+  linkType: hard
+
+"@vitest/browser-playwright@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/browser-playwright@npm:4.1.9"
+  dependencies:
+    "@vitest/browser": "npm:4.1.9"
+    "@vitest/mocker": "npm:4.1.9"
+    tinyrainbow: "npm:^3.1.0"
+  peerDependencies:
+    playwright: "*"
+    vitest: 4.1.9
+  peerDependenciesMeta:
+    playwright:
+      optional: false
+  checksum: 10c0/4c042c980bb0aa950646d4d1f0f131f44156141d86f54eb96f5f69863ed05720cac7ef1a0901ab71e18929a62c41e5d64a428b2612ea708905bf423ff961dcf4
+  languageName: node
+  linkType: hard
+
+"@vitest/browser@npm:4.1.9":
+  version: 4.1.9
+  resolution: "@vitest/browser@npm:4.1.9"
+  dependencies:
+    "@blazediff/core": "npm:1.9.1"
+    "@vitest/mocker": "npm:4.1.9"
+    "@vitest/utils": "npm:4.1.9"
+    magic-string: "npm:^0.30.21"
+    pngjs: "npm:^7.0.0"
+    sirv: "npm:^3.0.2"
+    tinyrainbow: "npm:^3.1.0"
+    ws: "npm:^8.19.0"
+  peerDependencies:
+    vitest: 4.1.9
+  checksum: 10c0/9ff634e56b0bd5a3727f2eec7666f97a089b92fb596d5b9e4fbe2a2e4fd988aa7a7bd2a7b98d7cf14790717db69db8f72bae6dc007f2fac613b9bb93d8e8edfb
   languageName: node
   linkType: hard
 
@@ -6923,6 +7494,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"am-i-vibing@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "am-i-vibing@npm:0.4.0"
+  dependencies:
+    process-ancestry: "npm:^0.1.0"
+  bin:
+    am-i-vibing: dist/cli.mjs
+  checksum: 10c0/af511ee621c78957e7e9e86b15498d64b9d73c54689e571a03531fe123002d3a5f7bd2d7fadda9cc07511c8f7cfdcc888d897bebeb12d2bc8b725161e64fd3f5
+  languageName: node
+  linkType: hard
+
 "ansi-align@npm:^3.0.1":
   version: 3.0.1
   resolution: "ansi-align@npm:3.0.1"
@@ -7315,6 +7897,78 @@ __metadata:
   bin:
     astro: ./bin/astro.mjs
   checksum: 10c0/61eec0c0fdfc19a1edeb75554bb870d7da16eb4dd1764f2ca5a92a82e8c3377ce40611fd52be47e05431bc08557763f8f2597b283ff1a64b962eefee9708c5d7
+  languageName: node
+  linkType: hard
+
+"astro@npm:7.2.8":
+  version: 7.2.8
+  resolution: "astro@npm:7.2.8"
+  dependencies:
+    "@astrojs/compiler-rs": "npm:^0.4.0"
+    "@astrojs/internal-helpers": "npm:0.10.4"
+    "@astrojs/markdown-satteri": "npm:0.3.8"
+    "@astrojs/telemetry": "npm:3.3.3"
+    "@capsizecss/unpack": "npm:^4.0.0"
+    "@clack/prompts": "npm:^1.1.0"
+    "@oslojs/encoding": "npm:^1.1.0"
+    am-i-vibing: "npm:^0.4.0"
+    aria-query: "npm:^5.3.2"
+    axobject-query: "npm:^4.1.0"
+    ci-info: "npm:^4.4.0"
+    clsx: "npm:^2.1.1"
+    common-ancestor-path: "npm:^2.0.0"
+    cookie: "npm:^2.0.1"
+    devalue: "npm:^5.8.1"
+    diff: "npm:^9.0.0"
+    dset: "npm:^3.1.4"
+    es-module-lexer: "npm:^2.0.0"
+    esbuild: "npm:^0.28.0"
+    find-proc: "npm:0.1.0"
+    flattie: "npm:^1.1.1"
+    fontace: "npm:~0.4.1"
+    get-tsconfig: "npm:5.0.0-beta.4"
+    github-slugger: "npm:^2.0.0"
+    html-escaper: "npm:3.0.3"
+    http-cache-semantics: "npm:^4.2.0"
+    js-yaml: "npm:^4.3.0"
+    jsonc-parser: "npm:^3.3.1"
+    magic-string: "npm:^1.0.0"
+    magicast: "npm:^0.5.2"
+    mrmime: "npm:^2.0.1"
+    neotraverse: "npm:^1.0.1"
+    obug: "npm:^2.1.1"
+    p-limit: "npm:^7.3.0"
+    p-queue: "npm:^9.1.0"
+    package-manager-detector: "npm:^1.6.0"
+    piccolore: "npm:^0.1.3"
+    picomatch: "npm:^4.0.4"
+    semver: "npm:^7.7.4"
+    sharp: "npm:^0.35.4"
+    shiki: "npm:^4.0.2"
+    smol-toml: "npm:^1.6.0"
+    svgo: "npm:^4.0.1"
+    tinyclip: "npm:^0.1.12"
+    tinyexec: "npm:^1.0.4"
+    tinyglobby: "npm:^0.2.15"
+    ultrahtml: "npm:^1.6.0"
+    unifont: "npm:~0.7.5"
+    unstorage: "npm:^1.17.5"
+    vite: "npm:^8.0.13"
+    vitefu: "npm:^1.1.2"
+    xxhash-wasm: "npm:^1.1.0"
+    yargs-parser: "npm:^22.0.0"
+    zod: "npm:^4.3.6"
+  peerDependencies:
+    "@astrojs/markdown-remark": 7.2.4
+  dependenciesMeta:
+    sharp:
+      optional: true
+  peerDependenciesMeta:
+    "@astrojs/markdown-remark":
+      optional: true
+  bin:
+    astro: ./bin/astro.mjs
+  checksum: 10c0/72e44f7931b438c59b48f5c2bd73efe0d0d16f5944576f1f5b6c8b5f198f1c35260300392e0ad11c1ea45c954dddf196b2d995c5065a1eeef48e47bf1387d66d
   languageName: node
   linkType: hard
 
@@ -7953,6 +8607,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "cookie@npm:2.0.1"
+  checksum: 10c0/dcf3bd6ec9d0f4f32be7575e23242866cb53be55fc3d4cf36215638596661cec1327a3b4ca286ba15eba8f2abd443e422b8c5f708af4ea9f75b4d3dedc67ee4c
+  languageName: node
+  linkType: hard
+
 "copy-anything@npm:^4":
   version: 4.0.5
   resolution: "copy-anything@npm:4.0.5"
@@ -8255,6 +8916,13 @@ __metadata:
   version: 8.0.3
   resolution: "diff@npm:8.0.3"
   checksum: 10c0/d29321c70d3545fdcb56c5fdd76028c3f04c012462779e062303d4c3c531af80d2c360c26b871e6e2b9a971d2422d47e1779a859106c4cac4b5d2d143df70e20
+  languageName: node
+  linkType: hard
+
+"diff@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "diff@npm:9.0.0"
+  checksum: 10c0/a971cc88f66071a33bd3942db2f51b57d484e9856265ae45cf44fb28ab2fde91f132d9c26d8be0fb6082d2be94d29e1295c1adb251b7461935d6a2dd304cd161
   languageName: node
   linkType: hard
 
@@ -9491,6 +10159,13 @@ __metadata:
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
+  languageName: node
+  linkType: hard
+
+"find-proc@npm:0.1.0":
+  version: 0.1.0
+  resolution: "find-proc@npm:0.1.0"
+  checksum: 10c0/5fde77ff99037cc7a06eecf7b2e586062239d0b101ea89e694123b319ef891ecba50af2a53093ea9e6cf6689164135b9379f3566daaac17ae4265b2f31f0998b
   languageName: node
   linkType: hard
 
@@ -10758,6 +11433,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:^4.3.0":
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/dedd34c2e8fef1d504687f1bc94ed0ee1311a1f78770fa2800352c6d59c635ccf555009d74e9afe529ae62199da2b1ccef30e53dc84dcd8d2d8187c22574bc97
+  languageName: node
+  linkType: hard
+
 "jsbn@npm:1.1.0":
   version: 1.1.0
   resolution: "jsbn@npm:1.1.0"
@@ -11187,6 +11873,15 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.5"
   checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^1.0.0":
+  version: 1.2.3
+  resolution: "magic-string@npm:1.2.3"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/541ecb30ec96e4d9b76ca65aed00124592dca26739aeee86e01d7fbce227b3fce43c9d2f0b9495dc9077c30794c967b1e091445614e2e45722ea4c128be60a93
   languageName: node
   linkType: hard
 
@@ -12288,6 +12983,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"neotraverse@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "neotraverse@npm:1.0.1"
+  checksum: 10c0/98e5d2d1974f91d527851a9dcfceb62701a1d31970b324b9f35fbdd244d173edc7a379ea1773f64771a9dc282486e3d3b693b24e14b1e969291612b2ff6b5054
+  languageName: node
+  linkType: hard
+
 "nlcst-to-string@npm:^4.0.0":
   version: 4.0.0
   resolution: "nlcst-to-string@npm:4.0.0"
@@ -12965,6 +13667,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.62.1":
+  version: 1.62.1
+  resolution: "playwright-core@npm:1.62.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/a37d0f03bb73364cfd0eba704c4b3359b609c4779ae2649a88d8e2b3a29c7357dfcc58bdcf0cb68ddffdef7687abf78902c8356e89f189682c7e19be38e108f0
+  languageName: node
+  linkType: hard
+
 "playwright@npm:1.60.0":
   version: 1.60.0
   resolution: "playwright@npm:1.60.0"
@@ -12977,6 +13688,28 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/714ad76d85b4865d7e43c0012f9039800c1485373388973ed39d79339cee5ad467052d1e2f1eaeca107a1cb6e65342186a8578a4c3504853d84c3a691250d5db
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.49.0":
+  version: 1.62.1
+  resolution: "playwright@npm:1.62.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.62.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/4d3522cd46325f50c46f8874d31f70d036f6983228a9f8b9d68fc249e4c17464edcd97cc4adfbb24e712d1829c1386d3bc24e17f58a1ced94e7c423300c21845
+  languageName: node
+  linkType: hard
+
+"pngjs@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "pngjs@npm:7.0.0"
+  checksum: 10c0/0d4c7a0fd476a9c33df7d0a2a73e1d56537628a668841f6995c2bca070cf30819f9254a64363266bc14ef2fee47659dd3b4f2b18eec7ab65143015139f497b38
   languageName: node
   linkType: hard
 
@@ -14140,6 +14873,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"satteri@npm:^0.10.3":
+  version: 0.10.5
+  resolution: "satteri@npm:0.10.5"
+  dependencies:
+    "@bruits/satteri-darwin-arm64": "npm:0.10.5"
+    "@bruits/satteri-darwin-x64": "npm:0.10.5"
+    "@bruits/satteri-linux-arm64-gnu": "npm:0.10.5"
+    "@bruits/satteri-linux-arm64-musl": "npm:0.10.5"
+    "@bruits/satteri-linux-x64-gnu": "npm:0.10.5"
+    "@bruits/satteri-linux-x64-musl": "npm:0.10.5"
+    "@bruits/satteri-wasm32-wasi": "npm:0.10.5"
+    "@bruits/satteri-win32-arm64-msvc": "npm:0.10.5"
+    "@bruits/satteri-win32-x64-msvc": "npm:0.10.5"
+    "@types/estree-jsx": "npm:^1.0.5"
+    "@types/hast": "npm:^3.0.5"
+    "@types/mdast": "npm:^4.0.4"
+    "@types/unist": "npm:^3.0.3"
+  dependenciesMeta:
+    "@bruits/satteri-darwin-arm64":
+      optional: true
+    "@bruits/satteri-darwin-x64":
+      optional: true
+    "@bruits/satteri-linux-arm64-gnu":
+      optional: true
+    "@bruits/satteri-linux-arm64-musl":
+      optional: true
+    "@bruits/satteri-linux-x64-gnu":
+      optional: true
+    "@bruits/satteri-linux-x64-musl":
+      optional: true
+    "@bruits/satteri-wasm32-wasi":
+      optional: true
+    "@bruits/satteri-win32-arm64-msvc":
+      optional: true
+    "@bruits/satteri-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/e1a9f6f9784c8ea79be59ddb803403999521632ef57a595579e1e310646172c9661a0ce41c2667ed9b82a55d697dd192f6470e9a6ee348d5b207172d89d0cba3
+  languageName: node
+  linkType: hard
+
 "satteri@npm:^0.9.1":
   version: 0.9.1
   resolution: "satteri@npm:0.9.1"
@@ -14236,6 +15009,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.8.5":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
   languageName: node
   linkType: hard
 
@@ -14336,6 +15118,96 @@ __metadata:
     "@img/sharp-win32-x64":
       optional: true
   checksum: 10c0/fd79e29df0597a7d5704b8461c51f944ead91a5243691697be6e8243b966402beda53ddc6f0a53b96ea3cb8221f0b244aa588114d3ebf8734fb4aefd41ab802f
+  languageName: node
+  linkType: hard
+
+"sharp@npm:^0.35.4":
+  version: 0.35.4
+  resolution: "sharp@npm:0.35.4"
+  dependencies:
+    "@img/colour": "npm:^1.1.0"
+    "@img/sharp-darwin-arm64": "npm:0.35.4"
+    "@img/sharp-darwin-x64": "npm:0.35.4"
+    "@img/sharp-freebsd-wasm32": "npm:0.35.4"
+    "@img/sharp-libvips-darwin-arm64": "npm:1.3.3"
+    "@img/sharp-libvips-darwin-x64": "npm:1.3.3"
+    "@img/sharp-libvips-linux-arm": "npm:1.3.3"
+    "@img/sharp-libvips-linux-arm64": "npm:1.3.3"
+    "@img/sharp-libvips-linux-ppc64": "npm:1.3.3"
+    "@img/sharp-libvips-linux-riscv64": "npm:1.3.3"
+    "@img/sharp-libvips-linux-s390x": "npm:1.3.3"
+    "@img/sharp-libvips-linux-x64": "npm:1.3.3"
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.3.3"
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.3.3"
+    "@img/sharp-linux-arm": "npm:0.35.4"
+    "@img/sharp-linux-arm64": "npm:0.35.4"
+    "@img/sharp-linux-ppc64": "npm:0.35.4"
+    "@img/sharp-linux-riscv64": "npm:0.35.4"
+    "@img/sharp-linux-s390x": "npm:0.35.4"
+    "@img/sharp-linux-x64": "npm:0.35.4"
+    "@img/sharp-linuxmusl-arm64": "npm:0.35.4"
+    "@img/sharp-linuxmusl-x64": "npm:0.35.4"
+    "@img/sharp-webcontainers-wasm32": "npm:0.35.4"
+    "@img/sharp-win32-arm64": "npm:0.35.4"
+    "@img/sharp-win32-ia32": "npm:0.35.4"
+    "@img/sharp-win32-x64": "npm:0.35.4"
+    detect-libc: "npm:^2.1.2"
+    semver: "npm:^7.8.5"
+  dependenciesMeta:
+    "@img/sharp-darwin-arm64":
+      optional: true
+    "@img/sharp-darwin-x64":
+      optional: true
+    "@img/sharp-freebsd-wasm32":
+      optional: true
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+    "@img/sharp-linux-arm":
+      optional: true
+    "@img/sharp-linux-arm64":
+      optional: true
+    "@img/sharp-linux-ppc64":
+      optional: true
+    "@img/sharp-linux-riscv64":
+      optional: true
+    "@img/sharp-linux-s390x":
+      optional: true
+    "@img/sharp-linux-x64":
+      optional: true
+    "@img/sharp-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-linuxmusl-x64":
+      optional: true
+    "@img/sharp-webcontainers-wasm32":
+      optional: true
+    "@img/sharp-win32-arm64":
+      optional: true
+    "@img/sharp-win32-ia32":
+      optional: true
+    "@img/sharp-win32-x64":
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/dbcc0909200cbff98e82805c86085b94afbd45f373897a04b21e52e9bbc1671dc64970350dd3cb6b2d0970f3444be7100d728005dc6620e39b599269ed7e15eb
   languageName: node
   linkType: hard
 
@@ -15531,6 +16403,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^8.0.0":
+  version: 8.10.0
+  resolution: "undici@npm:8.10.0"
+  checksum: 10c0/37ae2b1db8f65c3a003504e2040e96887b99f9db16ba07dcf49c37ed8b7f8c72f4452f2d46f52f7c9e49518fe8325e3b5e7e02ac3a2424886bd67d4b62a0ecab
+  languageName: node
+  linkType: hard
+
 "unicorn-magic@npm:^0.3.0":
   version: 0.3.0
   resolution: "unicorn-magic@npm:0.3.0"
@@ -15572,6 +16451,17 @@ __metadata:
     ofetch: "npm:^1.5.1"
     ohash: "npm:^2.0.11"
   checksum: 10c0/2b1c23e13083ce52382ac3e430b24c7f7a9a8657480f82847e254d5e3aa8a639c1178fda9ad157c21d2ceff5f7a037021c547501856dca7a93bc75bef6fe2f7d
+  languageName: node
+  linkType: hard
+
+"unifont@npm:~0.7.5":
+  version: 0.7.5
+  resolution: "unifont@npm:0.7.5"
+  dependencies:
+    css-tree: "npm:^3.1.0"
+    ohash: "npm:^2.0.11"
+    undici: "npm:^8.0.0"
+  checksum: 10c0/bf91799b2fe53c8d360421f48cde7f56f2f14a9573cf49d10d97c9013efe50094a69258f3618108d899a202b36a2c627676fd901f61c2d6310e8ef2feed66047
   languageName: node
   linkType: hard
 
@@ -16793,6 +17683,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.19.0":
+  version: 8.21.3
+  resolution: "ws@npm:8.21.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/7b28dc2863ea0e2cece68d142a3eee90361021b73f750431e6d8076bb7dede5fdfdb75b3d29534b62f411261147b76b1bc80fb5cc63ab0aabd467280e85b22e0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5348,7 +5348,6 @@ __metadata:
     happy-dom: "npm:^20.10.6"
     http-server: "npm:^14.1.1"
     msw: "npm:^2.12.10"
-    playwright: "npm:^1.49.0"
     preact: "npm:^10.28.1"
     prop-types: "npm:^15.8.1"
     react: "npm:^19.2.3"
@@ -5417,7 +5416,6 @@ __metadata:
     happy-dom: "npm:^20.10.6"
     http-server: "npm:^14.1.1"
     msw: "npm:^2.12.10"
-    playwright: "npm:^1.49.0"
     preact: "npm:^10.28.1"
     prop-types: "npm:^15.8.1"
     react: "npm:^19.2.3"
@@ -5486,7 +5484,6 @@ __metadata:
     happy-dom: "npm:^20.10.6"
     http-server: "npm:^14.1.1"
     msw: "npm:^2.12.10"
-    playwright: "npm:^1.49.0"
     preact: "npm:^10.28.1"
     prop-types: "npm:^15.8.1"
     react: "npm:^19.2.3"
@@ -13667,15 +13664,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.62.1":
-  version: 1.62.1
-  resolution: "playwright-core@npm:1.62.1"
-  bin:
-    playwright-core: cli.js
-  checksum: 10c0/a37d0f03bb73364cfd0eba704c4b3359b609c4779ae2649a88d8e2b3a29c7357dfcc58bdcf0cb68ddffdef7687abf78902c8356e89f189682c7e19be38e108f0
-  languageName: node
-  linkType: hard
-
 "playwright@npm:1.60.0":
   version: 1.60.0
   resolution: "playwright@npm:1.60.0"
@@ -13688,21 +13676,6 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/714ad76d85b4865d7e43c0012f9039800c1485373388973ed39d79339cee5ad467052d1e2f1eaeca107a1cb6e65342186a8578a4c3504853d84c3a691250d5db
-  languageName: node
-  linkType: hard
-
-"playwright@npm:^1.49.0":
-  version: 1.62.1
-  resolution: "playwright@npm:1.62.1"
-  dependencies:
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.62.1"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    playwright: cli.js
-  checksum: 10c0/4d3522cd46325f50c46f8874d31f70d036f6983228a9f8b9d68fc249e4c17464edcd97cc4adfbb24e712d1829c1386d3bc24e17f58a1ced94e7c423300c21845
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #159.

`@storybook/addon-vitest` now runs Astro component stories as Vitest browser tests on **Astro 5, 6 and 7**. Stories render through the same server-side pipeline the canvas uses, and play functions run against the resulting DOM.

## The issue's premise was wrong

#159 described this as gated on `astro@7.0.6`, with Astro 5/6 blocked upstream. That isn't true for this path.

The upstream bug ([withastro/astro#16275](https://github.com/withastro/astro/issues/16275)) comes from `astro:server`'s `configureServer` hook — and `mergeWithAstroConfig` already strips that plugin from the Storybook Vite config. The internal SSR server does keep it, but it's a plain Vite server with a genuinely runnable SSR environment, so it boots fine. Astro 5 and 6, which never received the fix, work too.

**No version guard is added**, because there's no version-gated failure to guard against. The issue description has been rewritten accordingly (the original is preserved as a comment).

## What actually needed fixing

**Vite's dependency scanner could not read `.astro` files.** It classifies `.astro` as an HTML type and regex-matches `<script>` out of the raw source, stripping HTML comments but not JavaScript ones. So this, in `Accordion.astro`'s frontmatter:

```js
/**
 * ...interactivity uses an inline `<script>` tag.
 */
```

was matched as real markup. The slice that followed started mid-comment and failed to parse, which aborted the entire scan (`Failed to run dependency scan. Skipping dependency pre-bundling`). Dependencies were then discovered while tests were already running, and Vite reloaded the page **during collection**. That surfaced as the unrelated-looking `Vitest failed to find the current suite`, and — once `storybook/test` ended up loaded both raw and pre-bundled — `TypeError: Illegal invocation` inside `patchFocus`.

`vitePluginAstroDepScan` hands the scanner the file's import graph instead of regex-sliced source, registered on both optimizer backends (esbuild for Vite 6/7, Rolldown for Vite 8). Frontmatter imports are included, which Vite's own extraction misses entirely.

**Two pre-existing bugs surfaced while fixing that:**

- `preset.ts` read the Vite version from the copy hoisted beside the framework (8.0.2 here) rather than the one the project runs (7.3.1 for `integration/astro6`), so every `viteMajor` gate was wrong for Astro 5/6 apps.
- The renderer entry-preview exclusion sat behind a `viteMajor >= 8` gate despite its own comment describing an **esbuild** failure — a Vite ≤7 problem. It only ever ran because of the bug above, and fixing that immediately exposed it.

**The internal Astro SSR Vite server was never closed**, so every run ended with `close timed out after 10000ms`. It now closes on `closeBundle`. Verified by A/B smoke test that Storybook dev is unaffected — it already force-exits, which is why this only ever showed under Vitest.

## Coverage

Story globs in the integration apps are now resolved portably and *then* made relative: addon-vitest resolves each `stories` entry with `join(configDir, storyPath)`, so absolute paths silently matched nothing and every story in `@storybook-astro/components` was being skipped without warning.

| App | Astro | Vite | Before | After |
| --- | --- | --- | --- | --- |
| `integration/astro5` | 5.17.2 | 6.4.1 | 29 tests | **72 tests** |
| `integration/astro6` | 6.4.8 | 7.3.1 | 32 tests | **75 tests** |
| `integration/astro7` | 7.2.8 | 8.x Rolldown | 37 tests | **80 tests** |

Six `.mdx` docs files per app are reported as skipped, correctly — they produce no tests.

## Also included

- CI steps for all three majors, reusing the Playwright Chromium install the existing browser-test steps already do
- Testing guide section: setup, why the Vitest config must stay separate from the portable-stories one and carry no `setupFiles`, and the relative-glob requirement
- Troubleshooting entries for both failure signatures
- Roadmap entry rewritten (not just flipped) plus the support matrix row
- Play-functions roadmap entry moved To Do → Partial: verified under the test addon, **not** verified in the canvas or Interactions panel, and the entry says exactly that

No `docs/specs/` record: there's no new behaviour contract here, just a feature that already worked and three bugs fixed.

## Verification

`yarn lint`, `yarn lint:links`, `yarn test` (363 tests), website build, Storybook builds for all three integrations, and all three addon-vitest suites — all pass.

The lockfile was regenerated and verified against a CI-equivalent run: `CI=true yarn install` in a **clean worktree with no `node_modules`** exits 0 and leaves `yarn.lock` unmodified, so the immutable-install check should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
