### PR TITLE
chore: changelog, CI hygiene, and a deterministic playwright pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -27,7 +27,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Lint code
         run: yarn lint

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -29,12 +29,12 @@ jobs:
             token: CHROMATIC_PROJECT_TOKEN_ASTRO7
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Chromatic needs full history for baselines/TurboSnap
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -42,7 +42,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Build packages
         run: yarn build:packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -25,7 +25,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Lint code
         run: yarn lint

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -46,7 +46,7 @@ jobs:
         run: corepack enable
 
       - name: Install workspace dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Run smoke test
         run: bash scripts/smoke-test.sh ${{ matrix.astro }} ${{ matrix.scenario }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Component descriptions and prop documentation are extracted from JSDoc in a component's `.astro` frontmatter, so autodocs pages populate without `argTypes` boilerplate in story files (#163, #110). Covers per-prop descriptions, types and defaults, select controls for literal union props, and types imported from other files including through tsconfig `paths` aliases. Inherited DOM attributes are filtered out while destructured props are kept. Opt out with the `docgen` framework option.
+- `@storybook/addon-vitest` support: Storybook's official test runner now runs Astro component stories as Vitest browser tests on Astro 5, 6 and 7 (#159). Stories render through the same server-side pipeline the canvas uses, and play functions run against the resulting DOM. This was previously believed to require `astro@7.0.6`; it does not — the upstream crash ([withastro/astro#16275](https://github.com/withastro/astro/issues/16275)) originates in Astro's `astro:server` Vite plugin, which the framework already strips from the Storybook Vite config, so no version guard is needed. Note that `@storybook/addon-vitest` resolves each `stories` entry against your `.storybook` directory, so absolute story globs silently match nothing — keep them relative.
+
+### Fixed
+- Vite's dependency scanner can now read `.astro` files (#159). It classifies `.astro` as an HTML type and regex-matches `<script>` out of the raw source, stripping HTML comments but not JavaScript ones — so a `<script>` mentioned inside a frontmatter JSDoc comment was treated as real markup, and the resulting unparseable slice aborted the entire scan (`Failed to run dependency scan. Skipping dependency pre-bundling`). Dependencies were then discovered mid-run and Vite reloaded the page, which under `@storybook/addon-vitest` landed during test collection and surfaced as `Vitest failed to find the current suite` or `TypeError: Illegal invocation`. The framework now hands the scanner the file's import graph instead, on both optimizer backends (esbuild for Vite 6/7, Rolldown for Vite 8).
+- The framework read the Vite version from the copy hoisted beside its own package rather than the one the project runs, so every Vite-version gate in the preset was wrong for projects on a different Vite major than the hoisted one (#159). This meant Astro 5/6 projects in a monorepo missed the Vite ≤7 optimizer options and received Vite 8-only dev-server workarounds they did not need.
+- The Storybook renderer entry-preview exclusion was gated on Vite 8 despite guarding against an esbuild (Vite ≤7) failure, and only ever applied because of the version-detection bug above (#159).
+- The internal Astro SSR Vite server is now closed when the parent server closes (#159). It was never closed, so it kept the process alive — harmless in Storybook dev, which force-exits, but every `@storybook/addon-vitest` run ended with `close timed out after 10000ms`.
+
 ## [1.10.0] - 2026-08-02
 
 ### Added

--- a/integration/astro5/package.json
+++ b/integration/astro5/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.0",
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "1.60.0",
     "@storybook-astro/framework": "workspace:*",
     "@storybook/addon-docs": "10.5.2",
     "@storybook/addon-vitest": "^10.5.2",

--- a/integration/astro6/package.json
+++ b/integration/astro6/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.0",
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "1.60.0",
     "@storybook-astro/framework": "workspace:*",
     "@storybook/addon-docs": "10.5.2",
     "@storybook/addon-vitest": "^10.5.2",

--- a/integration/astro7/package.json
+++ b/integration/astro7/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.0",
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "1.60.0",
     "@storybook-astro/framework": "workspace:*",
     "@storybook/addon-docs": "10.5.2",
     "@storybook/addon-vitest": "^10.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4195,7 +4195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.49.0":
+"@playwright/test@npm:1.60.0":
   version: 1.60.0
   resolution: "@playwright/test@npm:1.60.0"
   dependencies:
@@ -5323,7 +5323,7 @@ __metadata:
     "@astrojs/svelte": "npm:^7.0.9"
     "@astrojs/vue": "npm:^5.0.9"
     "@chromatic-com/storybook": "npm:^5.0.0"
-    "@playwright/test": "npm:^1.49.0"
+    "@playwright/test": "npm:1.60.0"
     "@storybook-astro/components": "workspace:*"
     "@storybook-astro/framework": "workspace:*"
     "@storybook/addon-docs": "npm:10.5.2"
@@ -5392,7 +5392,7 @@ __metadata:
     "@astrojs/svelte": "npm:8.0.0"
     "@astrojs/vue": "npm:6.0.0"
     "@chromatic-com/storybook": "npm:^5.0.0"
-    "@playwright/test": "npm:^1.49.0"
+    "@playwright/test": "npm:1.60.0"
     "@storybook-astro/components": "workspace:*"
     "@storybook-astro/framework": "workspace:*"
     "@storybook/addon-docs": "npm:10.5.2"
@@ -5460,7 +5460,7 @@ __metadata:
     "@astrojs/svelte": "npm:9.0.0"
     "@astrojs/vue": "npm:7.0.0"
     "@chromatic-com/storybook": "npm:^5.0.0"
-    "@playwright/test": "npm:^1.49.0"
+    "@playwright/test": "npm:1.60.0"
     "@storybook-astro/components": "workspace:*"
     "@storybook-astro/framework": "workspace:*"
     "@storybook/addon-docs": "npm:10.5.2"


### PR DESCRIPTION
Four follow-ups surfaced while adding Storybook Test addon support (#174). No behaviour change to the framework itself — this is changelog, CI hygiene, and one dependency pin.

## 1. `[Unreleased]` changelog was empty

Two features have landed since 1.10.0 with nothing recorded: JSDoc docgen (#163, #110) and addon-vitest support (#159), plus the four framework fixes that came with the latter. Both roadmap entries already read "Shipped (unreleased)" with nothing behind them, which would make the next release cut lossy.

## 2. CI installs are now explicitly `--immutable`

All four workflows ran bare `yarn install`. Yarn already upgrades that to `--immutable` in CI, so **behaviour is unchanged** — but the failure mode wasn't obvious. When a `package.json` change lands without a regenerated lockfile, `YN0028` surfaces as what looks like a generic install error, and the fix (`yarn install` locally, commit `yarn.lock`) isn't apparent from the log. Writing the flag makes the constraint self-documenting.

There's prior art for this biting: `db13d4b "chore: update lockfile for the typescript optional peer dependency"` was a 4-line follow-up doing exactly that recovery.

## 3. `actions/checkout` and `actions/setup-node` bumped v4 → v5

Clears the annotation on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24.

## 4. `@playwright/test` pinned to 1.60.0

All three integration apps declared `^1.49.0`, resolving to 1.60.0 today. That's load-bearing: `@playwright/test` brings `playwright` transitively at a matching version, and it only hoists cleanly while there's exactly one of each.

If those ranges ever drift apart, you get two `@playwright/test` versions, two `playwright` versions, a nested copy under `@playwright/test`, and every Playwright suite dies with `Playwright Test did not expect test.describe() to be called here`. That is precisely what happened mid-way through #174 when an explicit `playwright` dependency resolved to 1.62.1 alongside `@playwright/test@1.60.0`.

Pinning matches how `astro`, `storybook` and `@vitest/browser` are already pinned in these apps, and makes any future bump an explicit, all-three change. Verified: exactly **one** `playwright@npm` entry in `yarn.lock`, no nested copy under `@playwright/test`.

## Verification

- `yarn lint`, `yarn lint:links`, `yarn test` (363 tests) — pass
- Playwright e2e suites: astro5 6 passed, astro6 8 passed, astro7 9 passed
- addon-vitest suites: 72 / 75 / 80 passed
- `CI=true yarn install --immutable` in a **clean worktree with no `node_modules`** — exit 0, `yarn.lock` unmodified

The Playwright suites are called out deliberately: skipping them locally is what let the dependency regression through in #174, so a dependency-touching PR gets them run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
