### PR TITLE
fix: declare and test the Vitest 4.1.0 floor for astro:assets imports (#117)

### DIFF
--- a/apps/website/src/content/docs/guides/testing.md
+++ b/apps/website/src/content/docs/guides/testing.md
@@ -5,6 +5,23 @@ description: Test Storybook stories outside of Storybook using portable stories 
 
 Stories can double as test cases with **portable stories**. You can compose stories and render them in Vitest without running the Storybook UI.
 
+## Requirements
+
+Testing requires **Vitest 4.1.0 or newer**. On `vitest@4.0.x`, importing a story
+whose component uses `astro:assets` fails at module load with:
+
+```
+TypeError: Unknown file extension ".astro" for .../astro/components/Image.astro
+```
+
+Vitest externalized `astro` in its SSR environment on those versions, so
+`astro:assets` — which re-exports `astro/components/Image.astro` — reached
+Node's ESM loader untransformed. This was fixed in Vitest 4.1.0; `4.0.18`, the
+last 4.0 release, still reproduces it.
+
+The framework declares this as an optional peer dependency, so your package
+manager will warn if you are below the floor.
+
 ## Basic test setup
 
 ```jsx

--- a/apps/website/src/content/docs/guides/troubleshooting.md
+++ b/apps/website/src/content/docs/guides/troubleshooting.md
@@ -276,6 +276,23 @@ rm -rf node_modules package-lock.json
 npm install
 ```
 
+### `Unknown file extension ".astro"` in Vitest
+
+**Symptom:** A test fails at module load, before any test runs:
+
+```
+TypeError: Unknown file extension ".astro" for .../astro/components/Image.astro
+```
+
+**Cause:** Your component imports `astro:assets` (e.g. `<Image>`), which
+re-exports `astro/components/Image.astro`. Vitest 4.0.x externalized `astro` in
+its SSR environment, so that `.astro` file reached Node's ESM loader
+untransformed.
+
+**Fix:** Upgrade to **Vitest 4.1.0 or newer**. `4.0.18`, the last 4.0 release,
+still reproduces it. Nothing in your Astro or Storybook Astro configuration
+affects this — it is purely the Vitest version.
+
 ### Storybook Test addon: "Vitest failed to find the current suite"
 
 **Symptom:** Running stories through `@storybook/addon-vitest` fails to collect

--- a/integration/astro6/src/components/PageCard/PageCard.test.ts
+++ b/integration/astro6/src/components/PageCard/PageCard.test.ts
@@ -1,0 +1,25 @@
+import { screen } from '@testing-library/dom';
+import { test, expect } from 'vitest';
+import { composeStories, renderStory } from '@storybook-astro/framework/testing';
+import * as stories from './PageCard.stories.jsx';
+
+// PageCard nests Card.astro (template nesting) and uses astro:assets <Image>
+// directly with the imageSrc prop. The SSR server is configured with
+// passthroughImageService so <Image> renders as a plain <img> tag regardless
+// of whether imageSrc is an ImageMetadata object or a URL string.
+//
+// Importing this story used to throw `Unknown file extension ".astro"` (#117):
+// `astro:assets` re-exports `astro/components/Image.astro`, and Vitest
+// externalized `astro` in its SSR environment, so the `.astro` file reached
+// Node's ESM loader untransformed. Vitest fixed that between 4.0.18 and 4.1.9
+// — pinning vitest back to 4.0.18 still reproduces it. This test guards the
+// version floor, since nothing in this repo pins it.
+const { Default } = composeStories(stories);
+
+test('PageCard renders nested Astro component and image via SSR', async () => {
+  await renderStory(Default);
+
+  expect(screen.getByText('Storybook Astro')).toBeInTheDocument();
+  expect(screen.getByText('Build and test Astro components in Storybook.')).toBeInTheDocument();
+  expect(screen.getByAltText('Storybook Astro logo')).toBeInTheDocument();
+});

--- a/integration/astro7/src/components/PageCard/PageCard.test.ts
+++ b/integration/astro7/src/components/PageCard/PageCard.test.ts
@@ -1,0 +1,25 @@
+import { screen } from '@testing-library/dom';
+import { test, expect } from 'vitest';
+import { composeStories, renderStory } from '@storybook-astro/framework/testing';
+import * as stories from './PageCard.stories.jsx';
+
+// PageCard nests Card.astro (template nesting) and uses astro:assets <Image>
+// directly with the imageSrc prop. The SSR server is configured with
+// passthroughImageService so <Image> renders as a plain <img> tag regardless
+// of whether imageSrc is an ImageMetadata object or a URL string.
+//
+// Importing this story used to throw `Unknown file extension ".astro"` (#117):
+// `astro:assets` re-exports `astro/components/Image.astro`, and Vitest
+// externalized `astro` in its SSR environment, so the `.astro` file reached
+// Node's ESM loader untransformed. Vitest fixed that between 4.0.18 and 4.1.9
+// — pinning vitest back to 4.0.18 still reproduces it. This test guards the
+// version floor, since nothing in this repo pins it.
+const { Default } = composeStories(stories);
+
+test('PageCard renders nested Astro component and image via SSR', async () => {
+  await renderStory(Default);
+
+  expect(screen.getByText('Storybook Astro')).toBeInTheDocument();
+  expect(screen.getByText('Build and test Astro components in Storybook.')).toBeInTheDocument();
+  expect(screen.getByAltText('Storybook Astro logo')).toBeInTheDocument();
+});

--- a/packages/@storybook-astro/framework/package.json
+++ b/packages/@storybook-astro/framework/package.json
@@ -101,7 +101,8 @@
     "storybook": "^10.0.0",
     "storybook-solidjs": "^1.0.0-beta.7",
     "typescript": "^5.0.0 || ^6.0.0",
-    "vite": "^6.4.1 || ^7.0.0 || ^8.0.0"
+    "vite": "^6.4.1 || ^7.0.0 || ^8.0.0",
+    "vitest": "^4.1.0"
   },
   "peerDependenciesMeta": {
     "@astrojs/alpinejs": {
@@ -150,6 +151,9 @@
       "optional": true
     },
     "typescript": {
+      "optional": true
+    },
+    "vitest": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,6 +5276,7 @@ __metadata:
     storybook-solidjs: ^1.0.0-beta.7
     typescript: ^5.0.0 || ^6.0.0
     vite: ^6.4.1 || ^7.0.0 || ^8.0.0
+    vitest: ^4.1.0
   peerDependenciesMeta:
     "@astrojs/alpinejs":
       optional: true
@@ -5308,6 +5309,8 @@ __metadata:
     storybook-solidjs:
       optional: true
     typescript:
+      optional: true
+    vitest:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Closes #117.

Adds the `PageCard` test to `integration/astro6` and `integration/astro7` — the one `integration/astro5` already has — and declares the Vitest version floor that makes it pass.

## The bug is gone, but not for the reason anyone assumed

#117 guessed the fix would be ours: inline `astro` rather than externalize it in the Vitest SSR config. That is **not** what fixed it. I bisected:

| What I changed | Result |
| --- | --- |
| Current `develop`, repro test added | ✅ passes |
| Current `develop`, `ssr.noExternal: /^astro/` **removed** | ✅ still passes — so that isn't the mechanism |
| Pre-fix framework (`17b19e5`), Astro upgraded 6.0.3 → 6.4.8 | ❌ fails — so it isn't Astro either |
| Commit `76efc70`, Astro at 6.4.8, **vitest pinned back to 4.0.18** | ❌ `Unknown file extension ".astro"` returns |

It was fixed by the **vitest 4.0.18 → 4.1.9** bump in #148, which landed as a security patch. Nobody knew it fixed this.

## The floor, bisected rather than guessed

The obvious next step was to declare a peer dependency — but "4.0.18 bad, 4.1.9 good" leaves **ten untested releases** in between, and asserting `>=4.1.0` from that would be a guess. That is precisely how #159 ended up with a phantom `astro@7.0.6` requirement that blocked the feature for months.

So I bisected the gap on current `develop`:

| vitest | Result |
| --- | --- |
| `4.0.18` (last 4.0 release) | ❌ broken |
| `4.1.0` (first 4.1 release) | ✅ works |
| `4.1.1`, `4.1.4` | ✅ works |

The boundary is exactly **4.1.0**, a clean minor-release boundary verified in both directions.

## What ships

**`vitest: ^4.1.0` as an optional peer dependency.** Optional because only the `/vitest` subpath imports `vitest/config`, and someone who never writes tests shouldn't be made to install it — the same shape as the 16 optional peers already declared (`typescript`, `@vitejs/plugin-react`, the `@astrojs/*` set).

Verified it behaves: silent at the repo's own 4.1.9, and pinning a workspace to 4.0.18 produces a warning naming `@storybook-astro/framework` as the requester.

**Docs** — a Requirements section at the top of the Testing guide, and a troubleshooting entry keyed to the error string, since that is what someone hitting this will actually search for.

**Regression tests** — the fix arrived incidentally from a dependency, and nothing here exercised the path. These fail with the original error when vitest is downgraded, so they're a real guard rather than a passing formality.

## Verification

`yarn lint`, `yarn lint:links` clean. Website builds. `yarn test` green: astro6 14 → 15 tests, astro7 16 → 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
