### PR TITLE
docs(roadmap): correct the Play Functions and Enhanced Testing entries (#160, #158)

### DIFF
--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -23,19 +23,20 @@ A `create-storybook-astro` CLI that generates a new Astro project with Storybook
 
 ### Enhanced Testing & Portable Stories
 
-🚧 **Partially Complete**
+🚧 **Documentation only** — the APIs are done
 
-Expand testing capabilities for Astro components tested in isolation, including better support for Container API integration and DOM testing patterns.
+The testing APIs and tooling are in place. What is left is writing up patterns that already work but are not documented anywhere.
 
-**Current Status**: Core APIs shipped, additional utilities and documentation in progress
+**Complexity**: Low — writing, not engineering
 
-**Complexity**: Medium
+**Done**:
+- Testing helpers — `composeStories`, `composeStory`, `setProjectAnnotations`, `renderStory`, `renderAstroStory`, and `defineConfig` from `@storybook-astro/framework/vitest`
+- Testing library integration — `@testing-library/dom` works against server-rendered output, and [`@storybook/addon-vitest`](/guides/testing/#storybook-test-addon-storybookaddon-vitest) runs stories as browser tests (1.11.0)
 
 **Still to do**:
-- Test helper utilities for common testing patterns
-- Documentation with examples for testing composed components
-- Integration with testing libraries (Testing Library, Vitest patterns)
-- Guidance on testing both server-rendered and client-side behavior
+- Examples for testing composed components — slots, nested components, components passed as props, and decorators. The patterns already work and are covered by tests in the repo (`Nesting.test.ts`, `SlotBox.test.ts`); they have simply never been written up in the [Testing guide](/guides/testing/)
+- Guidance on choosing between the two approaches: portable stories for fast assertions on server-rendered output, and the Storybook Test addon when a test needs real interaction
+- `renderAstroStory` is exported but missing from the guide's helper list
 
 ### Code Panel Source for Astro Components
 

--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -37,21 +37,6 @@ Expand testing capabilities for Astro components tested in isolation, including 
 - Integration with testing libraries (Testing Library, Vitest patterns)
 - Guidance on testing both server-rendered and client-side behavior
 
-### Play Functions for Astro Components
-
-🚧 **Partial** — works under the Storybook Test addon; unverified in the canvas
-
-Play functions on Astro component stories **do** run under [`@storybook/addon-vitest`](/guides/testing/#storybook-test-addon-storybookaddon-vitest): `@testing-library/user-event` interactions and assertions resolve against the server-rendered HTML, on Astro 5, 6 and 7. The `Counter` and `Accordion` stories in the integration apps cover this.
-
-What has *not* been verified is the same story running in the Storybook UI — the canvas and the Interactions panel. Both paths go through the renderer's `renderToCanvas`, so this is likely to work already, but until someone checks it this entry stays partial rather than supported.
-
-**Complexity**: Low — most likely verification and documentation rather than new code
-
-**What this still requires**:
-- Confirming play functions execute in the dev canvas after the server-rendered HTML is injected
-- Confirming the Interactions panel steps through them
-- Handling re-renders with new args (Controls changes) between play function runs
-
 ### Code Panel Source for Astro Components
 
 📋 **To Do**
@@ -160,6 +145,14 @@ This was previously listed as blocked by [withastro/astro#16275](https://github.
 **Known limitation**: `@storybook/addon-vitest` resolves each `stories` entry against your `.storybook` directory, so an absolute story glob matches nothing and those stories are silently untested. Keep story globs relative — see [Story globs must be relative](/guides/testing/#story-globs-must-be-relative).
 
 **Documentation**: See the [Testing guide](/guides/testing/#storybook-test-addon-storybookaddon-vitest)
+
+### Play Functions for Astro Components
+
+**Status**: Shipped (unreleased)
+
+[Play functions](https://storybook.js.org/docs/writing-stories/play-function) run on Astro component stories, on Astro 5, 6 and 7. `@testing-library/user-event` interactions and assertions resolve against the server-rendered HTML, in the dev canvas and under [`@storybook/addon-vitest`](/guides/testing/#storybook-test-addon-storybookaddon-vitest) alike, and the Interactions panel lists each step with its pass/fail state and the usual step-through controls. The `Counter` and `Accordion` stories in the integration apps cover this.
+
+**One difference from framework components**: changing a Control after a play function has run re-renders the story from fresh server HTML, which discards whatever the play function did to the DOM. A React component keeps that state, because React reconciles the existing tree. Neither re-runs the play function on an args change — that part matches Storybook's normal behaviour — so after changing a Control the Interactions panel shows a result that no longer describes what is on screen. Re-select the story to run it again.
 
 ### Decorator Support
 
@@ -296,7 +289,7 @@ This table tracks compatibility of Storybook's built-in features when used with 
 | Portable Stories | ✅ Supported | `composeStories`, `composeStory`, `setProjectAnnotations` for testing |
 | Portable Stories Testing (Vitest) | ✅ Supported | Test stories with `@storybook-astro/framework/testing`'s `composeStories`/`renderStory` and Vitest, outside Storybook |
 | Storybook Test Addon (`@storybook/addon-vitest`) | ✅ Supported | Runs stories as Vitest browser tests on Astro 5, 6 and 7. See the [Testing guide](/guides/testing/) |
-| Play Functions | 🚧 Partial | Supported for framework components. Astro components: verified under the Storybook Test addon, unverified in the canvas — see roadmap item above |
+| Play Functions | ✅ Supported | Works for both framework and Astro component stories, in the dev canvas and under the Storybook Test addon. One caveat on args changes — see roadmap item above |
 | Interactions Panel | ✅ Supported | Debug play function interactions |
 | Accessibility Addon | ✅ Supported | Automated accessibility testing with a11y addon |
 | Theming | ✅ Supported | Storybook UI theming and customization |

--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -148,9 +148,11 @@ This was previously listed as blocked by [withastro/astro#16275](https://github.
 
 ### Play Functions for Astro Components
 
-**Status**: Shipped (unreleased)
+**Shipped in**: 1.7.0
 
-[Play functions](https://storybook.js.org/docs/writing-stories/play-function) run on Astro component stories, on Astro 5, 6 and 7. `@testing-library/user-event` interactions and assertions resolve against the server-rendered HTML, in the dev canvas and under [`@storybook/addon-vitest`](/guides/testing/#storybook-test-addon-storybookaddon-vitest) alike, and the Interactions panel lists each step with its pass/fail state and the usual step-through controls. The `Counter` and `Accordion` stories in the integration apps cover this.
+[Play functions](https://storybook.js.org/docs/writing-stories/play-function) run on Astro component stories, on Astro 5, 6 and 7. `@testing-library/user-event` interactions and assertions resolve against the server-rendered HTML, and the Interactions panel lists each step with its pass/fail state and the usual step-through controls. The `Counter` and `Accordion` stories in the integration apps cover this.
+
+This has worked in the dev canvas since 1.7.0. Running the same play functions headlessly under [`@storybook/addon-vitest`](/guides/testing/#storybook-test-addon-storybookaddon-vitest) arrived later, in 1.11.0.
 
 **One difference from framework components**: changing a Control after a play function has run re-renders the story from fresh server HTML, which discards whatever the play function did to the DOM. A React component keeps that state, because React reconciles the existing tree. Neither re-runs the play function on an args change — that part matches Storybook's normal behaviour — so after changing a Control the Interactions panel shows a result that no longer describes what is on screen. Re-select the story to run it again.
 


### PR DESCRIPTION
Two roadmap corrections. Docs-only.

## 1. Play Functions — verified, and shipped earlier than the entry claimed (#160)

The entry said play functions were verified only under the Storybook Test addon and **unverified in the canvas**. That hedge was mine, and it was wrong.

Ran `storybook dev` against `integration/astro7` and opened the stories directly:

- **`Astro/Counter → Click Increment`** — canvas shows `Astro counter: 2`; Interactions panel **PASS**, both steps, step-through controls active
- **`Astro/Accordion → Toggle Open`** — **PASS**, all 4 steps, accordion expanded

I first labelled this "Shipped (unreleased)", which was also wrong — v1.11.0 added `@storybook/addon-vitest` support, a separate surface that never touched the canvas path. Checking out **v1.7.0** and running it in a browser shows the Counter play function passing in the canvas with the Interactions panel reporting PASS. 1.7.0 is where Astro play-function stories first appear (added alongside Astro 7 compatibility, #133), and `renderToCanvas` already awaited the server render then.

The entry now splits the dates instead of blurring them: **dev canvas since 1.7.0**, **headless under addon-vitest since 1.11.0**.

**One documented difference from framework components.** No framework story in the repo had a play function, so I temporarily added one to the React Accordion to compare, then reverted it. Changing a Control *after* a play function has run: React keeps the state (reconciliation), Astro resets (fresh server HTML discards the DOM changes). Neither re-runs the play function, so replay semantics match — only state preservation differs, inherent to render-and-replace SSR. Now stated in the entry rather than left unknown.

Moved to **Recently Completed**; support matrix row 🚧 → ✅.

*(A permanent framework play-function story, so this gap can't reappear unnoticed, is in #178.)*

## 2. Enhanced Testing & Portable Stories — scoped to what's actually left (#158)

The entry listed four outstanding items. **Two have shipped:**

- **Testing helpers** — `composeStories`, `composeStory`, `setProjectAnnotations`, `renderStory`, `renderAstroStory`, `defineConfig`
- **Testing library integration** — `@testing-library/dom` against server-rendered output, and addon-vitest in 1.11.0

**What remains is documentation, and the material already exists in the repo.** Composed-component testing — slots, nesting, components as props, decorators — is covered by `Nesting.test.ts` and `SlotBox.test.ts`, but appears nowhere in the Testing guide. Same for guidance on choosing between portable stories and the test addon. Also noted: `renderAstroStory` is exported but missing from the guide's helper list.

Complexity drops **Medium → Low**. The entry **stays under Medium Priority** — unlike docgen, addon-vitest and play functions, this one is genuinely unfinished.

## Verification

`yarn lint:links` clean, website builds, anchors verified in the built HTML. No CHANGELOG entry — website-only, no package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
