### PR TITLE
test: cover play functions on the framework rendering path (#160)

### DIFF
--- a/packages/components/src/Accordion/react/Accordion.stories.js
+++ b/packages/components/src/Accordion/react/Accordion.stories.js
@@ -1,3 +1,4 @@
+import { userEvent, within, expect } from 'storybook/test';
 import Accordion from './Accordion.tsx';
 
 export default {
@@ -55,5 +56,32 @@ export const AllowMultiple = {
       { title: 'Second Item', content: 'Try clicking on multiple headers.' },
       { title: 'Third Item', content: 'All can be open simultaneously.' },
     ],
+  },
+};
+
+// Deliberately mirrors the Astro Accordion's `ToggleOpen` story assertion for
+// assertion, so the two rendering paths are held to the same behaviour.
+//
+// Astro stories are server-rendered and injected into the canvas; framework
+// stories are delegated to the framework's own renderer before `storyFn()` runs
+// (see `renderToCanvas` in @storybook-astro/renderer). Play functions have to
+// work identically across both, and until this story existed nothing covered
+// the framework half — the delegation path could have broken without a single
+// test failing (#160).
+export const ToggleOpen = {
+  parameters: {
+    docs: { description: { story: 'Interaction test: click a header and verify section expands.' } },
+  },
+  args: {
+    items: [{ title: 'Section 1', content: 'Content for section 1' }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const header = canvas.getByRole('button', { name: /Section 1/ });
+
+    await expect(header).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(header);
+    await expect(header).toHaveAttribute('aria-expanded', 'true');
+    await expect(canvas.getByText('Content for section 1')).toBeVisible();
   },
 };


### PR DESCRIPTION
Follow-up to #160 / #177.

## The gap

Storybook Astro has two rendering paths, and play functions have to behave identically on both:

- **Astro stories** — server-rendered, HTML injected into the canvas
- **Framework stories** — delegated to the framework's own renderer *before* `storyFn()` runs (see `renderToCanvas` in `@storybook-astro/renderer`)

The Astro half has been covered since #174 (`Counter`, `Accordion`). The framework half had **no play function anywhere in the repo** — so the delegation path could have broken without a single test failing.

That gap is what made verifying #160 awkward: to compare the two paths I had to hand-build a temporary play function on the React Accordion, then throw it away. Nothing was left behind to catch a regression.

## The fix

Adds `ToggleOpen` to the React Accordion, mirroring the Astro Accordion's story of the same name **assertion for assertion** — both components already expose the same `aria-expanded` contract:

```js
await expect(header).toHaveAttribute('aria-expanded', 'false');
await userEvent.click(header);
await expect(header).toHaveAttribute('aria-expanded', 'true');
await expect(canvas.getByText('Content for section 1')).toBeVisible();
```

Identical assertions on both paths means a divergence shows up as a **failure**, not as a subtlety someone has to notice in a screenshot.

## Verified it can fail

A regression test that can't fail proves nothing — that discipline is what caught a wrong root-cause attribution in #176. Breaking the post-click assertion (`'true'` → `'BROKEN'`) fails the story in browser mode:

```
× Toggle Open 39ms
FAIL |astro7-storybook (chromium)| .../Accordion/react/Accordion.stories.js > Toggle Open
```

Then restored, and confirmed clean.

## Verification

- addon-vitest suites each gain exactly one test: **72/75/80 → 73/76/81**, all passing
- Confirmed it genuinely executes rather than being skipped — `Accordion/react/Accordion.stories.js: Toggle Open -> passed` in the JSON reporter output
- `yarn lint` clean, `yarn test` green, Storybook builds succeed for all three integration apps

**Note for review:** this adds a story, so Chromatic will report a new snapshot to accept on each integration app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
