### PR TITLE
docs(testing): composed components, choosing an approach, renderAstroStory (#158)

### DIFF
--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -21,23 +21,6 @@ A `create-storybook-astro` CLI that generates a new Astro project with Storybook
 - An example Astro component and its story file so the first `yarn storybook` renders something real
 - Optional prompts for framework integrations (React, Vue, Svelte, etc.) and TypeScript
 
-### Enhanced Testing & Portable Stories
-
-🚧 **Documentation only** — the APIs are done
-
-The testing APIs and tooling are in place. What is left is writing up patterns that already work but are not documented anywhere.
-
-**Complexity**: Low — writing, not engineering
-
-**Done**:
-- Testing helpers — `composeStories`, `composeStory`, `setProjectAnnotations`, `renderStory`, `renderAstroStory`, and `defineConfig` from `@storybook-astro/framework/vitest`
-- Testing library integration — `@testing-library/dom` works against server-rendered output, and [`@storybook/addon-vitest`](/guides/testing/#storybook-test-addon-storybookaddon-vitest) runs stories as browser tests (1.11.0)
-
-**Still to do**:
-- Examples for testing composed components — slots, nested components, components passed as props, and decorators. The patterns already work and are covered by tests in the repo (`Nesting.test.ts`, `SlotBox.test.ts`); they have simply never been written up in the [Testing guide](/guides/testing/)
-- Guidance on choosing between the two approaches: portable stories for fast assertions on server-rendered output, and the Storybook Test addon when a test needs real interaction
-- `renderAstroStory` is exported but missing from the guide's helper list
-
 ### Code Panel Source for Astro Components
 
 📋 **To Do**
@@ -156,6 +139,14 @@ This was previously listed as blocked by [withastro/astro#16275](https://github.
 This has worked in the dev canvas since 1.7.0. Running the same play functions headlessly under [`@storybook/addon-vitest`](/guides/testing/#storybook-test-addon-storybookaddon-vitest) arrived later, in 1.11.0.
 
 **One difference from framework components**: changing a Control after a play function has run re-renders the story from fresh server HTML, which discards whatever the play function did to the DOM. A React component keeps that state, because React reconciles the existing tree. Neither re-runs the play function on an args change — that part matches Storybook's normal behaviour — so after changing a Control the Interactions panel shows a result that no longer describes what is on screen. Re-select the story to run it again.
+
+### Enhanced Testing & Portable Stories
+
+**Status**: Complete — the APIs shipped across earlier releases; the remaining work was documentation, which is now live
+
+Testing helpers — `composeStories`, `composeStory`, `setProjectAnnotations`, `renderStory`, `renderAstroStory`, and `defineConfig` from `@storybook-astro/framework/vitest` — cover composing and rendering stories outside Storybook. `@testing-library/dom` queries resolve against the server-rendered output, and [`@storybook/addon-vitest`](/guides/testing/#storybook-test-addon-storybookaddon-vitest) runs stories as real browser tests (1.11.0).
+
+The [Testing guide](/guides/testing/) documents both halves: [choosing between the two approaches](/guides/testing/#choosing-an-approach) — portable stories for fast assertions on server-rendered output, the test addon when a test needs real interaction — and [testing composed components](/guides/testing/#testing-composed-components), covering slots, children with their own props and slots, components passed as props, and decorators.
 
 ### Decorator Support
 

--- a/apps/website/src/content/docs/guides/testing.md
+++ b/apps/website/src/content/docs/guides/testing.md
@@ -22,6 +22,30 @@ last 4.0 release, still reproduces it.
 The framework declares this as an optional peer dependency, so your package
 manager will warn if you are below the floor.
 
+## Choosing an approach
+
+There are two ways to test stories, and they are good at different things.
+
+**Portable stories** — `composeStories` + `renderStory`, described below. Runs in
+Node under happy-dom with no browser, so it is fast. `renderStory` renders the
+story through Astro's Container API and puts the resulting HTML into
+`document.body`, which you then assert on with `@testing-library/dom`. Use it for
+what the component *renders*: content, structure, props, slots, nesting,
+decorators.
+
+**The [Storybook Test addon](#storybook-test-addon-storybookaddon-vitest)** —
+runs every story as a test in a real browser via Playwright, with no test file to
+write. Use it when a test needs real *interaction*: clicking, typing, focus, and
+anything driven by a [play function](https://storybook.js.org/docs/writing-stories/play-function).
+
+The dividing line is interaction. Because portable stories render into happy-dom
+rather than a browser, `@testing-library/user-event` is unreliable there — it is
+the one thing the fast path cannot do well. Reach for the test addon at that
+point rather than fighting it.
+
+The two compose fine: most projects assert rendered output with portable stories
+and let the test addon cover the stories that have play functions.
+
 ## Basic test setup
 
 ```jsx
@@ -80,7 +104,133 @@ From `@storybook-astro/framework/testing`:
 - `composeStories(storiesImport, projectAnnotations?)`
 - `composeStory(story, componentAnnotations, projectAnnotations?, exportsName?)`
 - `setProjectAnnotations(annotations)`
-- `renderStory(story)`
+- `renderStory(story)` — renders the composed story and replaces `document.body`
+  with its HTML, so `screen` queries resolve against it
+- `renderAstroStory(story)` — an alias for `renderStory`, kept for readability in
+  suites that also render framework components
+
+## Testing composed components
+
+Slots, nested components, components passed as props, and decorators all render
+through the same server-side pipeline, so `renderStory` handles them without any
+extra setup. `within` is useful here: it scopes a query to a subtree, which is
+how you assert that a child ended up *inside* its parent rather than beside it.
+
+### A component in a slot
+
+Pass the imported component reference as slot content and assert it rendered
+inside the parent:
+
+```typescript
+import { screen, within } from '@testing-library/dom';
+import { test, expect } from 'vitest';
+import { composeStories, renderStory } from '@storybook-astro/framework/testing';
+import * as stories from './SlotNesting.stories.jsx';
+
+const { ComponentInSlot } = composeStories(stories);
+
+test('the badge renders inside the panel slot', async () => {
+  await renderStory(ComponentInSlot);
+
+  const panel = screen.getByTestId('panel');
+
+  expect(within(panel).getByTestId('badge')).toBeInTheDocument();
+});
+```
+
+String slot content is sanitized, because it is raw HTML — assert on text rather
+than on a `data-*` attribute the allowlist may strip.
+
+### A child with its own props and slots
+
+A slot entry can be a `{ component, props, slots }` descriptor, giving the child
+its own content:
+
+```typescript
+export const ConfiguredChild = {
+  args: {
+    slots: {
+      default: {
+        component: BoxChild,
+        props: { label: 'Child label' },
+        slots: { default: '<p>Lorem ipsum dolor sit amet</p>' },
+      },
+    },
+  },
+};
+```
+
+```typescript
+test('the child renders as a real component, with its props and slot', async () => {
+  await renderStory(ConfiguredChild);
+
+  expect(await screen.findByTestId('box-child')).toBeInTheDocument();
+  expect(screen.getByText('Child label')).toBeInTheDocument();
+  expect(screen.getByText('Lorem ipsum dolor sit amet')).toBeInTheDocument();
+});
+```
+
+A slot can also be an array mixing plain HTML with components, including a
+wrapper whose opening and closing tags live in separate entries. The array is
+sanitized as one document, so the child nests inside the wrapper:
+
+```typescript
+args: {
+  slots: {
+    default: [
+      '<div class="Wrapper">',
+      { component: BoxChild, slots: { default: '<p>Inside the wrapper</p>' } },
+      '</div>',
+    ],
+  },
+}
+```
+
+```typescript
+test('the child nests inside the wrapper', async () => {
+  await renderStory(WrappedChild);
+
+  expect(document.querySelector('.Wrapper')).toContainElement(
+    screen.getByTestId('box-child')
+  );
+});
+```
+
+### A component passed as a prop
+
+```typescript
+export const ComponentAsProp = {
+  args: { label: 'Save', Icon: Badge },
+};
+```
+
+```typescript
+test('the icon renders through the parent template', async () => {
+  await renderStory(ComponentAsProp);
+
+  const button = screen.getByTestId('icon-button');
+
+  expect(within(button).getByTestId('badge')).toBeInTheDocument();
+  expect(button).toHaveTextContent('Save');
+});
+```
+
+### Decorators
+
+Component-level decorators need nothing special — `composeStories` applies them,
+so the story renders wrapped exactly as it does in Storybook.
+
+Global decorators are not in the story file, so pass them as the second argument
+to `composeStories` (or register them once with `setProjectAnnotations`):
+
+```typescript
+const { Undecorated } = composeStories(stories, {
+  decorators: [(_Story) => ({ component: Wrapper, props: { label: 'Global' } })],
+});
+```
+
+See the [Slots](/writing-stories/slots/), [Props](/writing-stories/props/) and
+[Decorators](/writing-stories/decorators/) guides for the authoring side of each.
 
 ## Storybook Test addon (`@storybook/addon-vitest`)
 


### PR DESCRIPTION
Closes #158.

Documentation only. All three remaining items were write-ups of behaviour that already worked — no new capability, no package change.

## 1. Choosing an approach

The guide described two testing paths but never said which to reach for. New section up front:

- **Portable stories** — Node + happy-dom, fast, no browser. `renderStory` puts the story's HTML into `document.body` for `@testing-library/dom` to query. Good for what a component *renders*.
- **Storybook Test addon** — real browser via Playwright, no test file to write. Good when a test needs real *interaction*.

The dividing line is stated plainly: `user-event` is unreliable under happy-dom, so that's the point to switch rather than fight it.

This guidance already existed — I wrote it in a comment on #21 — but it only ever lived in a GitHub thread.

## 2. Testing composed components

The guide had **no mention of slots, nesting or decorators at all**, despite `Nesting.test.ts` and `SlotBox.test.ts` covering exactly those patterns. New section covering:

- a component in a slot (and the note that string slots are sanitized, so assert on text not `data-*`)
- a child with its own props and slots via the `{ component, props, slots }` descriptor
- arrays mixing HTML with components, including a wrapper whose tags are split across entries
- a component passed as a prop
- decorators — component-level automatically, global via `composeStories`' second argument

Cross-linked to the Slots, Props and Decorators guides for the authoring side.

## 3. `renderAstroStory`

Exported from `/testing` but missing from the helper list. Now documented as what it actually is — an alias for `renderStory`. Both entries also say where the HTML lands (`document.body`), which is what makes `screen` queries work.

## Every example was run before being written down

The examples are drawn from tests that already pass in CI. Two I **condensed** rather than copied verbatim, so I executed those as throwaway test files first — both pass:

- `expect(document.querySelector('.Wrapper')).toContainElement(screen.getByTestId('box-child'))`
- the `findByTestId` + props + slot assertions for the configured child

Scratch files removed; the working tree contains only the docs change.

## Roadmap

Entry moved to **Recently Completed**, labelled:

> **Status**: Complete — the APIs shipped across earlier releases; the remaining work was documentation, which is now live

Deliberately *not* "Shipped (unreleased)". The helpers shipped across earlier releases and only the docs were outstanding — labelling it with a package version would repeat the mistake corrected in #177, where I wrongly attributed play functions to 1.11.0 when they had worked since 1.7.0.

## Verification

`yarn lint:links` clean, website builds, and all three cross-links plus the two new in-page anchors verified against the built HTML. No CHANGELOG entry — website-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
