### PR TITLE
feat(renderer): generate Astro source for Docs "Show code" and the Code Panel (#106)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ This document provides guidance for AI assistants working on the `@storybook-ast
 - `src/render.tsx` - Exports `render()` and `renderToCanvas()` functions
 - `src/preset.ts` - Defines preview annotations
 - `src/extractArgTypes.ts` - Maps the `__docgenInfo` the framework attaches to a component stub into Storybook's props table. Registered through `preview-defaults.ts` so both CSF3 and CSF-factory stories pick it up
+- `src/docs/` - Docs "Show code" / Code Panel source. `generateAstroSource.ts` turns a story's component and args into Astro template text (pure, no Storybook imports); `sourceDecorator.ts` emits it via `emitTransformCode`. Shipped as the `entry-preview-docs` annotation, which `preset.ts` loads only when addon-docs is enabled. Design record: `docs/specs/code-panel-source.md`
 - `src/decorators.ts` - `applyDecorators`, the renderer's `applyDecorators` project annotation. Composes a story's `decorators` array into a `SlotValue` tree for Astro stories (Decision 2 in `docs/specs/decorators.md#design-decisions`), or defers to Storybook's `defaultDecorateStory` for framework-delegated stories (`parameters.renderer` set)
 
 ### Data Flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Docs "Show code" and the Code Panel now show the Astro template a story's args describe — `<Card title="Hello" featured>` — instead of falling back to the raw story file (#106, #161). The snippet regenerates on every render, so it follows Controls changes, and a manual `parameters.docs.source.code` still overrides it. Framework component stories are unaffected. The generator is shipped as a docs-only preview annotation, so projects without `@storybook/addon-docs` don't load it. See [Showing component source](https://storybook-astro.org/writing-stories/controls/#showing-component-source) for the serialization rules.
+
 ## [1.11.0] - 2026-08-27
 
 ### Added

--- a/apps/website/src/content/docs/guides/roadmap.md
+++ b/apps/website/src/content/docs/guides/roadmap.md
@@ -21,22 +21,6 @@ A `create-storybook-astro` CLI that generates a new Astro project with Storybook
 - An example Astro component and its story file so the first `yarn storybook` renders something real
 - Optional prompts for framework integrations (React, Vue, Svelte, etc.) and TypeScript
 
-### Code Panel Source for Astro Components
-
-📋 **To Do**
-
-The Storybook Docs "Show code" / Code Panel currently falls back to displaying the raw story file source because the framework doesn't implement a `sourceDecorator`. The panel should show the Astro template syntax for the component being rendered with the story's args (e.g. `<HeroHijri imageUrl="..." />`).
-
-**Complexity**: Medium
-**Tracking**: [Issue #106 — Code Panel shows story source instead of component usage](https://github.com/storybook-astro/storybook-astro/issues/106)
-
-**What this requires**:
-- A `sourceDecorator` registered via `entry-preview.ts` that intercepts story renders and records the component + args
-- An Astro template serializer that maps `{ component, args }` to a `.astro` template string, including decisions about bare string attributes vs. `{expression}` bindings and slot handling
-- Parity with how `@storybook/react`, `@storybook/vue3`, and similar packages implement dynamic source for their template syntaxes
-
-**Workaround**: Set `parameters.docs.source.code` manually on any story where you want a specific snippet shown.
-
 ### Astro Panel Addon
 
 📋 **To Do**
@@ -107,6 +91,16 @@ Integration with Astro's middleware system and `astro:env` module for managing e
 Support for Astro's built-in i18n routing and helpers, enabling documentation of multi-language components.
 
 ## Recently Completed
+
+### Code Panel Source for Astro Components
+
+**Status**: Shipped (unreleased)
+
+Docs "Show code" and the Code Panel show the Astro template a story's args describe — `<Card title="Hello" featured>` — instead of falling back to the raw story file. The snippet regenerates on every render, so it follows Controls changes, and `parameters.docs.source.code` still overrides it.
+
+See [Showing component source](/writing-stories/controls/#showing-component-source) for the serialization rules. Framework component stories are unaffected: they render through their own framework, so no Astro snippet is generated for them.
+
+**Tracking**: [Issue #106](https://github.com/storybook-astro/storybook-astro/issues/106), [Issue #161](https://github.com/storybook-astro/storybook-astro/issues/161)
 
 ### Automatic Documentation Extraction from JSDoc
 
@@ -278,7 +272,7 @@ This table tracks compatibility of Storybook's built-in features when used with 
 | Measure & Outline | ✅ Supported | Visual debugging tools for spacing and layout |
 | Component Description | 🚧 Manual | Component descriptions must be set manually via `parameters.docs.description.component` (automatic extraction from JSDoc planned) |
 | ArgTypes Documentation | ✅ Supported | Descriptions, types and defaults are extracted from `.astro` frontmatter JSDoc; `argTypes[].description` still overrides. See [Controls & ArgTypes](/writing-stories/controls/) |
-| Source Code Display | 🚧 Partial | Shows story file source; doesn't generate component usage syntax (e.g. `<Component prop="value" />`). See roadmap item above |
+| Source Code Display | ✅ Supported | Docs "Show code" and the Code Panel show generated Astro usage (e.g. `<Component prop="value" />`) that follows Controls changes. See [Showing component source](/writing-stories/controls/#showing-component-source) |
 | Decorators | ✅ Supported | Wrapper components/HTML for stories, in global/component/story positions. See [Decorators guide](/writing-stories/decorators/) and [design record](https://github.com/storybook-astro/storybook-astro/blob/develop/docs/specs/decorators.md) |
 | Portable Stories | ✅ Supported | `composeStories`, `composeStory`, `setProjectAnnotations` for testing |
 | Portable Stories Testing (Vitest) | ✅ Supported | Test stories with `@storybook-astro/framework/testing`'s `composeStories`/`renderStory` and Vitest, outside Storybook |

--- a/apps/website/src/content/docs/writing-stories/controls.md
+++ b/apps/website/src/content/docs/writing-stories/controls.md
@@ -190,6 +190,29 @@ The import path is always written as a sibling (`./Card.astro`). It is a usage
 sample rather than a copy of your file layout, so adjust it to wherever the
 component actually lives.
 
+### Turning the Code panel on everywhere
+
+`docs.codePanel` is an ordinary Storybook parameter, so setting it once in
+`.storybook/preview.js` enables the **Code** panel for every story in the
+project — no per-story opt-in:
+
+```javascript
+// .storybook/preview.js
+const preview = {
+  parameters: {
+    docs: { codePanel: true },
+  },
+};
+
+export default preview;
+```
+
+Individual stories can still opt out with `docs: { codePanel: false }`, and the
+same cascade works at the component level via the meta's `parameters`.
+
+The "Show code" block under stories on a docs page needs no parameter at all —
+it is always available.
+
 ### Overriding the snippet
 
 Set `parameters.docs.source.code` to show something specific instead — a manual

--- a/apps/website/src/content/docs/writing-stories/controls.md
+++ b/apps/website/src/content/docs/writing-stories/controls.md
@@ -150,6 +150,63 @@ installed, and during test builds.
 It needs TypeScript 5.0 or newer, which Astro projects already have. Without it,
 docgen is skipped with a warning and everything else keeps working.
 
+## Showing component source
+
+Docs pages render a **Show code** block under each story, and stories with
+`parameters.docs.codePanel = true` also get a **Code** panel. Both show the Astro
+template your story's args describe, generated fresh on every render — so it
+follows along as you change Controls:
+
+```astro
+---
+import Card from './Card.astro';
+---
+<Card title="Hello" featured>
+  <p>Body content</p>
+</Card>
+```
+
+The snippet describes the component and its args, not the decorators around it,
+so it stays the usage you would copy into a page.
+
+### How values are serialized
+
+| Arg value | Emitted as |
+| --- | --- |
+| `'text'` | `title="text"` — single-quoted if it contains `"`, a template literal if it contains both quote kinds or a newline |
+| `true` | `featured` (bare attribute) |
+| `false` | `featured={false}` |
+| number / bigint | `count={42}` |
+| `Date` | `published={new Date("2026-06-11T10:00:00.000Z")}` |
+| object / array | `author={author}`, with `const author = …` hoisted into the frontmatter |
+| `''`, `null`, `undefined`, functions | omitted |
+
+`args.slots` becomes the component's children — the `default` slot inline, and
+named slots wrapped in `<Fragment slot="name">`. A component (rather than a
+string) passed as slot content is shown as a placeholder comment, since it has no
+literal template form.
+
+The import path is always written as a sibling (`./Card.astro`). It is a usage
+sample rather than a copy of your file layout, so adjust it to wherever the
+component actually lives.
+
+### Overriding the snippet
+
+Set `parameters.docs.source.code` to show something specific instead — a manual
+snippet always wins:
+
+```javascript
+export const Custom = {
+  parameters: {
+    docs: { source: { code: '<Card title="Handwritten" />' } },
+  },
+};
+```
+
+Framework component stories (`parameters.renderer` set to `react`, `vue`, and so
+on) are left alone: they render through their own framework, so no Astro snippet
+is generated for them.
+
 ## Static build limitation
 
 In static builds (`storybook build`), Astro components are pre-rendered at build

--- a/docs/specs/code-panel-source.md
+++ b/docs/specs/code-panel-source.md
@@ -50,7 +50,9 @@ Stories delegated via `parameters.renderer` render through the framework's `rend
 
 **Decision 4 — Generate from context, not from output.** Source comes from `ctx.component` + `ctx.args`. This makes the decorator order-independent and immune to the decorator-support feature (`docs/specs/decorators.md`): when `storyFn()` starts returning renderable trees, the source decorator still passes the value through untouched and the snippet still shows the undecorated component usage — which is the desired behavior (parity with `excludeDecorators` defaults elsewhere).
 
-**Decision 5 — Component name resolution order.** `component.__docgenInfo.displayName` (populated by the docgen extractor, `docs/specs/docgen.md`) → basename of `component.moduleId` without `.astro` → last segment of `ctx.title`. Import path: `moduleId` relative to `dirname(parameters.fileName)` when both are available, else `./<Name>.astro`.
+**Decision 5 — Component name resolution order.** `component.__docgenInfo.displayName` (populated by the docgen extractor, `docs/specs/docgen.md`) → basename of `component.moduleId` without `.astro` → last segment of `ctx.title`.
+
+**Decision 6 — The import is always a sibling path.** This plan originally derived the import from `moduleId` relative to `dirname(parameters.fileName)`. That cannot work: Storybook reports `parameters.fileName` **relative to the project root** (`./src/components/Card.stories.jsx`) while the stub's `moduleId` is **absolute**, so the two are in different coordinate systems. Comparing them produced imports like `'../../../../Users/…/packages/components/src/Card/astro/Card.astro'`. Even with both made absolute, a component imported across packages has no relative path worth showing — the real specifier is a bare one (`@scope/components/Card.astro`) that the story context does not carry. The snippet is a usage sample, so it emits `./<Basename>.astro` and the reader adapts it.
 
 ## Source Generation Spec
 
@@ -99,7 +101,8 @@ const author = { name: "Ada", role: "Engineer" };
 
 ### Step 2 — Source decorator and wiring
 
-- `packages/@storybook-astro/renderer/src/docs/sourceDecorator.ts`: calls `storyFn()` and returns it; inside `useEffect`, skips per the standard logic (`__isArgsStory`, `docs.source.code`, `SourceType.CODE` / forced `DYNAMIC` — import `SourceType` from `storybook/internal/docs-tools`), additionally skips stories with `parameters.renderer` set and components that aren't Astro stubs (no `moduleId` and no string/HTMLElement story); otherwise emits via `emitTransformCode`.
+- `packages/@storybook-astro/renderer/src/docs/sourceDecorator.ts`: calls `storyFn()` and returns it; inside `useEffect`, skips per the standard logic (`__isArgsStory`, `docs.source.code`, `SourceType.CODE` / forced `DYNAMIC` — import `SourceType` from `storybook/internal/docs-tools`), additionally skips **framework-delegated** stories and components that aren't Astro stubs (no `moduleId`); otherwise emits via `emitTransformCode`.
+  > A framework story is one whose `parameters.renderer` is set to something **other than `'astro'`** — not merely "set". `entry-preview.ts` gives every story `renderer: 'astro'`, so skipping on presence alone would emit nothing at all. See the note on `applyDecorators` in `renderer/src/decorators.ts`.
 - `packages/@storybook-astro/renderer/src/entry-preview-docs.ts`: `export const decorators = [sourceDecorator];`
 - `renderer/package.json`: add `./entry-preview-docs` export; `tsup.config.ts`: add the entry (runtime-only, no DTS — same treatment as `entry-preview`).
 - `renderer/src/preset.ts`: append the docs entry to `previewAnnotations` when the docs preset is enabled.
@@ -109,7 +112,7 @@ const author = { name: "Ada", role: "Engineer" };
 ### Step 3 — Integration verification
 
 - In `integration/astro6` (has `@storybook/addon-docs`): verify "Show code" on an existing autodocs page shows the generated Astro snippet and live-updates when controls change args; add one story with `parameters.docs.codePanel = true` exercising the Code Panel; one story with `parameters.docs.source.code` proving the workaround still wins.
-- Spot-check `integration/astro5` and `integration/astro6-csf4` (CSF4 annotation loading).
+- Spot-check `integration/astro5` and `integration/astro7` (Vite 8 / Rolldown resolves the new entry differently). There is no `integration/astro6-csf4` app — an earlier draft of this plan named one.
 - Confirm a React story's docs page is unchanged (no Astro snippet leakage).
 - Rebuild packages first (`yarn build:packages`) — integration apps consume `dist`.
 

--- a/integration/astro6/src/components/Accordion/Accordion.stories.jsx
+++ b/integration/astro6/src/components/Accordion/Accordion.stories.jsx
@@ -73,3 +73,24 @@ export const ToggleMultiple = {
     await expect(second).toHaveAttribute('aria-expanded', 'true');
   },
 };
+
+// A richer Code Panel case than Card: `items` is an array of objects, so it is
+// hoisted into a frontmatter `const`, and `allowMultiple` renders as a bare
+// boolean attribute (docs/specs/code-panel-source.md#source-generation-spec).
+export const CodePanel = {
+  parameters: {
+    docs: {
+      codePanel: true,
+      description: {
+        story: 'Shows object hoisting and a bare boolean attribute in the generated snippet.',
+      },
+    },
+  },
+  args: {
+    allowMultiple: true,
+    items: [
+      { title: 'Shipping', content: 'Ships within two business days.' },
+      { title: 'Returns', content: 'Free returns for thirty days.' },
+    ],
+  },
+};

--- a/integration/astro6/src/components/Card/Card.stories.jsx
+++ b/integration/astro6/src/components/Card/Card.stories.jsx
@@ -21,3 +21,32 @@ export const Highlight = {
     highlight: true,
   },
 };
+
+// Exercises the Code Panel surface (docs/specs/code-panel-source.md): the same
+// generated snippet feeds both "Show code" and the panel.
+export const CodePanel = {
+  parameters: {
+    docs: {
+      codePanel: true,
+      description: { story: 'Shows the generated Astro snippet in the Code Panel.' },
+    },
+  },
+  args: {
+    title: 'Code panel card',
+    content: 'The panel shows Astro template usage, not this story file.',
+  },
+};
+
+// A user-supplied snippet must always win over the generated one.
+export const CustomSource = {
+  parameters: {
+    docs: {
+      source: { code: '<Card title="Handwritten" />' },
+      description: { story: 'A manual `docs.source.code` overrides the generated snippet.' },
+    },
+  },
+  args: {
+    title: 'Overridden',
+    content: 'The Show code block shows the handwritten snippet instead.',
+  },
+};

--- a/integration/astro7/src/components/Accordion/Accordion.stories.jsx
+++ b/integration/astro7/src/components/Accordion/Accordion.stories.jsx
@@ -73,3 +73,24 @@ export const ToggleMultiple = {
     await expect(second).toHaveAttribute('aria-expanded', 'true');
   },
 };
+
+// A richer Code Panel case than Card: `items` is an array of objects, so it is
+// hoisted into a frontmatter `const`, and `allowMultiple` renders as a bare
+// boolean attribute (docs/specs/code-panel-source.md#source-generation-spec).
+export const CodePanel = {
+  parameters: {
+    docs: {
+      codePanel: true,
+      description: {
+        story: 'Shows object hoisting and a bare boolean attribute in the generated snippet.',
+      },
+    },
+  },
+  args: {
+    allowMultiple: true,
+    items: [
+      { title: 'Shipping', content: 'Ships within two business days.' },
+      { title: 'Returns', content: 'Free returns for thirty days.' },
+    ],
+  },
+};

--- a/integration/astro7/src/components/Card/Card.stories.jsx
+++ b/integration/astro7/src/components/Card/Card.stories.jsx
@@ -21,3 +21,32 @@ export const Highlight = {
     highlight: true,
   },
 };
+
+// Exercises the Code Panel surface (docs/specs/code-panel-source.md): the same
+// generated snippet feeds both "Show code" and the panel.
+export const CodePanel = {
+  parameters: {
+    docs: {
+      codePanel: true,
+      description: { story: 'Shows the generated Astro snippet in the Code Panel.' },
+    },
+  },
+  args: {
+    title: 'Code panel card',
+    content: 'The panel shows Astro template usage, not this story file.',
+  },
+};
+
+// A user-supplied snippet must always win over the generated one.
+export const CustomSource = {
+  parameters: {
+    docs: {
+      source: { code: '<Card title="Handwritten" />' },
+      description: { story: 'A manual `docs.source.code` overrides the generated snippet.' },
+    },
+  },
+  args: {
+    title: 'Overridden',
+    content: 'The Show code block shows the handwritten snippet instead.',
+  },
+};

--- a/packages/@storybook-astro/renderer/package.json
+++ b/packages/@storybook-astro/renderer/package.json
@@ -38,6 +38,7 @@
       "import": "./dist/types.js"
     },
     "./entry-preview": "./dist/entry-preview.js",
+    "./entry-preview-docs": "./dist/entry-preview-docs.js",
     "./preview-defaults": {
       "types": "./dist/preview-defaults.d.ts",
       "import": "./dist/preview-defaults.js"

--- a/packages/@storybook-astro/renderer/src/docs/generateAstroSource.test.ts
+++ b/packages/@storybook-astro/renderer/src/docs/generateAstroSource.test.ts
@@ -1,0 +1,255 @@
+import { describe, test, expect } from 'vitest';
+import {
+  generateAstroSource,
+  resolveComponentName,
+  resolveImportPath
+} from './generateAstroSource.ts';
+
+describe('serializing prop values', () => {
+  test('a string becomes a quoted attribute', () => {
+    expect(generateAstroSource('Card', { title: 'Hello' })).toBe('<Card title="Hello" />');
+  });
+
+  test('a string containing a double quote switches to single quotes', () => {
+    expect(generateAstroSource('Card', { title: 'He said "hi"' })).toBe(
+      `<Card title='He said "hi"' />`
+    );
+  });
+
+  test('a string containing both quote kinds becomes a template literal', () => {
+    expect(generateAstroSource('Card', { title: `it's "quoted"` })).toBe(
+      '<Card title={`it\'s "quoted"`} />'
+    );
+  });
+
+  test('a multi-line string becomes a template literal', () => {
+    expect(generateAstroSource('Card', { body: 'one\ntwo' })).toBe(
+      '<Card body={`one\ntwo`} />'
+    );
+  });
+
+  test('backticks and interpolation in a template literal are escaped', () => {
+    expect(generateAstroSource('Card', { body: 'a `b` ${c}\nd' })).toBe(
+      '<Card body={`a \\`b\\` \\${c}\nd`} />'
+    );
+  });
+
+  test('true renders bare, false renders as an expression', () => {
+    expect(generateAstroSource('Card', { featured: true })).toBe('<Card featured />');
+    expect(generateAstroSource('Card', { featured: false })).toBe('<Card featured={false} />');
+  });
+
+  test('numbers and bigints render as expressions', () => {
+    expect(generateAstroSource('Card', { count: 42 })).toBe('<Card count={42} />');
+    expect(generateAstroSource('Card', { count: 9007199254740993n })).toBe(
+      '<Card count={9007199254740993n} />'
+    );
+  });
+
+  test('a Date renders as a constructor call', () => {
+    const source = generateAstroSource('Card', { published: new Date('2026-06-11T10:00:00Z') });
+
+    expect(source).toBe('<Card published={new Date("2026-06-11T10:00:00.000Z")} />');
+  });
+
+  test('empty, null, undefined and function values are omitted', () => {
+    const source = generateAstroSource('Card', {
+      title: '',
+      subtitle: null,
+      body: undefined,
+      onClick: () => {},
+      kept: 'yes'
+    });
+
+    expect(source).toBe('<Card kept="yes" />');
+  });
+
+  test('props are sorted alphabetically so snippets are stable', () => {
+    expect(generateAstroSource('Card', { zeta: 'z', alpha: 'a' })).toBe(
+      '<Card alpha="a" zeta="z" />'
+    );
+  });
+});
+
+describe('hoisting complex values into frontmatter', () => {
+  test('an object becomes a const and an attribute reference', () => {
+    const source = generateAstroSource('Card', { author: { name: 'Ada', role: 'Engineer' } });
+
+    expect(source).toBe(
+      [
+        '---',
+        'const author = {',
+        '  name: "Ada",',
+        '  role: "Engineer"',
+        '};',
+        '---',
+        '<Card author={author} />'
+      ].join('\n')
+    );
+  });
+
+  test('an array is hoisted the same way', () => {
+    const source = generateAstroSource('List', { items: ['a', 'b'] });
+
+    expect(source).toContain('const items = [\n  "a",\n  "b"\n];');
+    expect(source).toContain('<List items={items} />');
+  });
+
+  test('a const clashing with the component name is suffixed', () => {
+    const source = generateAstroSource('Card', { Card: { a: 1 } });
+
+    expect(source).toContain('const Card2 = {');
+    expect(source).toContain('<Card Card={Card2} />');
+  });
+
+  test('a prop name that is not a valid identifier is sanitised', () => {
+    const source = generateAstroSource('Card', { 'data-config': { a: 1 } });
+
+    expect(source).toContain('const dataconfig = {');
+    expect(source).toContain('data-config={dataconfig}');
+  });
+});
+
+describe('slots', () => {
+  test('a default slot becomes indented children and an open/close tag', () => {
+    const source = generateAstroSource('Card', {
+      title: 'Hi',
+      slots: { default: '<p>Body</p>' }
+    });
+
+    expect(source).toBe('<Card title="Hi">\n  <p>Body</p>\n</Card>');
+  });
+
+  test('a named slot is wrapped in a Fragment', () => {
+    const source = generateAstroSource('Card', {
+      slots: { footer: '<a href="/more">Read more</a>' }
+    });
+
+    expect(source).toBe(
+      '<Card>\n  <Fragment slot="footer"><a href="/more">Read more</a></Fragment>\n</Card>'
+    );
+  });
+
+  test('an array slot joins its string entries', () => {
+    const source = generateAstroSource('Box', {
+      slots: { default: ['<p>one</p>', '<p>two</p>'] }
+    });
+
+    expect(source).toBe('<Box>\n  <p>one</p>\n  <p>two</p>\n</Box>');
+  });
+
+  test('component slot content is marked rather than dropped silently', () => {
+    const source = generateAstroSource('Box', { slots: { default: { component: () => {} } } });
+
+    expect(source).toBe('<Box>\n  <!-- component slot content -->\n</Box>');
+  });
+
+  test('empty slots leave the tag self-closing', () => {
+    expect(generateAstroSource('Card', { slots: { default: '   ' } })).toBe('<Card />');
+    expect(generateAstroSource('Card', { slots: {} })).toBe('<Card />');
+  });
+});
+
+describe('line breaking', () => {
+  test('a tag longer than the print width breaks one attribute per line', () => {
+    const source = generateAstroSource('Hero', {
+      imageAlt: 'Beautiful Mosque Architecture',
+      imageUrl: 'https://example.com/a/rather/long/image/path/that/pushes/past/eighty.jpg'
+    });
+
+    expect(source).toBe(
+      [
+        '<Hero',
+        '  imageAlt="Beautiful Mosque Architecture"',
+        '  imageUrl="https://example.com/a/rather/long/image/path/that/pushes/past/eighty.jpg"',
+        '/>'
+      ].join('\n')
+    );
+  });
+
+  test('a broken tag with children still closes normally', () => {
+    const source = generateAstroSource(
+      'Hero',
+      { title: 'A fairly long title value here', slots: { default: '<p>Body</p>' } },
+      { printWidth: 20 }
+    );
+
+    expect(source).toBe(
+      ['<Hero', '  title="A fairly long title value here"', '>', '  <p>Body</p>', '</Hero>'].join(
+        '\n'
+      )
+    );
+  });
+});
+
+describe('frontmatter', () => {
+  test('an import path produces an import line', () => {
+    const source = generateAstroSource('Card', { title: 'Hi' }, { importPath: './Card.astro' });
+
+    expect(source).toBe(
+      ["---", "import Card from './Card.astro';", '---', '<Card title="Hi" />'].join('\n')
+    );
+  });
+
+  test('an import and a const are separated by a blank line', () => {
+    const source = generateAstroSource(
+      'Card',
+      { author: { name: 'Ada' } },
+      { importPath: './Card.astro' }
+    );
+
+    expect(source.split('\n').slice(0, 4)).toEqual([
+      '---',
+      "import Card from './Card.astro';",
+      '',
+      'const author = {'
+    ]);
+  });
+
+  test('no import and no consts means no frontmatter at all', () => {
+    expect(generateAstroSource('Card', { title: 'Hi' })).toBe('<Card title="Hi" />');
+  });
+});
+
+describe('resolveComponentName', () => {
+  test('prefers the docgen displayName', () => {
+    expect(
+      resolveComponentName({ displayName: 'HeroHijri', moduleId: '/x/Other.astro', title: 'A/B' })
+    ).toBe('HeroHijri');
+  });
+
+  test('falls back to the module basename', () => {
+    expect(resolveComponentName({ moduleId: '/src/components/Card.astro', title: 'A/B' })).toBe(
+      'Card'
+    );
+  });
+
+  test('falls back to the last title segment', () => {
+    expect(resolveComponentName({ title: 'Astro/Layout/Hero' })).toBe('Hero');
+  });
+
+  test('falls back to a generic name when nothing is known', () => {
+    expect(resolveComponentName({})).toBe('Component');
+  });
+});
+
+describe('resolveImportPath', () => {
+  // Storybook reports `parameters.fileName` project-relative while `moduleId`
+  // is absolute, so a derived relative path is meaningless — a sibling import
+  // is what a usage sample should show.
+  test('uses the component file basename', () => {
+    expect(resolveImportPath('/src/components/Card.astro', 'Card')).toBe('./Card.astro');
+  });
+
+  test('normalises Windows separators', () => {
+    expect(resolveImportPath('C:\\p\\src\\Card.astro', 'Card')).toBe('./Card.astro');
+  });
+
+  test('keeps the real filename when it differs from the display name', () => {
+    expect(resolveImportPath('/src/HeroHijri.astro', 'Hero')).toBe('./HeroHijri.astro');
+  });
+
+  test('falls back to the component name when there is no moduleId', () => {
+    expect(resolveImportPath(undefined, 'Card')).toBe('./Card.astro');
+  });
+});

--- a/packages/@storybook-astro/renderer/src/docs/generateAstroSource.ts
+++ b/packages/@storybook-astro/renderer/src/docs/generateAstroSource.ts
@@ -1,0 +1,290 @@
+/**
+ * Turns a story's component and args into the Astro source a user would paste
+ * into a `.astro` file — a frontmatter block with the import, then the tag.
+ *
+ * Pure by design (docs/specs/code-panel-source.md#design-decisions, Decision 2):
+ * the source decorator is a thin shell around this, so every serialization rule
+ * is unit-testable without Storybook or a browser. It runs in the preview
+ * iframe, so there is no `node:path` here either — the relative import path is
+ * derived with plain string work.
+ */
+
+/** Values Storybook can put in `args`. Narrowed as we serialize. */
+type ArgValue = unknown;
+
+export type AstroSourceOptions = {
+  /** Import specifier for the frontmatter. Omitted entirely when absent. */
+  importPath?: string;
+  /** Width at which a tag switches to one-attribute-per-line. */
+  printWidth?: number;
+};
+
+const DEFAULT_PRINT_WIDTH = 80;
+
+/**
+ * Picks the component name, preferring what the docgen extractor found, then
+ * the file it came from, then the story title
+ * (docs/specs/code-panel-source.md#design-decisions, Decision 5).
+ */
+export function resolveComponentName(input: {
+  displayName?: string;
+  moduleId?: string;
+  title?: string;
+}): string {
+  if (input.displayName) {
+    return input.displayName;
+  }
+
+  const fromModule = basenameWithoutAstro(input.moduleId);
+
+  if (fromModule) {
+    return fromModule;
+  }
+
+  const titleSegments = (input.title ?? '').split('/').filter(Boolean);
+
+  return titleSegments[titleSegments.length - 1] || 'Component';
+}
+
+/**
+ * The import line for the frontmatter.
+ *
+ * Deliberately always a sibling import rather than a path derived from the
+ * story's location. Storybook reports `parameters.fileName` relative to the
+ * project root (`./src/components/Card.stories.jsx`) while the stub's
+ * `moduleId` is absolute, so the two cannot be compared — and for a component
+ * imported from another package there is no relative path worth showing
+ * anyway. The snippet is a usage sample, so a plausible sibling import reads
+ * better than a 200-character absolute path.
+ */
+export function resolveImportPath(
+  moduleId: string | undefined,
+  componentName: string
+): string {
+  return `./${basenameWithoutAstro(moduleId) || componentName}.astro`;
+}
+
+export function generateAstroSource(
+  componentName: string,
+  args: Record<string, ArgValue> = {},
+  options: AstroSourceOptions = {}
+): string {
+  const printWidth = options.printWidth ?? DEFAULT_PRINT_WIDTH;
+  const { slots, ...props } = args;
+  const hoisted: string[] = [];
+  const attributes: string[] = [];
+
+  // Alphabetical so a snippet doesn't reshuffle when Storybook happens to
+  // enumerate args in a different order.
+  Object.keys(props)
+    .sort()
+    .forEach((name) => {
+      const attribute = serializeProp(name, props[name], componentName, hoisted);
+
+      if (attribute) {
+        attributes.push(attribute);
+      }
+    });
+
+  const children = serializeSlots(slots);
+  const tag = formatTag(componentName, attributes, children, printWidth);
+  const frontmatter = formatFrontmatter(componentName, options.importPath, hoisted);
+
+  return frontmatter ? `${frontmatter}\n${tag}` : tag;
+}
+
+/** Returns the attribute text, or `null` when the value shouldn't be emitted. */
+function serializeProp(
+  name: string,
+  value: ArgValue,
+  componentName: string,
+  hoisted: string[]
+): string | null {
+  // An absent or empty value is what the component would get by default, so
+  // showing it is noise. Functions have no Astro template representation.
+  if (value === undefined || value === null || value === '' || typeof value === 'function') {
+    return null;
+  }
+
+  if (value === true) {
+    return name;
+  }
+
+  if (value === false) {
+    return `${name}={false}`;
+  }
+
+  if (typeof value === 'number') {
+    return `${name}={${value}}`;
+  }
+
+  if (typeof value === 'bigint') {
+    return `${name}={${value}n}`;
+  }
+
+  if (typeof value === 'string') {
+    return `${name}=${quoteString(value)}`;
+  }
+
+  if (value instanceof Date) {
+    return `${name}={new Date(${JSON.stringify(value.toISOString())})}`;
+  }
+
+  // Objects and arrays would be unreadable inline, so they become a frontmatter
+  // `const` and the attribute references it — the same shape Vue's script-setup
+  // snippets use.
+  const constName = uniqueConstName(name, componentName, hoisted);
+
+  hoisted.push(`const ${constName} = ${prettyPrint(value)};`);
+
+  return `${name}={${constName}}`;
+}
+
+/**
+ * Astro attributes are JSX-like, so a plain string needs quoting that survives
+ * whatever the value contains: double quotes normally, single when the value
+ * has a double quote, and an expression with a template literal when it has
+ * both or spans lines.
+ */
+function quoteString(value: string): string {
+  const hasDouble = value.includes('"');
+  const hasSingle = value.includes("'");
+
+  if (value.includes('\n') || (hasDouble && hasSingle)) {
+    const escaped = value.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+
+    return `{\`${escaped}\`}`;
+  }
+
+  return hasDouble ? `'${value}'` : `"${value}"`;
+}
+
+function serializeSlots(slots: ArgValue): string[] {
+  if (!slots || typeof slots !== 'object' || Array.isArray(slots)) {
+    return [];
+  }
+
+  const entries = Object.entries(slots as Record<string, ArgValue>);
+  const children: string[] = [];
+
+  entries.forEach(([slotName, content]) => {
+    const text = slotContentToString(content);
+
+    if (!text) {
+      return;
+    }
+
+    children.push(
+      slotName === 'default' ? text : `<Fragment slot="${slotName}">${text}</Fragment>`
+    );
+  });
+
+  return children;
+}
+
+/**
+ * Slot content is normally an HTML string. A component reference or descriptor
+ * has no faithful template form, so it is shown as a comment rather than
+ * silently dropped — the reader can see something is there.
+ */
+function slotContentToString(content: ArgValue): string | null {
+  if (typeof content === 'string') {
+    return content.trim() || null;
+  }
+
+  if (Array.isArray(content)) {
+    const parts = content.map(slotContentToString).filter(Boolean);
+
+    return parts.length > 0 ? parts.join('\n') : null;
+  }
+
+  if (content === undefined || content === null) {
+    return null;
+  }
+
+  return '<!-- component slot content -->';
+}
+
+function formatTag(
+  name: string,
+  attributes: string[],
+  children: string[],
+  printWidth: number
+): string {
+  const inline = attributes.length > 0 ? ` ${attributes.join(' ')}` : '';
+  const openInline = `<${name}${inline}>`;
+  const selfClosingInline = `<${name}${inline} />`;
+  const fitsOnOneLine =
+    (children.length > 0 ? openInline.length : selfClosingInline.length) <= printWidth;
+
+  if (children.length === 0) {
+    return fitsOnOneLine ? selfClosingInline : `<${name}\n${indent(attributes)}\n/>`;
+  }
+
+  const open = fitsOnOneLine ? openInline : `<${name}\n${indent(attributes)}\n>`;
+
+  return `${open}\n${indent(children.flatMap((child) => child.split('\n')))}\n</${name}>`;
+}
+
+function formatFrontmatter(
+  componentName: string,
+  importPath: string | undefined,
+  hoisted: string[]
+): string | null {
+  const lines: string[] = [];
+
+  if (importPath) {
+    lines.push(`import ${componentName} from '${importPath}';`);
+  }
+
+  if (hoisted.length > 0) {
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    lines.push(...hoisted);
+  }
+
+  return lines.length > 0 ? `---\n${lines.join('\n')}\n---` : null;
+}
+
+/** JSON with the quotes left on keys only where JS would need them. */
+function prettyPrint(value: ArgValue): string {
+  return JSON.stringify(value, null, 2).replace(/^(\s*)"([A-Za-z_$][\w$]*)":/gm, '$1$2:');
+}
+
+function uniqueConstName(propName: string, componentName: string, hoisted: string[]): string {
+  const base = propName.replace(/[^A-Za-z0-9_$]/g, '') || 'value';
+  const safe = /^[A-Za-z_$]/.test(base) ? base : `_${base}`;
+  const taken = (candidate: string) =>
+    candidate === componentName || hoisted.some((line) => line.startsWith(`const ${candidate} =`));
+
+  if (!taken(safe)) {
+    return safe;
+  }
+
+  let suffix = 2;
+
+  while (taken(`${safe}${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${safe}${suffix}`;
+}
+
+function indent(lines: string[]): string {
+  return lines.map((line) => `  ${line}`).join('\n');
+}
+
+function posixSegments(path: string): string[] {
+  return path.replace(/\\/g, '/').split('/').filter(Boolean);
+}
+
+function basenameWithoutAstro(path: string | undefined): string {
+  if (!path) {
+    return '';
+  }
+
+  const last = posixSegments(path).pop() ?? '';
+
+  return last.replace(/\.astro$/, '');
+}

--- a/packages/@storybook-astro/renderer/src/docs/sourceDecorator.test.ts
+++ b/packages/@storybook-astro/renderer/src/docs/sourceDecorator.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+const emitTransformCode = vi.fn();
+
+// `useEffect` runs the callback immediately here — the decorator's emission is
+// what we're asserting on, not Storybook's effect scheduling.
+vi.mock('storybook/internal/preview-api', () => ({
+  emitTransformCode: (...args: unknown[]) => emitTransformCode(...args),
+  useEffect: (fn: () => void) => fn()
+}));
+
+const { sourceDecorator } = await import('./sourceDecorator.ts');
+
+/** A stand-in for the client stub `vitePluginAstroComponentMarker` produces. */
+function astroStub(moduleId: string, displayName?: string) {
+  const stub = () => {};
+
+  Object.assign(stub, {
+    isAstroComponentFactory: true,
+    moduleId,
+    ...(displayName ? { __docgenInfo: { displayName } } : {})
+  });
+
+  return stub;
+}
+
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    component: astroStub('/src/components/Card.astro', 'Card'),
+    title: 'Astro/Card',
+    args: { title: 'Hello' },
+    ...overrides,
+    parameters: {
+      __isArgsStory: true,
+      renderer: 'astro',
+      fileName: '/src/components/Card.stories.jsx',
+      ...(overrides.parameters as Record<string, unknown> | undefined)
+    }
+  } as never;
+}
+
+const storyFn = () => 'story-result';
+
+beforeEach(() => emitTransformCode.mockClear());
+
+describe('emitting Astro source', () => {
+  test('emits component usage for an Astro args story', () => {
+    sourceDecorator(storyFn, context());
+
+    expect(emitTransformCode).toHaveBeenCalledTimes(1);
+    expect(emitTransformCode.mock.calls[0][0]).toBe(
+      ["---", "import Card from './Card.astro';", '---', '<Card title="Hello" />'].join('\n')
+    );
+  });
+
+  test('returns the story untouched', () => {
+    expect(sourceDecorator(storyFn, context())).toBe('story-result');
+  });
+
+  test('prefers the docgen displayName over the filename', () => {
+    sourceDecorator(
+      storyFn,
+      context({ component: astroStub('/src/components/Card.astro', 'HeroHijri') })
+    );
+
+    expect(emitTransformCode.mock.calls[0][0]).toContain('<HeroHijri title="Hello" />');
+  });
+});
+
+describe('skipping', () => {
+  test('a story with docs.source.code set — the documented workaround wins', () => {
+    sourceDecorator(storyFn, context({ parameters: { docs: { source: { code: 'custom' } } } }));
+
+    expect(emitTransformCode).not.toHaveBeenCalled();
+  });
+
+  test('a custom-render story, which has no args to describe', () => {
+    sourceDecorator(storyFn, context({ parameters: { __isArgsStory: false } }));
+
+    expect(emitTransformCode).not.toHaveBeenCalled();
+  });
+
+  test('a framework-delegated story', () => {
+    sourceDecorator(storyFn, context({ parameters: { renderer: 'react' } }));
+
+    expect(emitTransformCode).not.toHaveBeenCalled();
+  });
+
+  test('a story whose component is not an Astro stub', () => {
+    sourceDecorator(storyFn, context({ component: () => {} }));
+
+    expect(emitTransformCode).not.toHaveBeenCalled();
+  });
+
+  test('docs.source.type CODE', () => {
+    sourceDecorator(storyFn, context({ parameters: { docs: { source: { type: 'code' } } } }));
+
+    expect(emitTransformCode).not.toHaveBeenCalled();
+  });
+
+  test('but DYNAMIC forces emission even for a non-args story', () => {
+    sourceDecorator(
+      storyFn,
+      context({ parameters: { __isArgsStory: false, docs: { source: { type: 'dynamic' } } } })
+    );
+
+    expect(emitTransformCode).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the renderer default does not suppress emission', () => {
+  // `parameters.renderer` is 'astro' for every story and is never unset, so a
+  // naive "skip when renderer is set" check would emit nothing at all.
+  test('the default astro renderer still emits', () => {
+    sourceDecorator(storyFn, context({ parameters: { renderer: 'astro' } }));
+
+    expect(emitTransformCode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@storybook-astro/renderer/src/docs/sourceDecorator.ts
+++ b/packages/@storybook-astro/renderer/src/docs/sourceDecorator.ts
@@ -1,0 +1,96 @@
+import { SourceType } from 'storybook/internal/docs-tools';
+import { emitTransformCode, useEffect } from 'storybook/internal/preview-api';
+import type { PartialStoryFn, StoryContext } from 'storybook/internal/types';
+import type { AstroRenderer } from '../types.ts';
+import {
+  generateAstroSource,
+  resolveComponentName,
+  resolveImportPath
+} from './generateAstroSource.ts';
+
+/**
+ * Emits the Astro template a story's args describe, so Docs "Show code" and the
+ * Code Panel show component usage instead of the raw story file
+ * (docs/specs/code-panel-source.md).
+ *
+ * Delivered as a docs-only preview annotation, so projects without addon-docs
+ * never load it. The snippet is generated from `context.component` + args
+ * rather than from what `storyFn()` returns, which keeps it independent of
+ * decorators and of which render mode produced the HTML.
+ */
+export const sourceDecorator = (
+  storyFn: PartialStoryFn<AstroRenderer>,
+  context: StoryContext<AstroRenderer>
+) => {
+  const story = storyFn();
+
+  // Generating source is a side effect of rendering, never a transform of it —
+  // the story value is returned untouched.
+  useEffect(() => {
+    if (shouldSkipSourceRender(context)) {
+      return;
+    }
+
+    const code = astroSourceFor(context);
+
+    if (code) {
+      emitTransformCode(code, context);
+    }
+  });
+
+  return story;
+};
+
+/** The standard skip logic every renderer implements, so user overrides win. */
+function shouldSkipSourceRender(context: StoryContext<AstroRenderer>): boolean {
+  const source = context?.parameters?.docs?.source;
+
+  if (source?.type === SourceType.DYNAMIC) {
+    return false;
+  }
+
+  return (
+    !context?.parameters?.__isArgsStory ||
+    Boolean(source?.code) ||
+    source?.type === SourceType.CODE
+  );
+}
+
+/**
+ * Returns the snippet, or `null` when this story isn't one we can describe in
+ * Astro template syntax.
+ */
+function astroSourceFor(context: StoryContext<AstroRenderer>): string | null {
+  // `parameters.renderer` is `'astro'` for every story and is never unset, so a
+  // *delegated* framework story is one set to something else (see the note on
+  // `applyDecorators` in ../decorators.ts). Those render through the
+  // framework's own pipeline and would need its source generator, not ours.
+  const renderer = context?.parameters?.renderer as string | undefined;
+
+  if (renderer && renderer !== 'astro') {
+    return null;
+  }
+
+  const component = context?.component as AstroStub | undefined;
+
+  // Astro component stubs carry `moduleId`. Anything else — a string or an
+  // HTMLElement story — has no component usage to show.
+  if (!component?.moduleId) {
+    return null;
+  }
+
+  const name = resolveComponentName({
+    displayName: component.__docgenInfo?.displayName,
+    moduleId: component.moduleId,
+    title: context.title
+  });
+
+  return generateAstroSource(name, context.args ?? {}, {
+    importPath: resolveImportPath(component.moduleId, name)
+  });
+}
+
+type AstroStub = {
+  moduleId?: string;
+  __docgenInfo?: { displayName?: string };
+};

--- a/packages/@storybook-astro/renderer/src/entry-preview-docs.ts
+++ b/packages/@storybook-astro/renderer/src/entry-preview-docs.ts
@@ -1,0 +1,3 @@
+import { sourceDecorator } from './docs/sourceDecorator.ts';
+
+export const decorators = [sourceDecorator];

--- a/packages/@storybook-astro/renderer/src/preset.ts
+++ b/packages/@storybook-astro/renderer/src/preset.ts
@@ -5,11 +5,17 @@ import type { Options } from 'storybook/internal/types';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-export const previewAnnotations = async (input = [], _options: Options) => {
+export const previewAnnotations = async (input = [], options: Options) => {
   const result: string[] = [];
+  // The source decorator is only useful when addon-docs is rendering a "Show
+  // code" block or Code Panel, so projects without it don't load the annotation
+  // at all (docs/specs/code-panel-source.md#design-decisions, Decision 1).
+  const docsEnabled =
+    Object.keys((await options.presets.apply('docs', {}, options)) ?? {}).length > 0;
 
   // Omit file extension — Vite resolves .ts (local dev) or .js (published dist)
   return result
     .concat(input)
-    .concat([join(__dirname, 'entry-preview')]);
+    .concat([join(__dirname, 'entry-preview')])
+    .concat(docsEnabled ? [join(__dirname, 'entry-preview-docs')] : []);
 };

--- a/packages/@storybook-astro/renderer/tsup.config.ts
+++ b/packages/@storybook-astro/renderer/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     'src/types.ts',
     'src/render.tsx',
     'src/entry-preview.ts',
+    'src/entry-preview-docs.ts',
     'src/preview-defaults.ts',
     'src/decorators.ts',
     'src/decoratedTree.ts',


### PR DESCRIPTION
Closes #106. Closes #161.

Docs "Show code" and the Code Panel fell back to printing the raw story file, because the renderer never emitted a dynamic snippet. They now show the Astro template a story's args describe:

```astro
---
import Card from './Card.astro';
---
<Card
  content="The panel shows Astro template usage, not this story file."
  title="Code panel card"
/>
```

Implements `docs/specs/code-panel-source.md`.

## Shape

- **`docs/generateAstroSource.ts`** — pure, with **no imports at all**, so every serialization rule is unit-testable in isolation. It runs in the preview iframe, so path handling is plain string work rather than `node:path`.
- **`docs/sourceDecorator.ts`** — a thin shell: calls `storyFn()`, returns it untouched, and emits through `emitTransformCode` inside `useEffect`.
- **`entry-preview-docs.ts`** — loaded by the renderer preset *only when addon-docs is enabled*, so projects without it pay nothing.

Generated from `context.component` + args rather than from render output, so it is independent of decorators and of which render mode produced the HTML.

## Two things the spec had wrong

Both corrected in the spec as well as the code.

**The import path plan was unworkable.** It called for deriving the import from `moduleId` relative to `dirname(parameters.fileName)`. Those are different coordinate systems — Storybook reports `fileName` **project-relative** (`./src/components/Card.stories.jsx`) while `moduleId` is **absolute** — so the derivation produced:

```
import Card from '../../../../Users/luke.mcdowell/Documents/Projects/Storybook Astro/code/storybook-astro/packages/components/src/Card/astro/Card.astro';
```

Unit tests passed happily; only opening the browser caught it. And even with both paths absolute, a component imported across packages has no useful relative path — the real specifier is a bare one the story context doesn't carry. The import is now always `./<Basename>.astro`, which is what a usage sample wants.

**The skip condition would have disabled the feature entirely.** The spec said to skip stories with `parameters.renderer` set — but `entry-preview.ts` gives *every* story `renderer: 'astro'`, so that emits nothing at all. A framework story is one set to something *other than* `'astro'` (the same convention `applyDecorators` documents). There's a regression test pinning exactly this, since it's an easy mistake to reintroduce.

## Verified in Storybook, not just in tests

On **Astro 6** and **Astro 7** (Vite 8/Rolldown resolves the new entry differently):

- snippets render in "Show code" and the Code Panel, syntax-highlighted and line-broken
- they **live-update** when Controls change — editing `title` re-emits with the new value
- `parameters.docs.source.code` still wins (the documented workaround)
- **React stories keep the raw-source fallback** — no Astro snippet leakage
- `<Button disabled>`, sorted attributes, and default-slot children all render as specified

Two verification stories added to `integration/astro6` per the spec: one exercising `docs.codePanel`, one proving the `docs.source.code` override.

## Verification

42 new unit tests (renderer 21 → 63). `yarn lint`, `yarn lint:links`, `yarn test` green; website and all three Storybook builds succeed.

**Note for review:** two new stories means Chromatic will report new snapshots to accept.

**Collision with #153:** none in code. Both touch `roadmap.md` and `AGENTS.md`, which are append-a-line conflicts at most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
